### PR TITLE
Put `Error<T>` in `decl_module`

### DIFF
--- a/balances/src/lib.rs
+++ b/balances/src/lib.rs
@@ -70,6 +70,7 @@ decl_event!(
 decl_module! {
     pub struct Module<T: Config> for enum Call where origin: T::Origin {
         fn deposit_event() = default;
+        type Error = Error<T>;
 
         /// Transfer some balance to another account.
         #[weight = 10_000]

--- a/bazaar/src/lib.rs
+++ b/bazaar/src/lib.rs
@@ -81,8 +81,8 @@ decl_error! {
 // TODO: Add Article Upload / Removal
 decl_module! {
     pub struct Module<T: Config> for enum Call where origin: T::Origin {
-        // initialisation
         fn deposit_event() = default;
+        type Error = Error<T>;
 
         /// Allow a user to create a shop
         #[weight = 10_000]

--- a/ceremonies/src/lib.rs
+++ b/ceremonies/src/lib.rs
@@ -108,6 +108,7 @@ decl_storage! {
 decl_module! {
     pub struct Module<T: Config> for enum Call where origin: T::Origin {
         fn deposit_event() = default;
+        type Error = Error<T>;
 
         #[weight = 10_000]
         pub fn grant_reputation(origin, cid: CommunityIdentifier, reputable: T::AccountId) -> DispatchResult {

--- a/communities/src/lib.rs
+++ b/communities/src/lib.rs
@@ -62,6 +62,7 @@ decl_storage! {
 decl_module! {
     pub struct Module<T: Config> for enum Call where origin: T::Origin {
         fn deposit_event() = default;
+        type Error = Error<T>;
         // FIXME: this function has complexity O(n^2)!
         // where n is the number of all locations of all communities
         // this should be run off-chain in substraTEE-worker later


### PR DESCRIPTION
Put `type Error = Error<T>;` in `decl_module` to have it appear in the node metadata. Closes #22 