### PR TITLE
Update parachain sibling `Multilocation` format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,6 +396,7 @@ dependencies = [
  "sp-runtime",
  "sp-std",
  "substrate-fixed",
+ "xcm",
 ]
 
 [[package]]

--- a/personhood-oracle/src/lib.rs
+++ b/personhood-oracle/src/lib.rs
@@ -28,11 +28,13 @@ use polkadot_parachain::primitives::Sibling;
 use rstd::prelude::*;
 use sp_core::H256;
 use sp_runtime::traits::{AccountIdConversion, Verify};
-use xcm::v0::{Error as XcmError, Junction, OriginKind, SendXcm, Xcm};
+use xcm::v0::{Error as XcmError, OriginKind, SendXcm, Xcm};
 
 use encointer_primitives::{
     ceremonies::{ProofOfAttendance, Reputation},
-    sybil::{OpaqueRequest, PersonhoodUniquenessRating, RequestHash, SybilResponseCall},
+    sybil::{
+        sibling_junction, OpaqueRequest, PersonhoodUniquenessRating, RequestHash, SybilResponseCall,
+    },
 };
 
 const LOG: &str = "encointer";
@@ -98,7 +100,7 @@ decl_module! {
             let call =  SybilResponseCall::new(sender_sybil_gate, requested_response, request_hash, confidence);
             let message = Xcm::Transact { origin_type: OriginKind::SovereignAccount, call: call.encode() };
 
-            match T::XcmSender::send_xcm(Junction::Parachain { id: para_id }.into(), message) {
+            match T::XcmSender::send_xcm(sibling_junction(para_id).into(), message) {
                 Ok(()) => Self::deposit_event(Event::PersonhoodUniquenessRatingSentSuccess(request_hash, para_id)),
                 Err(e) => Self::deposit_event(Event::PersonhoodUniquenessRatingSentFailure(request_hash, para_id, e)),
             }

--- a/personhood-oracle/src/tests.rs
+++ b/personhood-oracle/src/tests.rs
@@ -71,7 +71,7 @@ fn proof_of_attendance() -> ProofOfAttendance<Signature, AccountId> {
 #[test]
 fn issue_proof_of_personhood_is_ok() {
     new_test_ext().execute_with(|| {
-        let sibling = (Junction::Parent, Junction::Parachain { id: 1863 });
+        let sibling = sibling_junction(1863);
         let account_id = LocationConverter::from_location(&sibling.into()).unwrap();
         assert_ok!(PersonhoodOracle::issue_personhood_uniqueness_rating(
             Origin::signed(account_id),
@@ -109,7 +109,7 @@ fn create_proof_of_personhood_confidence_works() {
 #[test]
 fn account_id_conversion_works() {
     new_test_ext().execute_with(|| {
-        let sibling = (Junction::Parent, Junction::Parachain { id: 1863 });
+        let sibling = sibling_junction(1863);
         let account = LocationConverter::from_location(&sibling.clone().into()).unwrap();
         assert_eq!(
             LocationConverter::try_into_location(account).unwrap(),

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -34,6 +34,12 @@ package = "sp-std"
 git = "https://github.com/paritytech/substrate.git"
 branch = "master"
 
+[dependencies.xcm]
+default-features = false
+package = "xcm"
+git = "https://github.com/paritytech/polkadot.git"
+branch = "master"
+
 [dependencies.serde]
 features = ["derive"]
 optional = true

--- a/primitives/src/sybil.rs
+++ b/primitives/src/sybil.rs
@@ -3,6 +3,7 @@ use fixed::traits::Fixed;
 use rstd::vec::Vec;
 use sp_core::{RuntimeDebug, H256};
 use sp_runtime::traits::{BlakeTwo256, Hash};
+use xcm::v0::Junction;
 
 use crate::scheduler::CeremonyIndexType;
 
@@ -110,4 +111,8 @@ impl PersonhoodUniquenessRating {
             .checked_div(F::from_num(self.last_n_ceremonies))
             .unwrap_or_default();
     }
+}
+
+pub fn sibling_junction(id: u32) -> (Junction, Junction) {
+    (Junction::Parent, Junction::Parachain { id })
 }

--- a/sybil-gate-template/src/lib.rs
+++ b/sybil-gate-template/src/lib.rs
@@ -25,7 +25,10 @@
 use codec::{Decode, Encode};
 use encointer_primitives::{
     ceremonies::ProofOfAttendance,
-    sybil::{IssuePersonhoodUniquenessRatingCall, PersonhoodUniquenessRating, SybilResponse},
+    sybil::{
+        sibling_junction, IssuePersonhoodUniquenessRatingCall, PersonhoodUniquenessRating,
+        SybilResponse,
+    },
 };
 use fixed::types::I16F16;
 use frame_support::traits::Currency;
@@ -37,7 +40,7 @@ use polkadot_parachain::primitives::Sibling;
 use rstd::prelude::*;
 use sp_core::H256;
 use sp_runtime::traits::{AccountIdConversion, CheckedConversion, IdentifyAccount, Member, Verify};
-use xcm::v0::{Error as XcmError, Junction, OriginKind, SendXcm, Xcm};
+use xcm::v0::{Error as XcmError, OriginKind, SendXcm, Xcm};
 
 const LOG: &str = "encointer";
 
@@ -125,7 +128,7 @@ decl_module! {
 
             let message = Xcm::Transact { origin_type: OriginKind::SovereignAccount, call: call.encode() };
             debug::debug!(target: LOG, "[EncointerSybilGate]: Sending PersonhoodUniquenessRatingRequest to chain: {:?}", parachain_id);
-            match T::XcmSender::send_xcm(Junction::Parachain { id: parachain_id }.into(), message) {
+            match T::XcmSender::send_xcm(sibling_junction(parachain_id).into(), message) {
                 Ok(()) => {
                     <PendingRequests<T>>::insert(&request_hash, &sender);
                     Self::deposit_event(RawEvent::PersonhoodUniquenessRatingRequestSentSuccess(sender, request_hash, parachain_id))

--- a/sybil-gate-template/src/tests.rs
+++ b/sybil-gate-template/src/tests.rs
@@ -68,7 +68,7 @@ fn faucet_works() {
 
 #[test]
 fn faucet_returns_err_if_proof_too_weak() {
-    let sibling = (Junction::Parent, Junction::Parachain { id: 1863 });
+    let sibling = sibling_junction(1863);
     let account = LocationConverter::from_location(&sibling.clone().into()).unwrap();
     let alice: AccountId = AccountKeyring::Alice.into();
     let request_hash = H256::default();
@@ -90,7 +90,7 @@ fn faucet_returns_err_if_proof_too_weak() {
 
 #[test]
 fn faucet_returns_err_for_unexpected_request() {
-    let sibling = (Junction::Parent, Junction::Parachain { id: 1863 });
+    let sibling = sibling_junction(1863);
     let account = LocationConverter::from_location(&sibling.clone().into()).unwrap();
 
     new_test_ext().execute_with(|| {


### PR DESCRIPTION
rococo-v1 branch successfully performs the sybil demo with this update