### PR TITLE
Enable community branding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,9 +387,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80df024fbc5ac80f87dfef0d9f5209a252f2a497f7f42944cff24d8253cac065"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "encointer-primitives"
 version = "0.3.9"
 dependencies = [
+ "encoding_rs",
  "parity-scale-codec",
  "serde",
  "sp-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,19 +387,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80df024fbc5ac80f87dfef0d9f5209a252f2a497f7f42944cff24d8253cac065"
-dependencies = [
- "cfg-if 1.0.0",
-]
-
-[[package]]
 name = "encointer-primitives"
 version = "0.4.0"
 dependencies = [
- "encoding_rs",
  "parity-scale-codec",
  "serde",
  "sp-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1189,7 +1189,6 @@ dependencies = [
  "sp-core",
  "sp-externalities",
  "sp-io",
- "sp-keyring",
  "sp-runtime",
  "sp-std",
  "substrate-fixed",
@@ -1218,7 +1217,6 @@ dependencies = [
  "sp-externalities",
  "sp-inherents",
  "sp-io",
- "sp-keyring",
  "sp-runtime",
  "sp-std",
  "tempdir",
@@ -1238,7 +1236,6 @@ dependencies = [
  "sp-core",
  "sp-externalities",
  "sp-io",
- "sp-keyring",
  "sp-runtime",
  "sp-std",
  "substrate-fixed",
@@ -1262,7 +1259,6 @@ dependencies = [
  "polkadot-parachain",
  "sp-core",
  "sp-io",
- "sp-keyring",
  "sp-runtime",
  "sp-std",
  "test-utils",
@@ -1308,7 +1304,6 @@ dependencies = [
  "polkadot-parachain",
  "sp-core",
  "sp-io",
- "sp-keyring",
  "sp-runtime",
  "sp-std",
  "substrate-fixed",
@@ -2630,18 +2625,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76cc616c6abf8c8928e2fdcc0dbfab37175edd8fb49a4641066ad1364fdab146"
+checksum = "e0f4a65597094d4483ddaed134f409b2cb7c1beccf25201a9f73c719254fa98e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be73a2caec27583d0046ef3796c3794f868a5bc813db689eed00c7631275cd1"
+checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.8",
@@ -2720,9 +2715,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.23"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d40a22fd029e33300d8d89a5cc8ffce18bb7c587662f54629e94c9de5487f3"
+checksum = "01ebdc2bb4498ab1ab5f5b73c5803825e60199229ccba0698170e3be0e7f959f"
 dependencies = [
  "cfg-if 1.0.0",
  "pin-project-lite",
@@ -2732,9 +2727,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.12"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43f080ea7e4107844ef4766459426fa2d5c1ada2e47edba05dc7fa99d9629f47"
+checksum = "c42e6fa53307c8a17e4ccd4dc81cf5ec38db9209f59b222210375b54ee40d1e2"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.8",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -397,7 +397,7 @@ dependencies = [
 
 [[package]]
 name = "encointer-primitives"
-version = "0.3.9"
+version = "0.4.0"
 dependencies = [
  "encoding_rs",
  "parity-scale-codec",
@@ -1164,7 +1164,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-balances"
-version = "0.3.9"
+version = "0.4.0"
 dependencies = [
  "approx",
  "encointer-primitives",
@@ -1186,7 +1186,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-bazaar"
-version = "0.3.9"
+version = "0.4.0"
 dependencies = [
  "approx",
  "encointer-primitives",
@@ -1208,7 +1208,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-ceremonies"
-version = "0.3.9"
+version = "0.4.0"
 dependencies = [
  "approx",
  "encointer-primitives",
@@ -1235,7 +1235,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-communities"
-version = "0.3.9"
+version = "0.4.0"
 dependencies = [
  "approx",
  "encointer-primitives",
@@ -1254,7 +1254,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-personhood-oracle"
-version = "0.3.9"
+version = "0.4.0"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -1279,7 +1279,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-scheduler"
-version = "0.3.9"
+version = "0.4.0"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -1302,7 +1302,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-sybil-gate-template"
-version = "0.3.9"
+version = "0.4.0"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -2598,7 +2598,7 @@ dependencies = [
 
 [[package]]
 name = "test-utils"
-version = "0.3.9"
+version = "0.4.0"
 dependencies = [
  "encointer-primitives",
  "frame-support",

--- a/balances/Cargo.toml
+++ b/balances/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-encointer-balances"
-version = "0.3.9"
+version = "0.4.0"
 authors = ["encointer.org <alain@encointer.org> and Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/balances/src/lib.rs
+++ b/balances/src/lib.rs
@@ -111,8 +111,7 @@ impl<T: Config> Module<T> {
         let entry = <Balance<T>>::get(community_id, who);
         Self::apply_demurrage(
             entry,
-            <encointer_communities::Module<T>>::community_properties(community_id)
-                .demurrage_per_block,
+            <encointer_communities::Module<T>>::demurrage_per_block(community_id),
         )
     }
 
@@ -127,8 +126,7 @@ impl<T: Config> Module<T> {
         let entry = <TotalIssuance<T>>::get(community_id);
         Self::apply_demurrage(
             entry,
-            <encointer_communities::Module<T>>::community_properties(community_id)
-                .demurrage_per_block,
+            <encointer_communities::Module<T>>::demurrage_per_block(community_id),
         )
     }
 

--- a/balances/src/lib.rs
+++ b/balances/src/lib.rs
@@ -111,7 +111,7 @@ impl<T: Config> Module<T> {
         who: &T::AccountId,
     ) -> BalanceEntry<T::BlockNumber> {
         let entry = <Balance<T>>::get(community_id, who);
-        Self::apply_demurrage(entry, Self::demurrage(community_id))
+        Self::apply_demurrage(entry, Self::demurrage(&community_id))
     }
 
     pub fn total_issuance(community_id: CommunityIdentifier) -> BalanceType {
@@ -123,7 +123,7 @@ impl<T: Config> Module<T> {
         community_id: CommunityIdentifier,
     ) -> BalanceEntry<T::BlockNumber> {
         let entry = <TotalIssuance<T>>::get(community_id);
-        Self::apply_demurrage(entry, Self::demurrage(community_id))
+        Self::apply_demurrage(entry, Self::demurrage(&community_id))
     }
 
     /// calculate actual value with demurrage
@@ -214,7 +214,7 @@ impl<T: Config> Module<T> {
 
     /// Returns the community-specific demurrage if it is set. Otherwise returns the
     /// the demurrage defined in the genesis config
-    fn demurrage(cid: CommunityIdentifier) -> BalanceType {
+    fn demurrage(cid: &CommunityIdentifier) -> BalanceType {
         match encointer_communities::DemurragePerBlock::try_get(cid) {
             Ok(demurrage) => demurrage,
             Err(_) => Self::demurrage_per_block(),

--- a/balances/src/lib.rs
+++ b/balances/src/lib.rs
@@ -215,9 +215,7 @@ impl<T: Config> Module<T> {
     /// Returns the community-specific demurrage if it is set. Otherwise returns the
     /// the demurrage defined in the genesis config
     fn demurrage(cid: &CommunityIdentifier) -> BalanceType {
-        match encointer_communities::DemurragePerBlock::try_get(cid) {
-            Ok(demurrage) => demurrage,
-            Err(_) => Self::demurrage_per_block(),
-        }
+        encointer_communities::DemurragePerBlock::try_get(cid)
+            .unwrap_or_else(|_| Self::demurrage_per_block())
     }
 }

--- a/balances/src/lib.rs
+++ b/balances/src/lib.rs
@@ -55,8 +55,8 @@ decl_storage! {
     trait Store for Module<T: Config> as EncointerBalances {
         pub TotalIssuance get(fn total_issuance_entry): map hasher(blake2_128_concat) CommunityIdentifier => BalanceEntry<T::BlockNumber>;
         pub Balance get(fn balance_entry): double_map hasher(blake2_128_concat) CommunityIdentifier, hasher(blake2_128_concat) T::AccountId => BalanceEntry<T::BlockNumber>;
-        /// The default value to be used if there is no community specific demurrage set.
-        DemurragePerBlock get(fn demurrage_per_block) config(): Demurrage;
+        /// The demurrage per block if no community specific value is set.
+        DemurragePerBlockDefault get(fn demurrage_per_block_default) config(): Demurrage;
     }
 }
 
@@ -216,6 +216,6 @@ impl<T: Config> Module<T> {
     /// the demurrage defined in the genesis config
     fn demurrage(cid: &CommunityIdentifier) -> BalanceType {
         encointer_communities::DemurragePerBlock::try_get(cid)
-            .unwrap_or_else(|_| Self::demurrage_per_block())
+            .unwrap_or_else(|_| Self::demurrage_per_block_default())
     }
 }

--- a/balances/src/lib.rs
+++ b/balances/src/lib.rs
@@ -17,7 +17,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use encointer_primitives::{
-    balances::{BalanceEntry, BalanceType},
+    balances::{BalanceEntry, BalanceType, Demurrage},
     communities::CommunityIdentifier,
 };
 use fixed::transcendental::exp;
@@ -56,7 +56,7 @@ decl_storage! {
         pub TotalIssuance get(fn total_issuance_entry): map hasher(blake2_128_concat) CommunityIdentifier => BalanceEntry<T::BlockNumber>;
         pub Balance get(fn balance_entry): double_map hasher(blake2_128_concat) CommunityIdentifier, hasher(blake2_128_concat) T::AccountId => BalanceEntry<T::BlockNumber>;
         /// The default value to be used if there is no community specific demurrage set.
-        DemurragePerBlock get(fn demurrage_per_block) config(): BalanceType;
+        DemurragePerBlock get(fn demurrage_per_block) config(): Demurrage;
     }
 }
 

--- a/balances/src/mock.rs
+++ b/balances/src/mock.rs
@@ -49,7 +49,6 @@ impl_outer_origin_for_runtime!(TestRuntime);
 impl_frame_system!(TestRuntime, TestEvent);
 
 pub type System = frame_system::Module<TestRuntime>;
-pub type EncointerCommunities = encointer_communities::Module<TestRuntime>;
 pub type EncointerBalances = Module<TestRuntime>;
 
 impl encointer_communities::Config for TestRuntime {

--- a/balances/src/mock.rs
+++ b/balances/src/mock.rs
@@ -40,8 +40,6 @@ impl_outer_event! {
     }
 }
 
-type AccountId = u64;
-
 // Workaround for https://github.com/rust-lang/rust/issues/26925 . Remove when sorted.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct TestRuntime;
@@ -60,9 +58,6 @@ impl encointer_communities::Config for TestRuntime {
 impl Config for TestRuntime {
     type Event = TestEvent;
 }
-
-pub const ALICE: AccountId = 1;
-pub const BOB: AccountId = 2;
 
 pub struct ExtBuilder {}
 

--- a/balances/src/mock.rs
+++ b/balances/src/mock.rs
@@ -19,15 +19,9 @@
 #![cfg(test)]
 
 use super::*;
-use codec::Encode;
-use encointer_primitives::{
-    balances::consts::DEFAULT_DEMURRAGE,
-    communities::{CommunityIdentifier, Degree, Demurrage, Location},
-};
-use frame_support::assert_ok;
 use frame_support::impl_outer_event;
 use frame_system;
-use sp_core::{hashing::blake2_256, H256};
+use sp_core::H256;
 use sp_runtime::{testing::Header, traits::IdentityLookup};
 
 use test_utils::*;
@@ -85,44 +79,4 @@ impl ExtBuilder {
             .unwrap();
         t.into()
     }
-}
-
-/// register a simple test community with 3 meetup locations and well known bootstrappers
-pub fn register_test_community() -> CommunityIdentifier {
-    // all well-known keys are bootstrappers for easy testing afterwards
-    let alice = 1;
-    let bob = 2;
-    let charlie = 3;
-    let dave = 4;
-    let eve = 5;
-    let ferdie = 6;
-
-    let a = Location::default(); // 0, 0
-
-    let b = Location {
-        lat: Degree::from_num(1),
-        lon: Degree::from_num(1),
-    };
-    let c = Location {
-        lat: Degree::from_num(2),
-        lon: Degree::from_num(2),
-    };
-    let loc = vec![a, b, c];
-    let bs = vec![
-        alice.clone(),
-        bob.clone(),
-        charlie.clone(),
-        dave.clone(),
-        eve.clone(),
-        ferdie.clone(),
-    ];
-    assert_ok!(EncointerCommunities::new_community(
-        Origin::signed(alice.clone()),
-        loc.clone(),
-        bs.clone(),
-        Default::default(),
-        Some(Demurrage::from_bits(DEFAULT_DEMURRAGE)),
-        None
-    ));
-    CommunityIdentifier::from(blake2_256(&(loc, bs).encode()))
 }

--- a/balances/src/mock.rs
+++ b/balances/src/mock.rs
@@ -73,7 +73,7 @@ impl ExtBuilder {
             .build_storage::<TestRuntime>()
             .unwrap();
         GenesisConfig {
-            demurrage_per_block: Demurrage::from_bits(DEFAULT_DEMURRAGE),
+            demurrage_per_block_default: Demurrage::from_bits(DEFAULT_DEMURRAGE),
         }
         .assimilate_storage(&mut storage)
         .unwrap();

--- a/balances/src/mock.rs
+++ b/balances/src/mock.rs
@@ -24,7 +24,7 @@ use frame_system;
 use sp_core::H256;
 use sp_runtime::{testing::Header, traits::IdentityLookup};
 
-use encointer_primitives::{balances::consts::DEFAULT_DEMURRAGE, communities::Demurrage};
+use encointer_primitives::balances::{consts::DEFAULT_DEMURRAGE, Demurrage};
 use test_utils::*;
 
 mod tokens {

--- a/balances/src/mock.rs
+++ b/balances/src/mock.rs
@@ -86,7 +86,7 @@ impl ExtBuilder {
 
 /// register a simple test community with 3 meetup locations and well known bootstrappers
 pub fn register_test_community() -> CommunityIdentifier {
-    // all well-known keys are boottrappers for easy testen afterwards
+    // all well-known keys are bootstrappers for easy testing afterwards
     let alice = 1;
     let bob = 2;
     let charlie = 3;

--- a/balances/src/mock.rs
+++ b/balances/src/mock.rs
@@ -20,7 +20,7 @@
 
 use super::*;
 use codec::Encode;
-use encointer_primitives::communities::{CommunityIdentifier, Degree, Location};
+use encointer_primitives::communities::{CommunityIdentifier, Degree, Demurrage, Location};
 use frame_support::assert_ok;
 use frame_support::impl_outer_event;
 use frame_system;
@@ -116,7 +116,12 @@ pub fn register_test_community() -> CommunityIdentifier {
     assert_ok!(EncointerCommunities::new_community(
         Origin::signed(alice.clone()),
         loc.clone(),
-        bs.clone()
+        bs.clone(),
+        Default::default(),
+        Some(Demurrage::from_bits(
+            0x0000000000000000000001E3F0A8A973_i128
+        )),
+        None
     ));
     CommunityIdentifier::from(blake2_256(&(loc, bs).encode()))
 }

--- a/balances/src/mock.rs
+++ b/balances/src/mock.rs
@@ -20,7 +20,10 @@
 
 use super::*;
 use codec::Encode;
-use encointer_primitives::communities::{CommunityIdentifier, Degree, Demurrage, Location};
+use encointer_primitives::{
+    balances::consts::DEFAULT_DEMURRAGE,
+    communities::{CommunityIdentifier, Degree, Demurrage, Location},
+};
 use frame_support::assert_ok;
 use frame_support::impl_outer_event;
 use frame_system;
@@ -118,9 +121,7 @@ pub fn register_test_community() -> CommunityIdentifier {
         loc.clone(),
         bs.clone(),
         Default::default(),
-        Some(Demurrage::from_bits(
-            0x0000000000000000000001E3F0A8A973_i128
-        )),
+        Some(Demurrage::from_bits(DEFAULT_DEMURRAGE)),
         None
     ));
     CommunityIdentifier::from(blake2_256(&(loc, bs).encode()))

--- a/balances/src/mock.rs
+++ b/balances/src/mock.rs
@@ -24,6 +24,7 @@ use frame_system;
 use sp_core::H256;
 use sp_runtime::{testing::Header, traits::IdentityLookup};
 
+use encointer_primitives::{balances::consts::DEFAULT_DEMURRAGE, communities::Demurrage};
 use test_utils::*;
 
 mod tokens {
@@ -69,9 +70,14 @@ impl Default for ExtBuilder {
 
 impl ExtBuilder {
     pub fn build(self) -> runtime_io::TestExternalities {
-        let t = frame_system::GenesisConfig::default()
+        let mut storage = frame_system::GenesisConfig::default()
             .build_storage::<TestRuntime>()
             .unwrap();
-        t.into()
+        GenesisConfig {
+            demurrage_per_block: Demurrage::from_bits(DEFAULT_DEMURRAGE),
+        }
+        .assimilate_storage(&mut storage)
+        .unwrap();
+        storage.into()
     }
 }

--- a/balances/src/tests.rs
+++ b/balances/src/tests.rs
@@ -134,10 +134,8 @@ fn demurrage_should_work() {
         System::set_block_number(1);
         assert_eq!(
             EncointerBalances::balance(cid, &ALICE),
-            exp::<BalanceType, BalanceType>(
-                -EncointerCommunities::community_properties(cid).demurrage_per_block
-            )
-            .unwrap()
+            exp::<BalanceType, BalanceType>(-EncointerCommunities::demurrage_per_block(cid))
+                .unwrap()
         );
         //one year later
         System::set_block_number(86400 / 5 * 356);

--- a/balances/src/tests.rs
+++ b/balances/src/tests.rs
@@ -24,8 +24,8 @@ use frame_support::{assert_noop, assert_ok, traits::OnInitialize};
 use mock::{EncointerBalances, ExtBuilder, System, TestEvent, TestRuntime};
 
 use encointer_primitives::{
-    balances::consts::DEFAULT_DEMURRAGE,
-    communities::{CommunityIdentifier, Demurrage},
+    balances::{consts::DEFAULT_DEMURRAGE, Demurrage},
+    communities::CommunityIdentifier,
 };
 use test_utils::{helpers::register_test_community, AccountKeyring};
 

--- a/balances/src/tests.rs
+++ b/balances/src/tests.rs
@@ -21,7 +21,7 @@
 use super::*;
 use fixed::{traits::LossyInto, transcendental::exp};
 use frame_support::{assert_noop, assert_ok, traits::OnInitialize};
-use mock::{EncointerBalances, EncointerCommunities, ExtBuilder, System, TestEvent, TestRuntime};
+use mock::{EncointerBalances, ExtBuilder, System, TestEvent, TestRuntime};
 
 use encointer_primitives::{
     balances::consts::DEFAULT_DEMURRAGE,

--- a/balances/src/tests.rs
+++ b/balances/src/tests.rs
@@ -22,23 +22,22 @@ use super::*;
 use encointer_primitives::communities::CommunityIdentifier;
 use fixed::{traits::LossyInto, transcendental::exp};
 use frame_support::{assert_noop, assert_ok, traits::OnInitialize};
-use mock::{
-    EncointerBalances, EncointerCommunities, ExtBuilder, System, TestEvent, TestRuntime, ALICE, BOB,
-};
+use mock::{EncointerBalances, EncointerCommunities, ExtBuilder, System, TestEvent, TestRuntime};
 
-use test_utils::helpers::register_test_community;
+use test_utils::{helpers::register_test_community, AccountKeyring};
 
 #[test]
 fn issue_should_work() {
     ExtBuilder::default().build().execute_with(|| {
         let cid = CommunityIdentifier::default();
+        let alice = AccountKeyring::Alice.to_account_id();
         assert_ok!(EncointerBalances::issue(
             cid,
-            &ALICE,
+            &alice,
             BalanceType::from_num(50.1)
         ));
         assert_eq!(
-            EncointerBalances::balance(cid, &ALICE),
+            EncointerBalances::balance(cid, &alice),
             BalanceType::from_num(50.1)
         );
         assert_eq!(
@@ -52,18 +51,19 @@ fn issue_should_work() {
 fn burn_should_work() {
     ExtBuilder::default().build().execute_with(|| {
         let cid = CommunityIdentifier::default();
+        let alice = AccountKeyring::Alice.to_account_id();
         assert_ok!(EncointerBalances::issue(
             cid,
-            &ALICE,
+            &alice,
             BalanceType::from_num(50)
         ));
         assert_ok!(EncointerBalances::burn(
             cid,
-            &ALICE,
+            &alice,
             BalanceType::from_num(20)
         ));
         assert_eq!(
-            EncointerBalances::balance(cid, &ALICE),
+            EncointerBalances::balance(cid, &alice),
             BalanceType::from_num(30)
         );
         assert_eq!(
@@ -71,7 +71,7 @@ fn burn_should_work() {
             BalanceType::from_num(30)
         );
         assert_noop!(
-            EncointerBalances::burn(cid, &ALICE, BalanceType::from_num(31)),
+            EncointerBalances::burn(cid, &alice, BalanceType::from_num(31)),
             Error::<TestRuntime>::BalanceTooLow,
         );
     });
@@ -83,23 +83,25 @@ fn transfer_should_work() {
         System::set_block_number(System::block_number() + 1);
         System::on_initialize(System::block_number());
 
+        let alice = AccountKeyring::Alice.to_account_id();
+        let bob = AccountKeyring::Bob.to_account_id();
         let cid = CommunityIdentifier::default();
         assert_ok!(EncointerBalances::issue(
             cid,
-            &ALICE,
+            &alice,
             BalanceType::from_num(50)
         ));
         assert_ok!(EncointerBalances::transfer(
-            Some(ALICE).into(),
-            BOB,
+            Some(alice.clone()).into(),
+            bob.clone(),
             cid,
             BalanceType::from_num(9.999)
         ));
 
-        let balance: f64 = EncointerBalances::balance(cid, &ALICE).lossy_into();
+        let balance: f64 = EncointerBalances::balance(cid, &alice).lossy_into();
         assert_relative_eq!(balance, 40.001, epsilon = 1.0e-9);
 
-        let balance: f64 = EncointerBalances::balance(cid, &BOB).lossy_into();
+        let balance: f64 = EncointerBalances::balance(cid, &bob).lossy_into();
         assert_relative_eq!(balance, 9.999, epsilon = 1.0e-9);
 
         let balance: f64 = EncointerBalances::total_issuance(cid).lossy_into();
@@ -107,8 +109,8 @@ fn transfer_should_work() {
 
         let transferred_event = TestEvent::tokens(RawEvent::Transferred(
             cid,
-            ALICE,
-            BOB,
+            alice.clone(),
+            bob.clone(),
             BalanceType::from_num(9.999),
         ));
         assert!(System::events()
@@ -116,7 +118,7 @@ fn transfer_should_work() {
             .any(|record| record.event == transferred_event));
 
         assert_noop!(
-            EncointerBalances::transfer(Some(ALICE).into(), BOB, cid, BalanceType::from_num(60)),
+            EncointerBalances::transfer(Some(alice).into(), bob, cid, BalanceType::from_num(60)),
             Error::<TestRuntime>::BalanceTooLow,
         );
     });
@@ -125,22 +127,23 @@ fn transfer_should_work() {
 #[test]
 fn demurrage_should_work() {
     ExtBuilder::default().build().execute_with(|| {
+        let alice = AccountKeyring::Alice.to_account_id();
         let cid = register_test_community::<TestRuntime>(None, 3);
         System::set_block_number(0);
         assert_ok!(EncointerBalances::issue(
             cid,
-            &ALICE,
+            &alice,
             BalanceType::from_num(1)
         ));
         System::set_block_number(1);
         assert_eq!(
-            EncointerBalances::balance(cid, &ALICE),
+            EncointerBalances::balance(cid, &alice),
             exp::<BalanceType, BalanceType>(-EncointerCommunities::demurrage_per_block(cid))
                 .unwrap()
         );
         //one year later
         System::set_block_number(86400 / 5 * 356);
-        let result: f64 = EncointerBalances::balance(cid, &ALICE).lossy_into();
+        let result: f64 = EncointerBalances::balance(cid, &alice).lossy_into();
         assert_abs_diff_eq!(result, 0.5, epsilon = 1.0e-12);
         let result: f64 = EncointerBalances::total_issuance(cid).lossy_into();
         assert_abs_diff_eq!(result, 0.5, epsilon = 1.0e-12);
@@ -149,19 +152,21 @@ fn demurrage_should_work() {
 
 #[test]
 fn transfer_with_demurrage_exceeding_amount_should_fail() {
+    let alice = AccountKeyring::Alice.to_account_id();
+    let bob = AccountKeyring::Bob.to_account_id();
     ExtBuilder::default().build().execute_with(|| {
         let cid = register_test_community::<TestRuntime>(None, 3);
         System::set_block_number(0);
         assert_ok!(EncointerBalances::issue(
             cid,
-            &ALICE,
+            &alice,
             BalanceType::from_num(100)
         ));
         //one year later
         System::set_block_number(86400 / 5 * 356);
         // balance should now be 50
         assert_noop!(
-            EncointerBalances::transfer(Some(ALICE).into(), BOB, cid, BalanceType::from_num(60)),
+            EncointerBalances::transfer(Some(alice).into(), bob, cid, BalanceType::from_num(60)),
             Error::<TestRuntime>::BalanceTooLow,
         );
     });

--- a/balances/src/tests.rs
+++ b/balances/src/tests.rs
@@ -19,11 +19,14 @@
 #![cfg(test)]
 
 use super::*;
-use encointer_primitives::communities::CommunityIdentifier;
 use fixed::{traits::LossyInto, transcendental::exp};
 use frame_support::{assert_noop, assert_ok, traits::OnInitialize};
 use mock::{EncointerBalances, EncointerCommunities, ExtBuilder, System, TestEvent, TestRuntime};
 
+use encointer_primitives::{
+    balances::consts::DEFAULT_DEMURRAGE,
+    communities::{CommunityIdentifier, Demurrage},
+};
 use test_utils::{helpers::register_test_community, AccountKeyring};
 
 #[test]
@@ -138,8 +141,7 @@ fn demurrage_should_work() {
         System::set_block_number(1);
         assert_eq!(
             EncointerBalances::balance(cid, &alice),
-            exp::<BalanceType, BalanceType>(-EncointerCommunities::demurrage_per_block(cid))
-                .unwrap()
+            exp::<BalanceType, BalanceType>(-Demurrage::from_bits(DEFAULT_DEMURRAGE)).unwrap()
         );
         //one year later
         System::set_block_number(86400 / 5 * 356);

--- a/balances/src/tests.rs
+++ b/balances/src/tests.rs
@@ -23,9 +23,10 @@ use encointer_primitives::communities::CommunityIdentifier;
 use fixed::{traits::LossyInto, transcendental::exp};
 use frame_support::{assert_noop, assert_ok, traits::OnInitialize};
 use mock::{
-    register_test_community, EncointerBalances, EncointerCommunities, ExtBuilder, System,
-    TestEvent, TestRuntime, ALICE, BOB,
+    EncointerBalances, EncointerCommunities, ExtBuilder, System, TestEvent, TestRuntime, ALICE, BOB,
 };
+
+use test_utils::helpers::register_test_community;
 
 #[test]
 fn issue_should_work() {
@@ -124,7 +125,7 @@ fn transfer_should_work() {
 #[test]
 fn demurrage_should_work() {
     ExtBuilder::default().build().execute_with(|| {
-        let cid = register_test_community();
+        let cid = register_test_community::<TestRuntime>(None, 3);
         System::set_block_number(0);
         assert_ok!(EncointerBalances::issue(
             cid,
@@ -149,7 +150,7 @@ fn demurrage_should_work() {
 #[test]
 fn transfer_with_demurrage_exceeding_amount_should_fail() {
     ExtBuilder::default().build().execute_with(|| {
-        let cid = register_test_community();
+        let cid = register_test_community::<TestRuntime>(None, 3);
         System::set_block_number(0);
         assert_ok!(EncointerBalances::issue(
             cid,

--- a/bazaar/Cargo.toml
+++ b/bazaar/Cargo.toml
@@ -60,11 +60,6 @@ git = "https://github.com/encointer/substrate-fixed"
 tag = "v0.5.5"
 package = "substrate-fixed"
 
-[dev-dependencies.sp-keyring]
-package = "sp-keyring"
-git = "https://github.com/paritytech/substrate.git" 
-branch = "master"
-
 [dev-dependencies.balances]
 package = "pallet-balances"
 git = "https://github.com/paritytech/substrate.git" 

--- a/bazaar/Cargo.toml
+++ b/bazaar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-encointer-bazaar"
-version = "0.3.9"
+version = "0.4.0"
 authors = ["encointer.org <alain@encointer.org>"]
 edition = "2018"
 

--- a/bazaar/src/lib.rs
+++ b/bazaar/src/lib.rs
@@ -36,7 +36,8 @@ use frame_system::ensure_signed;
 use rstd::prelude::*;
 
 use encointer_primitives::{
-    bazaar::{consts::MAX_HASH_SIZE, ArticleIdentifier, ShopIdentifier},
+    bazaar::{ArticleIdentifier, ShopIdentifier},
+    common::consts::MAX_HASH_SIZE,
     communities::CommunityIdentifier,
 };
 

--- a/bazaar/src/lib.rs
+++ b/bazaar/src/lib.rs
@@ -53,7 +53,7 @@ decl_storage! {
         // Item owner
         pub ShopOwner get(fn shop_owner): double_map hasher(blake2_128_concat) CommunityIdentifier, hasher(blake2_128_concat) ShopIdentifier => T::AccountId;
         pub ArticleOwner get(fn article_owner): double_map hasher(blake2_128_concat) CommunityIdentifier, hasher(blake2_128_concat) ArticleIdentifier => (T::AccountId, ShopIdentifier);
-        // The set of all shops and articles per community (community)
+        // The set of all shops and articles per community
         pub ShopRegistry get(fn shop_registry): map hasher(blake2_128_concat) CommunityIdentifier => Vec<ShopIdentifier>;
         pub ArticleRegistry get(fn article_registry): map hasher(blake2_128_concat) CommunityIdentifier => Vec<ArticleIdentifier>;
     }

--- a/bazaar/src/lib.rs
+++ b/bazaar/src/lib.rs
@@ -35,9 +35,9 @@ use frame_support::{
 use frame_system::ensure_signed;
 use rstd::prelude::*;
 
+use encointer_primitives::common::validate_ipfs_cid;
 use encointer_primitives::{
     bazaar::{ArticleIdentifier, ShopIdentifier},
-    common::consts::MAX_HASH_SIZE,
     communities::CommunityIdentifier,
 };
 
@@ -76,6 +76,8 @@ decl_error! {
         ShopAlreadyCreated,
         /// shop can not be removed by anyone else than its owner
         OnlyOwnerCanRemoveShop,
+        /// invalid IpfsCid supplied
+        InvalidIpfsCid,
     }
 }
 
@@ -97,8 +99,7 @@ decl_module! {
             let mut owned_shops = ShopsOwned::<T>::get(cid, &sender);
             let mut shops = ShopRegistry::get(cid);
 
-            // Check the string length of the to be uploaded shop
-            ensure!(shop.len() <= MAX_HASH_SIZE, "oversized shop");
+            ensure!(validate_ipfs_cid(&shop).is_ok(), Error::<T>::InvalidIpfsCid);
 
             // Verify that the specified shop has not already been created with fast search
             ensure!(!ShopOwner::<T>::contains_key(cid, &shop), Error::<T>::ShopAlreadyCreated);

--- a/bazaar/src/tests.rs
+++ b/bazaar/src/tests.rs
@@ -21,7 +21,6 @@ use crate::{Config, Module};
 use codec::Encode;
 use encointer_primitives::communities::CommunityIdentifier;
 use sp_core::{hashing::blake2_256, H256};
-use sp_keyring::AccountKeyring;
 use sp_runtime::{
     testing::Header,
     traits::{BlakeTwo256, IdentityLookup},

--- a/bazaar/src/tests.rs
+++ b/bazaar/src/tests.rs
@@ -17,7 +17,7 @@
 //! Unit tests for the tokens module.
 
 use super::*;
-use crate::{Module, Config};
+use crate::{Config, Module};
 use codec::Encode;
 use encointer_primitives::communities::{CommunityIdentifier, Degree, Location};
 use frame_support::assert_ok;
@@ -78,7 +78,10 @@ fn register_test_community() -> CommunityIdentifier {
     assert_ok!(EncointerCommunities::new_community(
         Origin::signed(alice.clone()),
         loc.clone(),
-        bs.clone()
+        bs.clone(),
+        Default::default(),
+        None,
+        None,
     ));
     CommunityIdentifier::from(blake2_256(&(loc, bs).encode()))
 }

--- a/bazaar/src/tests.rs
+++ b/bazaar/src/tests.rs
@@ -19,8 +19,7 @@
 use super::*;
 use crate::{Config, Module};
 use codec::Encode;
-use encointer_primitives::communities::{CommunityIdentifier, Degree, Location};
-use frame_support::assert_ok;
+use encointer_primitives::communities::CommunityIdentifier;
 use sp_core::{hashing::blake2_256, H256};
 use sp_keyring::AccountKeyring;
 use sp_runtime::{
@@ -28,7 +27,7 @@ use sp_runtime::{
     traits::{BlakeTwo256, IdentityLookup},
 };
 
-use test_utils::*;
+use test_utils::{helpers::register_test_community, *};
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct TestRuntime;
@@ -43,7 +42,6 @@ impl Config for TestRuntime {
 }
 
 pub type EncointerBazaar = Module<TestRuntime>;
-pub type EncointerCommunities = encointer_communities::Module<TestRuntime>;
 
 pub struct ExtBuilder;
 
@@ -56,41 +54,11 @@ impl ExtBuilder {
     }
 }
 
-/// register a simple test community with 3 meetup locations and well known bootstrappers
-fn register_test_community() -> CommunityIdentifier {
-    // all well-known keys are boottrappers for easy testen afterwards
-    let alice = AccountId::from(AccountKeyring::Alice);
-    let bob = AccountId::from(AccountKeyring::Bob);
-    let charlie = AccountId::from(AccountKeyring::Charlie);
-
-    let a = Location::default(); // 0, 0
-
-    let b = Location {
-        lat: Degree::from_num(1),
-        lon: Degree::from_num(1),
-    };
-    let c = Location {
-        lat: Degree::from_num(2),
-        lon: Degree::from_num(2),
-    };
-    let loc = vec![a, b, c];
-    let bs = vec![alice.clone(), bob.clone(), charlie.clone()];
-    assert_ok!(EncointerCommunities::new_community(
-        Origin::signed(alice.clone()),
-        loc.clone(),
-        bs.clone(),
-        Default::default(),
-        None,
-        None,
-    ));
-    CommunityIdentifier::from(blake2_256(&(loc, bs).encode()))
-}
-
 #[test]
 fn create_new_shop_works() {
     ExtBuilder::build().execute_with(|| {
         // initialisation
-        let cid = register_test_community();
+        let cid = register_test_community::<TestRuntime>(None, 2);
         let alice = AccountId::from(AccountKeyring::Alice);
         let alice_shop = ShopIdentifier::from("QmW6WLLhUPsosBcKebejveknjrSQjZjq5eYFVBRfugygTB");
         // upload dummy store to blockchain
@@ -138,7 +106,7 @@ fn create_new_shop_with_bad_cid_fails() {
 fn removal_of_shop_works() {
     ExtBuilder::build().execute_with(|| {
         // initialisation
-        let cid = register_test_community();
+        let cid = register_test_community::<TestRuntime>(None, 2);
         let alice = AccountId::from(AccountKeyring::Alice);
         let alice_shop = ShopIdentifier::from("QmW6WLLhUPsosBcKebejveknjrSQjZjq5eYFVBRfugygTB");
 
@@ -181,7 +149,7 @@ fn removal_of_shop_works() {
 fn alices_store_are_differentiated() {
     ExtBuilder::build().execute_with(|| {
         // initialisation
-        let cid = register_test_community();
+        let cid = register_test_community::<TestRuntime>(None, 2);
         let alice = AccountId::from(AccountKeyring::Alice);
         let alice_shop_one = ShopIdentifier::from("QmW6WLLhUPsosBcKebejveknjrSQjZjq5eYFVBRfugygTA");
         let alice_shop_two = ShopIdentifier::from("QmW6WLLhUPsosBcKebejveknjrSQjZjq5eYFVBRfugygTB");
@@ -241,7 +209,7 @@ fn alices_store_are_differentiated() {
 fn stores_cannot_be_created_twice() {
     ExtBuilder::build().execute_with(|| {
         // initialisation
-        let cid = register_test_community();
+        let cid = register_test_community::<TestRuntime>(None, 2);
         let alice = AccountId::from(AccountKeyring::Alice);
         let alice_shop_one = ShopIdentifier::from("QmW6WLLhUPsosBcKebejveknjrSQjZjq5eYFVBRfugygTB");
         let alice_shop_two = ShopIdentifier::from("QmW6WLLhUPsosBcKebejveknjrSQjZjq5eYFVBRfugygTB");
@@ -276,7 +244,7 @@ fn stores_cannot_be_created_twice() {
 fn bob_cannot_remove_alices_store() {
     ExtBuilder::build().execute_with(|| {
         // initialisation
-        let cid = register_test_community();
+        let cid = register_test_community::<TestRuntime>(None, 2);
         let alice = AccountId::from(AccountKeyring::Alice);
         let bob = AccountId::from(AccountKeyring::Bob);
         let alice_shop = ShopIdentifier::from("QmW6WLLhUPsosBcKebejveknjrSQjZjq5eYFVBRfugygTA");
@@ -325,7 +293,7 @@ fn bob_cannot_remove_alices_store() {
 fn create_oversized_shop_fails() {
     ExtBuilder::build().execute_with(|| {
         // initialisation
-        let cid = register_test_community();
+        let cid = register_test_community::<TestRuntime>(None, 2);
         let alice = AccountId::from(AccountKeyring::Alice);
         let alice_shop = ShopIdentifier::from("QmW6WLLhUPsosBcKebejveknjrSQjZjq5eYFVBRfugygTBB");
 

--- a/ceremonies/Cargo.toml
+++ b/ceremonies/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-encointer-ceremonies"
-version = "0.3.9"
+version = "0.4.0"
 authors = ["encointer.org <alain@encointer.org>"]
 edition = "2018"
 

--- a/ceremonies/Cargo.toml
+++ b/ceremonies/Cargo.toml
@@ -104,11 +104,6 @@ package = "sp-externalities"
 git = "https://github.com/paritytech/substrate.git" 
 branch = "master"
 
-[dev-dependencies.sp-keyring]
-package = "sp-keyring"
-git = "https://github.com/paritytech/substrate.git"
-branch = "master"
-
 [dev-dependencies.test-utils]
 path = "../test-utils"
 

--- a/ceremonies/src/lib.rs
+++ b/ceremonies/src/lib.rs
@@ -643,10 +643,8 @@ impl<T: Config> Module<T> {
     /// Returns the community-specific nominal income if it is set. Otherwise returns the
     /// the ceremony reward defined in the genesis config.
     fn nominal_income(cid: &CommunityIdentifier) -> BalanceType {
-        match encointer_communities::NominalIncome::try_get(cid) {
-            Ok(income) => income,
-            Err(_) => Self::ceremony_reward(),
-        }
+        encointer_communities::NominalIncome::try_get(cid)
+            .unwrap_or_else(|_| Self::ceremony_reward())
     }
 
     #[cfg(test)]

--- a/ceremonies/src/lib.rs
+++ b/ceremonies/src/lib.rs
@@ -48,7 +48,7 @@ use encointer_primitives::{
     balances::BalanceType,
     ceremonies::consts::{AMOUNT_NEWBIE_TICKETS, REPUTATION_LIFETIME},
     ceremonies::*,
-    communities::{CommunityIdentifier, Degree, Location, LossyFrom},
+    communities::{CommunityIdentifier, Degree, Location, LossyFrom, NominalIncome},
     scheduler::{CeremonyIndexType, CeremonyPhaseType},
 };
 use encointer_scheduler::OnCeremonyPhaseChange;
@@ -642,7 +642,7 @@ impl<T: Config> Module<T> {
 
     /// Returns the community-specific nominal income if it is set. Otherwise returns the
     /// the ceremony reward defined in the genesis config.
-    fn nominal_income(cid: &CommunityIdentifier) -> BalanceType {
+    fn nominal_income(cid: &CommunityIdentifier) -> NominalIncome {
         encointer_communities::NominalIncome::try_get(cid)
             .unwrap_or_else(|_| Self::ceremony_reward())
     }

--- a/ceremonies/src/lib.rs
+++ b/ceremonies/src/lib.rs
@@ -641,7 +641,7 @@ impl<T: Config> Module<T> {
     }
 
     /// Returns the community-specific nominal income if it is set. Otherwise returns the
-    /// the demurrage defined in the genesis config.
+    /// the ceremony reward defined in the genesis config.
     fn nominal_income(cid: &CommunityIdentifier) -> BalanceType {
         match encointer_communities::NominalIncome::try_get(cid) {
             Ok(income) => income,

--- a/ceremonies/src/tests.rs
+++ b/ceremonies/src/tests.rs
@@ -19,7 +19,7 @@
 //extern crate node_primitives;
 
 use super::*;
-use crate::{GenesisConfig, Module, Config};
+use crate::{Config, GenesisConfig, Module};
 use encointer_primitives::{
     communities::{CommunityIdentifier, Degree, Location, LossyInto},
     scheduler::{CeremonyIndexType, CeremonyPhaseType},
@@ -41,6 +41,7 @@ use std::ops::Rem;
 type TestAttestation = Attestation<Signature, AccountId, Moment>;
 type TestProofOfAttendance = ProofOfAttendance<Signature, AccountId>;
 
+use encointer_primitives::communities::Demurrage;
 use test_utils::*;
 
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -73,6 +74,11 @@ impl ExtBuilder {
         let mut storage = frame_system::GenesisConfig::default()
             .build_storage::<TestRuntime>()
             .unwrap();
+        encointer_balances::GenesisConfig {
+            demurrage_per_block: Demurrage::from_bits(0x0000000000000000000001E3F0A8A973_i128),
+        }
+        .assimilate_storage(&mut storage)
+        .unwrap();
         encointer_communities::GenesisConfig::<TestRuntime> {
             community_master: AccountId::from(AccountKeyring::Alice),
         }
@@ -314,7 +320,10 @@ fn register_test_community(
     assert_ok!(EncointerCommunities::new_community(
         Origin::signed(prime.clone()),
         loc.clone(),
-        bs.clone()
+        bs.clone(),
+        Default::default(),
+        None,
+        None,
     ));
     CommunityIdentifier::from(blake2_256(&(loc, bs).encode()))
 }

--- a/ceremonies/src/tests.rs
+++ b/ceremonies/src/tests.rs
@@ -30,7 +30,6 @@ use inherents::ProvideInherent;
 use rstest::*;
 use sp_core::crypto::Ss58Codec;
 use sp_core::{sr25519, Pair, U256};
-use sp_keyring::AccountKeyring;
 use sp_runtime::{
     testing::Header,
     traits::{BlakeTwo256, IdentityLookup},

--- a/ceremonies/src/tests.rs
+++ b/ceremonies/src/tests.rs
@@ -77,7 +77,7 @@ impl ExtBuilder {
             .build_storage::<TestRuntime>()
             .unwrap();
         encointer_balances::GenesisConfig {
-            demurrage_per_block: Demurrage::from_bits(DEFAULT_DEMURRAGE),
+            demurrage_per_block_default: Demurrage::from_bits(DEFAULT_DEMURRAGE),
         }
         .assimilate_storage(&mut storage)
         .unwrap();

--- a/ceremonies/src/tests.rs
+++ b/ceremonies/src/tests.rs
@@ -40,8 +40,7 @@ use std::ops::Rem;
 type TestAttestation = Attestation<Signature, AccountId, Moment>;
 type TestProofOfAttendance = ProofOfAttendance<Signature, AccountId>;
 
-use encointer_primitives::balances::consts::DEFAULT_DEMURRAGE;
-use encointer_primitives::communities::Demurrage;
+use encointer_primitives::balances::{consts::DEFAULT_DEMURRAGE, Demurrage};
 use test_utils::{
     helpers::{account_id, bootstrappers, register_test_community},
     *,

--- a/ceremonies/src/tests.rs
+++ b/ceremonies/src/tests.rs
@@ -41,6 +41,7 @@ use std::ops::Rem;
 type TestAttestation = Attestation<Signature, AccountId, Moment>;
 type TestProofOfAttendance = ProofOfAttendance<Signature, AccountId>;
 
+use encointer_primitives::balances::consts::DEFAULT_DEMURRAGE;
 use encointer_primitives::communities::Demurrage;
 use test_utils::*;
 
@@ -75,7 +76,7 @@ impl ExtBuilder {
             .build_storage::<TestRuntime>()
             .unwrap();
         encointer_balances::GenesisConfig {
-            demurrage_per_block: Demurrage::from_bits(0x0000000000000000000001E3F0A8A973_i128),
+            demurrage_per_block: Demurrage::from_bits(DEFAULT_DEMURRAGE),
         }
         .assimilate_storage(&mut storage)
         .unwrap();

--- a/ceremonies/src/tests.rs
+++ b/ceremonies/src/tests.rs
@@ -29,7 +29,7 @@ use frame_support::traits::{OnFinalize, OnInitialize, UnfilteredDispatchable};
 use inherents::ProvideInherent;
 use rstest::*;
 use sp_core::crypto::Ss58Codec;
-use sp_core::{hashing::blake2_256, sr25519, Pair, U256};
+use sp_core::{sr25519, Pair, U256};
 use sp_keyring::AccountKeyring;
 use sp_runtime::{
     testing::Header,
@@ -43,7 +43,10 @@ type TestProofOfAttendance = ProofOfAttendance<Signature, AccountId>;
 
 use encointer_primitives::balances::consts::DEFAULT_DEMURRAGE;
 use encointer_primitives::communities::Demurrage;
-use test_utils::*;
+use test_utils::{
+    helpers::{account_id, bootstrappers, register_test_community},
+    *,
+};
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct TestRuntime;
@@ -153,7 +156,7 @@ fn correct_meetup_time(cid: &CommunityIdentifier, mindex: MeetupIndexType) -> Mo
     t.into()
 }
 
-/// generate a fresh claim for claimant and sign it by attester
+/// generate a fresh claim for claimant and sign it by attestor
 fn meetup_claim_sign(
     claimant: AccountId,
     attester: sr25519::Pair,
@@ -292,65 +295,13 @@ fn gets_attested_by(
     ));
 }
 
-/// shorthand to convert Pair to AccountId
-fn account_id(pair: &sr25519::Pair) -> AccountId {
-    pair.public().into()
-}
-
-/// register a simple test community with N meetup locations and defined bootstrappers
-fn register_test_community(
-    custom_bootstrappers: Option<Vec<sr25519::Pair>>,
-    n_locations: u32,
-) -> CommunityIdentifier {
-    let bs: Vec<AccountId> = custom_bootstrappers
-        .unwrap_or_else(|| bootstrappers())
-        .into_iter()
-        .map(|b| account_id(&b))
-        .collect();
-
-    let prime = &bs[0];
-
-    let mut loc = Vec::with_capacity(n_locations as usize);
-    for l in 0..n_locations {
-        loc.push(Location {
-            lat: Degree::from_num(l),
-            lon: Degree::from_num(l),
-        })
-    }
-
-    assert_ok!(EncointerCommunities::new_community(
-        Origin::signed(prime.clone()),
-        loc.clone(),
-        bs.clone(),
-        Default::default(),
-        None,
-        None,
-    ));
-    CommunityIdentifier::from(blake2_256(&(loc, bs).encode()))
-}
-
-/// All well-known keys are bootstrappers for easy testing afterwards
-fn bootstrappers() -> Vec<sr25519::Pair> {
-    return vec![
-        AccountKeyring::Alice,
-        AccountKeyring::Bob,
-        AccountKeyring::Charlie,
-        AccountKeyring::Dave,
-        AccountKeyring::Eve,
-        AccountKeyring::Ferdie,
-    ]
-    .iter()
-    .map(|k| k.pair())
-    .collect();
-}
-
 /// perform bootstrapping ceremony for test community with either the supplied bootstrappers or the default bootstrappers
 fn perform_bootstrapping_ceremony(
     custom_bootstrappers: Option<Vec<sr25519::Pair>>,
     n_locations: u32,
 ) -> CommunityIdentifier {
     let bootstrappers: Vec<sr25519::Pair> = custom_bootstrappers.unwrap_or_else(|| bootstrappers());
-    let cid = register_test_community(Some(bootstrappers.clone()), n_locations);
+    let cid = register_test_community::<TestRuntime>(Some(bootstrappers.clone()), n_locations);
     bootstrappers
         .iter()
         .for_each(|b| register(b.public().into(), cid, None).unwrap());
@@ -420,7 +371,7 @@ fn fully_attest_meetup(
 #[test]
 fn registering_participant_works() {
     ExtBuilder::build().execute_with(|| {
-        let cid = register_test_community(None, 1);
+        let cid = register_test_community::<TestRuntime>(None, 1);
         let alice = AccountId::from(AccountKeyring::Alice);
         let bob = AccountId::from(AccountKeyring::Bob);
         let cindex = EncointerScheduler::current_ceremony_index();
@@ -449,7 +400,7 @@ fn registering_participant_works() {
 #[test]
 fn registering_participant_twice_fails() {
     ExtBuilder::build().execute_with(|| {
-        let cid = register_test_community(None, 1);
+        let cid = register_test_community::<TestRuntime>(None, 1);
         let alice = AccountId::from(AccountKeyring::Alice);
         assert_ok!(register(alice.clone(), cid, None));
         assert!(register(alice.clone(), cid, None).is_err());
@@ -459,7 +410,7 @@ fn registering_participant_twice_fails() {
 #[test]
 fn registering_participant_in_wrong_phase_fails() {
     ExtBuilder::build().execute_with(|| {
-        let cid = register_test_community(None, 1);
+        let cid = register_test_community::<TestRuntime>(None, 1);
         let alice = AccountId::from(AccountKeyring::Alice);
         run_to_next_phase();
         assert_eq!(
@@ -473,7 +424,7 @@ fn registering_participant_in_wrong_phase_fails() {
 #[test]
 fn verify_attestation_signature_works() {
     ExtBuilder::build().execute_with(|| {
-        let cid = register_test_community(None, 1);
+        let cid = register_test_community::<TestRuntime>(None, 1);
         let claimant = AccountKeyring::Alice.pair();
         let attester = AccountKeyring::Bob.pair();
 
@@ -516,7 +467,7 @@ fn verify_attestation_signature_works() {
 #[test]
 fn register_attestations_works() {
     ExtBuilder::build().execute_with(|| {
-        let cid = register_test_community(None, 1);
+        let cid = register_test_community::<TestRuntime>(None, 1);
         let alice = AccountKeyring::Alice.pair();
         let bob = AccountKeyring::Bob.pair();
         let ferdie = AccountKeyring::Ferdie.pair();
@@ -580,7 +531,7 @@ fn register_attestations_works() {
 #[test]
 fn register_attestations_for_non_participant_fails_silently() {
     ExtBuilder::build().execute_with(|| {
-        let cid = register_test_community(None, 1);
+        let cid = register_test_community::<TestRuntime>(None, 1);
         let alice = AccountKeyring::Alice.pair();
         let bob = AccountKeyring::Bob.pair();
         let cindex = EncointerScheduler::current_ceremony_index();
@@ -609,7 +560,7 @@ fn register_attestations_for_non_participant_fails_silently() {
 #[test]
 fn register_attestations_for_non_participant_fails() {
     ExtBuilder::build().execute_with(|| {
-        let cid = register_test_community(None, 1);
+        let cid = register_test_community::<TestRuntime>(None, 1);
         let alice = AccountKeyring::Alice.pair();
         let ferdie = AccountKeyring::Ferdie.pair();
         let eve = AccountKeyring::Eve.pair();
@@ -658,7 +609,7 @@ fn register_attestations_for_non_participant_fails() {
 #[test]
 fn register_attestations_with_non_participant_fails_silently() {
     ExtBuilder::build().execute_with(|| {
-        let cid = register_test_community(None, 1);
+        let cid = register_test_community::<TestRuntime>(None, 1);
         let alice = AccountKeyring::Alice.pair();
         let bob = AccountKeyring::Bob.pair();
         let eve = AccountKeyring::Eve.pair();
@@ -687,7 +638,7 @@ fn register_attestations_with_non_participant_fails_silently() {
 #[test]
 fn register_attestations_with_wrong_meetup_index_fails() {
     ExtBuilder::build().execute_with(|| {
-        let cid = register_test_community(None, 1);
+        let cid = register_test_community::<TestRuntime>(None, 1);
         let alice = AccountKeyring::Alice.pair();
         let bob = AccountKeyring::Bob.pair();
         let ferdie = AccountKeyring::Ferdie.pair();
@@ -734,7 +685,7 @@ fn register_attestations_with_wrong_meetup_index_fails() {
 #[test]
 fn register_attestations_with_wrong_ceremony_index_fails() {
     ExtBuilder::build().execute_with(|| {
-        let cid = register_test_community(None, 1);
+        let cid = register_test_community::<TestRuntime>(None, 1);
         let alice = AccountKeyring::Alice.pair();
         let bob = AccountKeyring::Bob.pair();
         let ferdie = AccountKeyring::Ferdie.pair();
@@ -781,7 +732,7 @@ fn register_attestations_with_wrong_ceremony_index_fails() {
 #[test]
 fn register_attestations_with_wrong_timestamp_fails() {
     ExtBuilder::build().execute_with(|| {
-        let cid = register_test_community(None, 1);
+        let cid = register_test_community::<TestRuntime>(None, 1);
         let alice = AccountKeyring::Alice.pair();
         let bob = AccountKeyring::Bob.pair();
         let ferdie = AccountKeyring::Ferdie.pair();
@@ -830,7 +781,7 @@ fn register_attestations_with_wrong_timestamp_fails() {
 #[test]
 fn register_attestations_with_wrong_location_fails() {
     ExtBuilder::build().execute_with(|| {
-        let cid = register_test_community(None, 1);
+        let cid = register_test_community::<TestRuntime>(None, 1);
         let alice = AccountKeyring::Alice.pair();
         let bob = AccountKeyring::Bob.pair();
         let ferdie = AccountKeyring::Ferdie.pair();
@@ -878,7 +829,7 @@ fn register_attestations_with_wrong_location_fails() {
 #[test]
 fn ballot_meetup_n_votes_works() {
     ExtBuilder::build().execute_with(|| {
-        let cid = register_test_community(None, 1);
+        let cid = register_test_community::<TestRuntime>(None, 1);
         let alice = AccountKeyring::Alice.pair();
         let bob = AccountKeyring::Bob.pair();
         let ferdie = AccountKeyring::Ferdie.pair();
@@ -1089,7 +1040,7 @@ fn ballot_meetup_n_votes_works() {
 #[test]
 fn issue_reward_works() {
     ExtBuilder::build().execute_with(|| {
-        let cid = register_test_community(None, 1);
+        let cid = register_test_community::<TestRuntime>(None, 1);
         let alice = AccountKeyring::Alice.pair();
         let bob = AccountKeyring::Bob.pair();
         let ferdie = AccountKeyring::Ferdie.pair();
@@ -1356,7 +1307,7 @@ fn endorsing_newbie_works_until_no_more_tickets() {
 #[test]
 fn endorsing_newbie_for_second_next_ceremony_works() {
     ExtBuilder::build().execute_with(|| {
-        let cid = register_test_community(None, 1);
+        let cid = register_test_community::<TestRuntime>(None, 1);
         let alice = AccountId::from(AccountKeyring::Alice);
         let cindex = EncointerScheduler::current_ceremony_index();
         run_to_next_phase();
@@ -1459,7 +1410,7 @@ fn get_meetup_time_works() {
         System::set_block_number(0);
         run_to_block(1);
 
-        let cid = register_test_community(None, 3);
+        let cid = register_test_community::<TestRuntime>(None, 3);
 
         assert_eq!(EncointerScheduler::current_ceremony_index(), 1);
         assert_eq!(
@@ -1513,7 +1464,7 @@ fn get_meetup_time_works() {
 #[test]
 fn ceremony_index_and_purging_registry_works() {
     ExtBuilder::build().execute_with(|| {
-        let cid = register_test_community(None, 1);
+        let cid = register_test_community::<TestRuntime>(None, 1);
         let alice = AccountId::from(AccountKeyring::Alice);
         let cindex = EncointerScheduler::current_ceremony_index();
         assert_ok!(register(alice.clone(), cid, None));
@@ -1553,7 +1504,7 @@ fn ceremony_index_and_purging_registry_works() {
 #[test]
 fn assigning_meetup_at_phase_change_and_purge_works() {
     ExtBuilder::build().execute_with(|| {
-        let cid = register_test_community(None, 1);
+        let cid = register_test_community::<TestRuntime>(None, 1);
         let alice = AccountId::from(AccountKeyring::Alice);
         let cindex = EncointerScheduler::current_ceremony_index();
         register_alice_bob_ferdie(cid);

--- a/communities/Cargo.toml
+++ b/communities/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-encointer-communities"
-version = "0.3.9"
+version = "0.4.0"
 authors = ["encointer.org <alain@encointer.org>"]
 edition = "2018"
 

--- a/communities/Cargo.toml
+++ b/communities/Cargo.toml
@@ -69,11 +69,6 @@ package = "sp-core"
 git = "https://github.com/paritytech/substrate.git"
 branch = "master"
 
-[dev-dependencies.sp-keyring]
-package = "sp-keyring"
-git = "https://github.com/paritytech/substrate.git" 
-branch = "master"
-
 [dev-dependencies.test-utils]
 path = "../test-utils"
 

--- a/communities/src/lib.rs
+++ b/communities/src/lib.rs
@@ -131,8 +131,8 @@ decl_module! {
             validate_demurrage(&demurrage).map_err(|_| <Error<T>>::InvalidDemurrage)?;
             Self::ensure_cid_exists(&cid)?;
 
-            <DemurragePerBlock>::insert(&cid, demurrage);
-            Self::deposit_event(RawEvent::DemurrageUpdated(cid));
+            <DemurragePerBlock>::insert(&cid, &demurrage);
+            Self::deposit_event(RawEvent::DemurrageUpdated(cid, demurrage.to_bits()));
             debug::info!(target: LOG, " updated demurrage for cid: {:?}", cid);
         }
 
@@ -143,8 +143,8 @@ decl_module! {
             validate_nominal_income(&nominal_income).map_err(|_| <Error<T>>::InvalidDemurrage)?;
             Self::ensure_cid_exists(&cid)?;
 
-            <NominalIncome>::insert(&cid, nominal_income);
-            Self::deposit_event(RawEvent::NominalIncomeUpdated(cid));
+            <NominalIncome>::insert(&cid, &nominal_income);
+            Self::deposit_event(RawEvent::NominalIncomeUpdated(cid, nominal_income.to_bits()));
             debug::info!(target: LOG, " updated nominal income for cid: {:?}", cid);
         }
     }
@@ -157,12 +157,12 @@ decl_event!(
     {
         /// A new community was registered \[who, community_identifier\]
         CommunityRegistered(AccountId, CommunityIdentifier),
-        /// CommunityMetadata was updated \[who, community_identifier\]
+        /// CommunityMetadata was updated \[community_identifier\]
         MetadataUpdated(CommunityIdentifier),
-        /// A community's nominal income was updated \[who, community_identifier\]
-        NominalIncomeUpdated(CommunityIdentifier),
-        /// A community's demurrage was updated \[who, community_identifier\]
-        DemurrageUpdated(CommunityIdentifier),
+        /// A community's nominal income was updated \[community_identifier, new_income\]
+        NominalIncomeUpdated(CommunityIdentifier, i128),
+        /// A community's demurrage was updated \[community_identifier, new_demurrage\]
+        DemurrageUpdated(CommunityIdentifier, i128),
     }
 );
 

--- a/communities/src/lib.rs
+++ b/communities/src/lib.rs
@@ -89,7 +89,7 @@ decl_module! {
                 validate_demurrage(&d).map_err(|_| <Error<T>>::InvalidDemurrage)?;
             }
             if let Some(i) = nominal_income {
-                validate_nominal_income(&i).map_err(|_| <Error<T>>::InvalidDemurrage)?;
+                validate_nominal_income(&i).map_err(|_| <Error<T>>::InvalidNominalIncome)?;
             }
 
             let cid = CommunityIdentifier::from(blake2_256(&(loc.clone(), bootstrappers.clone()).encode()));

--- a/communities/src/lib.rs
+++ b/communities/src/lib.rs
@@ -59,7 +59,7 @@ decl_storage! {
         Locations get(fn locations): map hasher(blake2_128_concat) CommunityIdentifier => Vec<Location>;
         Bootstrappers get(fn bootstrappers): map hasher(blake2_128_concat) CommunityIdentifier => Vec<T::AccountId>;
         CommunityIdentifiers get(fn community_identifiers): Vec<CommunityIdentifier>;
-        CommunityMetadata get(fn community_properties): map hasher(blake2_128_concat) CommunityIdentifier => CommunityMetadataType;
+        CommunityMetadata get(fn community_metadata): map hasher(blake2_128_concat) CommunityIdentifier => CommunityMetadataType;
         /// If it is empty, the genesis config's default is used.
         pub DemurragePerBlock get(fn demurrage_per_block): map hasher(blake2_128_concat) CommunityIdentifier => Demurrage;
         /// Amount of UBI to be paid for every attended ceremony.         /// If it is empty, the genesis config's default is used.

--- a/communities/src/lib.rs
+++ b/communities/src/lib.rs
@@ -103,7 +103,6 @@ decl_module! {
             <CommunityIdentifiers>::mutate(|v| v.push(cid));
             <Locations>::insert(&cid, &loc);
             <Bootstrappers<T>>::insert(&cid, &bootstrappers);
-            // Todo: Validate metadata??
             <CommunityMetadata>::insert(&cid, community_metadata);
 
             demurrage.map(|d| <DemurragePerBlock>::insert(&cid, d));
@@ -120,7 +119,6 @@ decl_module! {
             Self::ensure_cid_exists(&cid)?;
             community_metadata.validate().map_err(|_|  <Error<T>>::InvalidCommunityMetadata)?;
 
-            // Todo: Validate metadata??
             <CommunityMetadata>::insert(&cid, community_metadata);
             Self::deposit_event(RawEvent::MetadataUpdated(cid));
             debug::info!(target: LOG, "updated community metadata for cid: {:?}", cid);

--- a/communities/src/lib.rs
+++ b/communities/src/lib.rs
@@ -18,12 +18,11 @@
 //!
 //! provides functionality for
 //! - registering new communities
-//! - modify community characteristics
+//! - modifying community characteristics
 //!
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-// use host_calls::runtime_interfaces;
 use frame_support::{
     debug, decl_error, decl_event, decl_module, decl_storage, ensure,
     storage::{StorageMap, StorageValue},
@@ -96,7 +95,9 @@ decl_module! {
             let cid = CommunityIdentifier::from(blake2_256(&(loc.clone(), bootstrappers.clone()).encode()));
             let cids = Self::community_identifiers();
             ensure!(!cids.contains(&cid), "community already registered");
-            Self::validate_locations(&loc, &cids)?;
+            Self::validate_locations(&loc, &cids)?; // <- O(n^2) !!!
+
+            // All checks done, now mutate state
 
             <CommunityIdentifiers>::mutate(|v| v.push(cid));
             <Locations>::insert(&cid, &loc);

--- a/communities/src/lib.rs
+++ b/communities/src/lib.rs
@@ -36,10 +36,10 @@ use fixed::transcendental::{asin, cos, powi, sin, sqrt};
 use runtime_io::hashing::blake2_256;
 
 use encointer_primitives::{
-    balances::BalanceType,
+    balances::{BalanceType, Demurrage},
     communities::{
         consts::*, validate_demurrage, validate_nominal_income, CommunityIdentifier,
-        CommunityMetadata as CommunityMetadataType, Degree, Demurrage, Location, LossyFrom,
+        CommunityMetadata as CommunityMetadataType, Degree, Location, LossyFrom,
         NominalIncome as NominalIncomeType,
     },
 };

--- a/communities/src/lib.rs
+++ b/communities/src/lib.rs
@@ -60,9 +60,10 @@ decl_storage! {
         Bootstrappers get(fn bootstrappers): map hasher(blake2_128_concat) CommunityIdentifier => Vec<T::AccountId>;
         CommunityIdentifiers get(fn community_identifiers): Vec<CommunityIdentifier>;
         CommunityMetadata get(fn community_properties): map hasher(blake2_128_concat) CommunityIdentifier => CommunityMetadataType;
-        DemurragePerBlock get(fn demurrage_per_block): map hasher(blake2_128_concat) CommunityIdentifier => Demurrage;
-        /// amount of UBI to be paid for every attended ceremony. If empty, the config's default is used.
-        NominalIncome get(fn nominal_income): map hasher(blake2_128_concat) CommunityIdentifier => BalanceType;
+        /// If it is empty, the genesis config's default is used.
+        pub DemurragePerBlock get(fn demurrage_per_block): map hasher(blake2_128_concat) CommunityIdentifier => Demurrage;
+        /// Amount of UBI to be paid for every attended ceremony.         /// If it is empty, the genesis config's default is used.
+        pub NominalIncome get(fn nominal_income): map hasher(blake2_128_concat) CommunityIdentifier => BalanceType;
         // TODO: replace this with on-chain governance
         CommunityMaster get(fn community_master) config(): T::AccountId;
     }

--- a/communities/src/lib.rs
+++ b/communities/src/lib.rs
@@ -152,6 +152,34 @@ decl_module! {
             Self::deposit_event(RawEvent::CommunityMetadataUpdated(cid));
             debug::info!(target: LOG, "updated community metadata for cid: {:?}", cid);
         }
+
+        #[weight = 10_000]
+        fn update_demurrage(origin, cid: CommunityIdentifier, demurrage: BalanceType) {
+            debug::RuntimeLogger::init();
+            ensure_root(origin)?;
+
+            if !Self::community_identifiers().contains(&cid) {
+                return Err(<Error<T>>::CommunityInexistent)?;
+            }
+
+            <DemurragePerBlock>::insert(&cid, demurrage);
+            Self::deposit_event(RawEvent::CommunityDemurrageUpdated(cid));
+            debug::info!(target: LOG, " updated demurrage for cid: {:?}", cid);
+        }
+
+        #[weight = 10_000]
+        fn update_nominal_income(origin, cid: CommunityIdentifier, nominal_income: BalanceType) {
+            debug::RuntimeLogger::init();
+            ensure_root(origin)?;
+
+            if !Self::community_identifiers().contains(&cid) {
+                return Err(<Error<T>>::CommunityInexistent)?;
+            }
+
+            <NominalIncome>::insert(&cid, nominal_income);
+            Self::deposit_event(RawEvent::CommunityNominalIncomeUpdated(cid));
+            debug::info!(target: LOG, " updated nominal income for cid: {:?}", cid);
+        }
     }
 }
 
@@ -164,6 +192,11 @@ decl_event!(
         CommunityRegistered(AccountId, CommunityIdentifier),
         /// CommunityMetadata was updated \[who, community_identifier\]
         CommunityMetadataUpdated(CommunityIdentifier),
+        /// A community's nominal income was updated \[who, community_identifier\]
+        CommunityNominalIncomeUpdated(CommunityIdentifier),
+        /// A community's demurrage was updated \[who, community_identifier\]
+        CommunityDemurrageUpdated(CommunityIdentifier),
+    }
 );
 
 decl_error! {

--- a/communities/src/lib.rs
+++ b/communities/src/lib.rs
@@ -85,6 +85,7 @@ decl_module! {
             debug::RuntimeLogger::init();
             let sender = ensure_signed(origin)?;
             Self::validate_bootstrappers(&bootstrappers)?;
+            community_metadata.validate().map_err(|_|  <Error<T>>::InvalidCommunityMetadata)?;
             if let Some(d) = demurrage {
                 validate_demurrage(&d).map_err(|_| <Error<T>>::InvalidDemurrage)?;
             }
@@ -117,6 +118,7 @@ decl_module! {
             debug::RuntimeLogger::init();
             ensure_root(origin)?;
             Self::ensure_cid_exists(&cid)?;
+            community_metadata.validate().map_err(|_|  <Error<T>>::InvalidCommunityMetadata)?;
 
             // Todo: Validate metadata??
             <CommunityMetadata>::insert(&cid, community_metadata);
@@ -140,7 +142,7 @@ decl_module! {
         fn update_nominal_income(origin, cid: CommunityIdentifier, nominal_income: NominalIncomeType) {
             debug::RuntimeLogger::init();
             ensure_root(origin)?;
-            validate_nominal_income(&nominal_income).map_err(|_| <Error<T>>::InvalidDemurrage)?;
+            validate_nominal_income(&nominal_income).map_err(|_| <Error<T>>::InvalidNominalIncome)?;
             Self::ensure_cid_exists(&cid)?;
 
             <NominalIncome>::insert(&cid, &nominal_income);
@@ -188,6 +190,8 @@ decl_error! {
         CommunityAlreadyRegistered,
         /// Community does not exist yet
         CommunityInexistent,
+        /// Invalid Metadata supplied
+        InvalidCommunityMetadata,
         /// Invalid demurrage supplied
         InvalidDemurrage,
         /// Invalid demurrage supplied

--- a/communities/src/lib.rs
+++ b/communities/src/lib.rs
@@ -120,7 +120,7 @@ decl_module! {
 
             // Todo: Validate metadata??
             <CommunityMetadata>::insert(&cid, community_metadata);
-            Self::deposit_event(RawEvent::CommunityMetadataUpdated(cid));
+            Self::deposit_event(RawEvent::MetadataUpdated(cid));
             debug::info!(target: LOG, "updated community metadata for cid: {:?}", cid);
         }
 
@@ -132,7 +132,7 @@ decl_module! {
             Self::ensure_cid_exists(&cid)?;
 
             <DemurragePerBlock>::insert(&cid, demurrage);
-            Self::deposit_event(RawEvent::CommunityDemurrageUpdated(cid));
+            Self::deposit_event(RawEvent::DemurrageUpdated(cid));
             debug::info!(target: LOG, " updated demurrage for cid: {:?}", cid);
         }
 
@@ -144,7 +144,7 @@ decl_module! {
             Self::ensure_cid_exists(&cid)?;
 
             <NominalIncome>::insert(&cid, nominal_income);
-            Self::deposit_event(RawEvent::CommunityNominalIncomeUpdated(cid));
+            Self::deposit_event(RawEvent::NominalIncomeUpdated(cid));
             debug::info!(target: LOG, " updated nominal income for cid: {:?}", cid);
         }
     }
@@ -158,11 +158,11 @@ decl_event!(
         /// A new community was registered \[who, community_identifier\]
         CommunityRegistered(AccountId, CommunityIdentifier),
         /// CommunityMetadata was updated \[who, community_identifier\]
-        CommunityMetadataUpdated(CommunityIdentifier),
+        MetadataUpdated(CommunityIdentifier),
         /// A community's nominal income was updated \[who, community_identifier\]
-        CommunityNominalIncomeUpdated(CommunityIdentifier),
+        NominalIncomeUpdated(CommunityIdentifier),
         /// A community's demurrage was updated \[who, community_identifier\]
-        CommunityDemurrageUpdated(CommunityIdentifier),
+        DemurrageUpdated(CommunityIdentifier),
     }
 );
 

--- a/communities/src/lib.rs
+++ b/communities/src/lib.rs
@@ -132,7 +132,7 @@ decl_module! {
             Self::ensure_cid_exists(&cid)?;
 
             <DemurragePerBlock>::insert(&cid, &demurrage);
-            Self::deposit_event(RawEvent::DemurrageUpdated(cid, demurrage.to_bits()));
+            Self::deposit_event(RawEvent::DemurrageUpdated(cid, demurrage));
             debug::info!(target: LOG, " updated demurrage for cid: {:?}", cid);
         }
 
@@ -144,7 +144,7 @@ decl_module! {
             Self::ensure_cid_exists(&cid)?;
 
             <NominalIncome>::insert(&cid, &nominal_income);
-            Self::deposit_event(RawEvent::NominalIncomeUpdated(cid, nominal_income.to_bits()));
+            Self::deposit_event(RawEvent::NominalIncomeUpdated(cid, nominal_income));
             debug::info!(target: LOG, " updated nominal income for cid: {:?}", cid);
         }
     }
@@ -160,9 +160,9 @@ decl_event!(
         /// CommunityMetadata was updated \[community_identifier\]
         MetadataUpdated(CommunityIdentifier),
         /// A community's nominal income was updated \[community_identifier, new_income\]
-        NominalIncomeUpdated(CommunityIdentifier, i128),
+        NominalIncomeUpdated(CommunityIdentifier, NominalIncomeType),
         /// A community's demurrage was updated \[community_identifier, new_demurrage\]
-        DemurrageUpdated(CommunityIdentifier, i128),
+        DemurrageUpdated(CommunityIdentifier, Demurrage),
     }
 );
 

--- a/communities/src/lib.rs
+++ b/communities/src/lib.rs
@@ -124,9 +124,14 @@ decl_module! {
             <CommunityIdentifiers>::mutate(|v| v.push(cid));
             <Locations>::insert(&cid, &loc);
             <Bootstrappers<T>>::insert(&cid, &bootstrappers);
-
             <CommunityMetadata>::insert(&cid, community_metadata);
-            <DemurragePerBlock>::insert(&cid, Demurrage::from_bits(0x0000000000000000000001E3F0A8A973_i128));
+
+            if demurrage.is_some() {
+                <DemurragePerBlock>::insert(&cid, demurrage.unwrap());
+            }
+            if nominal_income.is_some() {
+                <NominalIncome>::insert(&cid, nominal_income.unwrap());
+            }
 
             Self::deposit_event(RawEvent::CommunityRegistered(sender, cid));
             debug::info!(target: LOG, "registered community with cid: {:?}", cid);

--- a/communities/src/lib.rs
+++ b/communities/src/lib.rs
@@ -75,7 +75,7 @@ decl_module! {
         // where n is the number of all locations of all communities
         // this should be run off-chain in substraTEE-worker later
         #[weight = 10_000]
-        fn new_community(
+        pub fn new_community(
             origin,
             loc: Vec<Location>,
             bootstrappers: Vec<T::AccountId>,

--- a/communities/src/lib.rs
+++ b/communities/src/lib.rs
@@ -62,7 +62,7 @@ decl_storage! {
         CommunityMetadata get(fn community_metadata): map hasher(blake2_128_concat) CommunityIdentifier => CommunityMetadataType;
         /// If it is empty, the genesis config's default is used.
         pub DemurragePerBlock get(fn demurrage_per_block): map hasher(blake2_128_concat) CommunityIdentifier => Demurrage;
-        /// Amount of UBI to be paid for every attended ceremony.         /// If it is empty, the genesis config's default is used.
+        /// Amount of UBI to be paid for every attended ceremony. If it is empty, the genesis config's default is used.
         pub NominalIncome get(fn nominal_income): map hasher(blake2_128_concat) CommunityIdentifier => BalanceType;
         // TODO: replace this with on-chain governance
         CommunityMaster get(fn community_master) config(): T::AccountId;

--- a/communities/src/lib.rs
+++ b/communities/src/lib.rs
@@ -58,9 +58,8 @@ decl_storage! {
         Bootstrappers get(fn bootstrappers): map hasher(blake2_128_concat) CommunityIdentifier => Vec<T::AccountId>;
         CommunityIdentifiers get(fn community_identifiers): Vec<CommunityIdentifier>;
         CommunityMetadata get(fn community_metadata): map hasher(blake2_128_concat) CommunityIdentifier => CommunityMetadataType;
-        /// If it is empty, the genesis config's default is used.
         pub DemurragePerBlock get(fn demurrage_per_block): map hasher(blake2_128_concat) CommunityIdentifier => Demurrage;
-        /// Amount of UBI to be paid for every attended ceremony. If it is empty, the genesis config's default is used.
+        /// Amount of UBI to be paid for every attended ceremony.
         pub NominalIncome get(fn nominal_income): map hasher(blake2_128_concat) CommunityIdentifier => NominalIncomeType;
         // TODO: replace this with on-chain governance
         CommunityMaster get(fn community_master) config(): T::AccountId;

--- a/communities/src/lib.rs
+++ b/communities/src/lib.rs
@@ -85,6 +85,7 @@ decl_module! {
         ) {
             debug::RuntimeLogger::init();
             let sender = ensure_signed(origin)?;
+            Self::validate_bootstrappers(&bootstrappers)?;
             if let Some(d) = demurrage {
                 validate_demurrage(&d).map_err(|_| <Error<T>>::InvalidDemurrage)?;
             }
@@ -174,6 +175,8 @@ decl_error! {
         TooFewLocations,
         /// Location is not a valid geolocation
         InvalidLocation,
+        /// Invalid amount of bootstrappers supplied. Needs to be \[3, 12\]
+        InvalidAmountBootstrappers,
         /// minimum distance violation within community
         MinimumDistanceViolationWithinCommunity,
         /// minimum distance violated towards pole
@@ -247,6 +250,18 @@ impl<T: Config> Module<T> {
         let c: D = two * asin(sqrt::<D, D>(aa).unwrap_or_default());
         let d = D::from(MEAN_EARTH_RADIUS) * c;
         i64::lossy_from(d).saturated_into()
+    }
+
+    fn validate_bootstrappers(boostrappers: &Vec<T::AccountId>) -> DispatchResult {
+        ensure!(
+            boostrappers.len() <= 1000,
+            <Error<T>>::InvalidAmountBootstrappers
+        );
+        ensure!(
+            !boostrappers.len() >= 3,
+            <Error<T>>::InvalidAmountBootstrappers
+        );
+        Ok(())
     }
 
     fn validate_locations(loc: &Vec<Location>, cids: &Vec<CommunityIdentifier>) -> DispatchResult {

--- a/communities/src/tests.rs
+++ b/communities/src/tests.rs
@@ -15,7 +15,7 @@
 // along with Encointer.  If not, see <http://www.gnu.org/licenses/>.
 
 use super::*;
-use crate::{GenesisConfig, Module, Config};
+use crate::{Config, GenesisConfig, Module};
 use frame_support::assert_ok;
 use sp_core::{hashing::blake2_256, sr25519, Pair, H256};
 use sp_keyring::AccountKeyring;
@@ -184,16 +184,28 @@ fn new_community_works() {
         println!("north pole at {:?}", NORTH_POLE);
         let loc = vec![a, b];
         let bs = vec![alice.clone(), bob.clone(), charlie.clone()];
+        let community_meta: CommunityMetadataType = CommunityMetadataType {
+            name: "Default".into(),
+            symbol: "DEF".into(),
+            ..Default::default()
+        };
         assert_ok!(EncointerCommunities::new_community(
             Origin::signed(alice.clone()),
             loc.clone(),
-            bs.clone()
+            bs.clone(),
+            community_meta.clone(),
+            None,
+            None
         ));
         let cid = CommunityIdentifier::from(blake2_256(&(loc.clone(), bs.clone()).encode()));
         let cids = EncointerCommunities::community_identifiers();
         assert!(cids.contains(&cid));
         assert_eq!(EncointerCommunities::locations(&cid), loc);
         assert_eq!(EncointerCommunities::bootstrappers(&cid), bs);
+        assert_eq!(
+            EncointerCommunities::community_metadata(&cid),
+            community_meta
+        );
     });
 }
 
@@ -215,9 +227,15 @@ fn new_community_with_too_close_inner_locations_fails() {
         let loc = vec![a, b];
         let bs = vec![alice.clone(), bob.clone(), charlie.clone()];
 
-        assert!(
-            EncointerCommunities::new_community(Origin::signed(alice.clone()), loc, bs).is_err()
-        );
+        assert!(EncointerCommunities::new_community(
+            Origin::signed(alice.clone()),
+            loc,
+            bs,
+            Default::default(),
+            None,
+            None
+        )
+        .is_err());
     });
 }
 
@@ -240,7 +258,10 @@ fn new_community_too_close_to_existing_community_fails() {
         assert_ok!(EncointerCommunities::new_community(
             Origin::signed(alice.clone()),
             loc.clone(),
-            bs.clone()
+            bs.clone(),
+            Default::default(),
+            None,
+            None
         ));
 
         // second community
@@ -256,7 +277,10 @@ fn new_community_too_close_to_existing_community_fails() {
         assert!(EncointerCommunities::new_community(
             Origin::signed(alice.clone()),
             loc.clone(),
-            bs.clone()
+            bs.clone(),
+            Default::default(),
+            None,
+            None
         )
         .is_err());
     });
@@ -282,7 +306,10 @@ fn new_community_with_near_pole_locations_fails() {
         assert!(EncointerCommunities::new_community(
             Origin::signed(alice.clone()),
             loc,
-            bs.clone()
+            bs.clone(),
+            Default::default(),
+            None,
+            None
         )
         .is_err());
 
@@ -295,9 +322,15 @@ fn new_community_with_near_pole_locations_fails() {
             lon: T::from_num(-60),
         };
         let loc = vec![a, b];
-        assert!(
-            EncointerCommunities::new_community(Origin::signed(alice.clone()), loc, bs).is_err()
-        );
+        assert!(EncointerCommunities::new_community(
+            Origin::signed(alice.clone()),
+            loc,
+            bs,
+            Default::default(),
+            None,
+            None
+        )
+        .is_err());
     });
 }
 
@@ -321,7 +354,10 @@ fn new_community_near_dateline_fails() {
         assert!(EncointerCommunities::new_community(
             Origin::signed(alice.clone()),
             loc,
-            bs.clone()
+            bs.clone(),
+            Default::default(),
+            None,
+            None
         )
         .is_err());
     });
@@ -349,7 +385,10 @@ fn new_currency_with_very_close_location_works() {
         assert!(EncointerCommunities::new_community(
             Origin::signed(alice.clone()),
             loc,
-            bs.clone()
+            bs.clone(),
+            Default::default(),
+            None,
+            None
         )
         .is_ok());
     });

--- a/communities/src/tests.rs
+++ b/communities/src/tests.rs
@@ -235,6 +235,24 @@ fn updating_nominal_income_works() {
 }
 
 #[test]
+fn updating_demurrage_works() {
+    ExtBuilder::build().execute_with(|| {
+        // Assert that is the genesis config's value
+        let cid = register_test_community::<TestRuntime>(None, 1);
+        assert!(DemurragePerBlock::try_get(cid).is_err());
+        assert_ok!(EncointerCommunities::update_demurrage(
+            Origin::root(),
+            cid,
+            Demurrage::from_num(0.0001),
+        ));
+        assert_eq!(
+            DemurragePerBlock::try_get(&cid).unwrap(),
+            BalanceType::from_num(0.0001)
+        );
+    });
+}
+
+#[test]
 fn new_community_with_too_close_inner_locations_fails() {
     ExtBuilder::build().execute_with(|| {
         let alice = AccountId::from(AccountKeyring::Alice);

--- a/communities/src/tests.rs
+++ b/communities/src/tests.rs
@@ -18,7 +18,6 @@ use super::*;
 use crate::{Config, GenesisConfig, Module};
 use frame_support::assert_ok;
 use sp_core::{hashing::blake2_256, sr25519, Pair, H256};
-use sp_keyring::AccountKeyring;
 use sp_runtime::{
     testing::Header,
     traits::{BlakeTwo256, IdentityLookup},

--- a/communities/src/tests.rs
+++ b/communities/src/tests.rs
@@ -49,7 +49,7 @@ impl ExtBuilder {
             .build_storage::<TestRuntime>()
             .unwrap();
         encointer_balances::GenesisConfig {
-            demurrage_per_block: Demurrage::from_bits(DEFAULT_DEMURRAGE),
+            demurrage_per_block_default: Demurrage::from_bits(DEFAULT_DEMURRAGE),
         }
         .assimilate_storage(&mut storage)
         .unwrap();

--- a/communities/src/tests.rs
+++ b/communities/src/tests.rs
@@ -24,7 +24,8 @@ use sp_runtime::{
     traits::{BlakeTwo256, IdentityLookup},
 };
 
-use test_utils::*;
+use encointer_primitives::communities::NominalIncome;
+use test_utils::{helpers::register_test_community, *};
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct TestRuntime;
@@ -38,6 +39,7 @@ pub type EncointerCommunities = Module<TestRuntime>;
 
 impl_frame_system!(TestRuntime);
 impl_balances!(TestRuntime, System);
+impl_encointer_communities!(TestRuntime);
 impl_outer_origin_for_runtime!(TestRuntime);
 
 pub struct ExtBuilder;
@@ -205,6 +207,20 @@ fn new_community_works() {
         assert_eq!(
             EncointerCommunities::community_metadata(&cid),
             community_meta
+        );
+    });
+}
+
+#[test]
+fn updating_nominal_income_works() {
+    ExtBuilder::build().execute_with(|| {
+        // Assert that is the genesis config's value
+        let cid = register_test_community::<TestRuntime>(None, 1);
+        assert!(NominalIncome::try_get(cid).is_none());
+        EncointerCommunities::update_nominal_income(Origin::Root, cid, BalanceType::from_num(1.1));
+        assert_eq!(
+            NominalIncome::try_get(&cid).unwrap(),
+            BalanceType::from_num(1.1)
         );
     });
 }

--- a/communities/src/tests.rs
+++ b/communities/src/tests.rs
@@ -218,7 +218,6 @@ fn new_community_works() {
 #[test]
 fn updating_nominal_income_works() {
     ExtBuilder::build().execute_with(|| {
-        // Assert that is the genesis config's value
         let cid = register_test_community::<TestRuntime>(None, 1);
         assert!(NominalIncome::try_get(cid).is_err());
         assert_ok!(EncointerCommunities::update_nominal_income(
@@ -236,7 +235,6 @@ fn updating_nominal_income_works() {
 #[test]
 fn updating_demurrage_works() {
     ExtBuilder::build().execute_with(|| {
-        // Assert that is the genesis config's value
         let cid = register_test_community::<TestRuntime>(None, 1);
         assert!(DemurragePerBlock::try_get(cid).is_err());
         assert_ok!(EncointerCommunities::update_demurrage(

--- a/personhood-oracle/Cargo.toml
+++ b/personhood-oracle/Cargo.toml
@@ -87,11 +87,6 @@ package = "sp-io"
 git = "https://github.com/paritytech/substrate.git"
 branch = "master"
 
-[dev-dependencies.sp-keyring]
-package = "sp-keyring"
-git = "https://github.com/paritytech/substrate.git"
-branch = "master"
-
 [dev-dependencies.xcm-builder]
 git = "https://github.com/paritytech/polkadot.git"
 branch = "master"

--- a/personhood-oracle/Cargo.toml
+++ b/personhood-oracle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-encointer-personhood-oracle"
-version = "0.3.9"
+version = "0.4.0"
 authors = ["encointer.org <alain@encointer.org>"]
 edition = "2018"
 

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -50,6 +50,7 @@ default = ["std"]
 std = [
     "codec/std",
     "fixed/std",
+    "fixed/serde",
     "rstd/std",
     "serde",
     "sp-core/std",

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -45,10 +45,6 @@ features = ["derive"]
 optional = true
 version = "1.0.101"
 
-[dependencies.encoding_rs]
-default-features = false
-version = "0.8.28"
-
 [features]
 default = ["std"]
 std = [

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "encointer-primitives"
-version = "0.3.9"
+version = "0.4.0"
 authors = ["Christian Langenbacher <christian.langenbacher91@gmail.com>"]
 edition = "2018"
 

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -45,6 +45,10 @@ features = ["derive"]
 optional = true
 version = "1.0.101"
 
+[dependencies.encoding_rs]
+default-features = false
+version = "0.8.28"
+
 [features]
 default = ["std"]
 std = [

--- a/primitives/src/balances.rs
+++ b/primitives/src/balances.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 
 // We're working with fixpoint here.
 pub type BalanceType = I64F64;
+pub type Demurrage = I64F64;
 
 #[derive(Encode, Decode, Default, RuntimeDebug, Clone, Copy)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]

--- a/primitives/src/balances.rs
+++ b/primitives/src/balances.rs
@@ -16,3 +16,7 @@ pub struct BalanceEntry<BlockNumber> {
     /// The time (block height) at which the balance was last adjusted
     pub last_update: BlockNumber,
 }
+
+pub mod consts {
+    pub const DEFAULT_DEMURRAGE: i128 = 0x0000000000000000000001E3F0A8A973_i128;
+}

--- a/primitives/src/bazaar.rs
+++ b/primitives/src/bazaar.rs
@@ -1,10 +1,4 @@
-use rstd::vec::Vec;
+use crate::common::IpfsCid;
 
-pub type ShopIdentifier = Vec<u8>;
-pub type ArticleIdentifier = Vec<u8>;
-
-pub mod consts {
-    // Only valid for current hashing algorithm of IPFS (sha256)
-    // string length: 46 characters (base-58)
-    pub const MAX_HASH_SIZE: usize = 46;
-}
+pub type ShopIdentifier = IpfsCid;
+pub type ArticleIdentifier = IpfsCid;

--- a/primitives/src/common.rs
+++ b/primitives/src/common.rs
@@ -1,0 +1,14 @@
+use rstd::vec::Vec;
+
+/// Substrate runtimes provide no string type. Hence, for arbitrary data of varying length the
+/// `Vec<u8>` is used. In the polkadot-js the typedef `Text` is used to automatically
+/// utf8 decode bytes into a string.
+pub type PalletString = Vec<u8>;
+
+pub type IpfsCid = PalletString;
+
+pub mod consts {
+    // Only valid for current hashing algorithm of IPFS (sha256)
+    // string length: 46 characters (base-58)
+    pub const MAX_HASH_SIZE: usize = 46;
+}

--- a/primitives/src/common.rs
+++ b/primitives/src/common.rs
@@ -1,5 +1,4 @@
 use codec::{Decode, Encode};
-use consts::MAX_HASH_SIZE;
 use rstd::vec::Vec;
 use sp_core::RuntimeDebug;
 
@@ -19,6 +18,10 @@ pub fn validate_ascii(bytes: &[u8]) -> Result<(), u8> {
     Ok(())
 }
 
+// Only valid for current hashing algorithm of IPFS (sha256)
+// string length: 46 bs58 characters (bs58 -> 1 byte/char)
+pub const MAX_HASH_SIZE: usize = 46;
+
 pub fn validate_ipfs_cid(cid: &IpfsCid) -> Result<(), IpfsValidationError> {
     if cid.len() != MAX_HASH_SIZE {
         return Err(IpfsValidationError::InvalidLength);
@@ -30,12 +33,6 @@ pub fn validate_ipfs_cid(cid: &IpfsCid) -> Result<(), IpfsValidationError> {
 pub enum IpfsValidationError {
     InvalidLength,
     InvalidBase58(Bs58Error),
-}
-
-pub mod consts {
-    // Only valid for current hashing algorithm of IPFS (sha256)
-    // string length: 46 characters (base-58)
-    pub const MAX_HASH_SIZE: usize = 46;
 }
 
 /// Simple Bs58 verification adapted from https://github.com/mycorrhiza/bs58-rs

--- a/primitives/src/common.rs
+++ b/primitives/src/common.rs
@@ -1,4 +1,7 @@
+use codec::{Decode, Encode};
+use consts::MAX_HASH_SIZE;
 use rstd::vec::Vec;
+use sp_core::RuntimeDebug;
 
 /// Substrate runtimes provide no string type. Hence, for arbitrary data of varying length the
 /// `Vec<u8>` is used. In the polkadot-js the typedef `Text` is used to automatically
@@ -7,8 +10,60 @@ pub type PalletString = Vec<u8>;
 
 pub type IpfsCid = PalletString;
 
+pub fn validate_ipfs_cid(cid: &IpfsCid) -> Result<(), IpfsValidationError> {
+    if cid.len() != MAX_HASH_SIZE {
+        return Err(IpfsValidationError::InvalidLength);
+    }
+    Bs58verify::verify(&cid).map_err(|e| IpfsValidationError::InvalidBase58(e))
+}
+
+#[derive(Encode, Decode, Clone, PartialEq, Eq, RuntimeDebug)]
+pub enum IpfsValidationError {
+    InvalidLength,
+    InvalidBase58(Bs58Error),
+}
+
 pub mod consts {
     // Only valid for current hashing algorithm of IPFS (sha256)
     // string length: 46 characters (base-58)
     pub const MAX_HASH_SIZE: usize = 46;
+}
+
+/// Simple Bs58 verification adapted from https://github.com/mycorrhiza/bs58-rs
+pub struct Bs58verify {}
+
+impl Bs58verify {
+    const BITCOIN_ALPHABET: &'static [u8] =
+        b"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+    const BITCOIN_DECODE_MAP: fn() -> [u8; 128] = || -> [u8; 128] {
+        let mut decode = [0xFF; 128];
+
+        let mut i = 0;
+        while i < Self::BITCOIN_ALPHABET.len() {
+            decode[Self::BITCOIN_ALPHABET[i] as usize] = i as u8;
+            i += 1;
+        }
+        return decode;
+    };
+
+    pub fn verify(bytes: &[u8]) -> Result<(), Bs58Error> {
+        for (i, c) in bytes.iter().enumerate() {
+            if *c > 127 {
+                return Err(Bs58Error::NonAsciiCharacter(i as u8));
+            }
+
+            if Self::BITCOIN_DECODE_MAP()[*c as usize] as usize == 0xFF {
+                return Err(Bs58Error::NonBs58Character(i as u8));
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Encode, Decode, Clone, PartialEq, Eq, RuntimeDebug)]
+pub enum Bs58Error {
+    /// Non ascii character at index
+    NonAsciiCharacter(u8),
+    /// Non bs58 character at index
+    NonBs58Character(u8),
 }

--- a/primitives/src/common.rs
+++ b/primitives/src/common.rs
@@ -10,6 +10,15 @@ pub type PalletString = Vec<u8>;
 
 pub type IpfsCid = PalletString;
 
+pub fn validate_ascii(bytes: &[u8]) -> Result<(), u8> {
+    for (i, c) in bytes.iter().enumerate() {
+        if *c > 127 {
+            return Err(i as u8);
+        }
+    }
+    Ok(())
+}
+
 pub fn validate_ipfs_cid(cid: &IpfsCid) -> Result<(), IpfsValidationError> {
     if cid.len() != MAX_HASH_SIZE {
         return Err(IpfsValidationError::InvalidLength);

--- a/primitives/src/common.rs
+++ b/primitives/src/common.rs
@@ -24,14 +24,15 @@ pub const MAX_HASH_SIZE: usize = 46;
 
 pub fn validate_ipfs_cid(cid: &IpfsCid) -> Result<(), IpfsValidationError> {
     if cid.len() != MAX_HASH_SIZE {
-        return Err(IpfsValidationError::InvalidLength);
+        return Err(IpfsValidationError::InvalidLength(cid.len() as u8));
     }
     Bs58verify::verify(&cid).map_err(|e| IpfsValidationError::InvalidBase58(e))
 }
 
 #[derive(Encode, Decode, Clone, PartialEq, Eq, RuntimeDebug)]
 pub enum IpfsValidationError {
-    InvalidLength,
+    /// Invalid length supplied. Should be 46. Is: \[length\]
+    InvalidLength(u8),
     InvalidBase58(Bs58Error),
 }
 

--- a/primitives/src/communities.rs
+++ b/primitives/src/communities.rs
@@ -9,14 +9,22 @@ pub type CommunityIndexType = u32;
 pub type LocationIndexType = u32;
 pub type Degree = I64F64;
 pub type Demurrage = I64F64;
+pub type NominalIncome = I64F64;
 pub type CommunityIdentifier = H256;
 
-/// Ensure that the demurrage is in a sane range. Currently, it is only checked if the demurrage
-/// is bigger than zero.
+/// Ensure that the demurrage is in a sane range.
 ///
 /// Todo: Other sanity checks, e.g., 0 < e^(demurrage_per_block*sum(phase_durations)) < 1?
-pub fn validate_demurrage(demurrage: Demurrage) -> Result<(), ()> {
-    if demurrage <= Demurrage::from_num(0) {
+pub fn validate_demurrage(demurrage: &Demurrage) -> Result<(), ()> {
+    if demurrage < &Demurrage::from_num(0) {
+        return Err(());
+    }
+    Ok(())
+}
+
+/// Ensure that the demurrage is in a sane range.
+pub fn validate_nominal_income(nominal_income: &NominalIncome) -> Result<(), ()> {
+    if nominal_income <= &NominalIncome::from_num(0) {
         return Err(());
     }
     Ok(())
@@ -88,10 +96,20 @@ pub mod consts {
 
 #[cfg(test)]
 mod tests {
-    use crate::communities::{ensure_valid, Demurrage};
+    use crate::communities::{
+        validate_demurrage, validate_nominal_income, Demurrage, NominalIncome,
+    };
 
     #[test]
     fn demurrage_smaller_0_fails() {
-        assert_eq!(ensure_valid(Demurrage::from_num(-1)), Err(()));
+        assert_eq!(validate_demurrage(&Demurrage::from_num(-1)), Err(()));
+    }
+
+    #[test]
+    fn nominal_income_smaller_0_fails() {
+        assert_eq!(
+            validate_nominal_income(&NominalIncome::from_num(-1)),
+            Err(())
+        );
     }
 }

--- a/primitives/src/communities.rs
+++ b/primitives/src/communities.rs
@@ -19,9 +19,33 @@ pub struct Location {
 }
 
 #[derive(Encode, Decode, Clone, PartialEq, Eq, Default, RuntimeDebug)]
-pub struct CommunityPropertiesType {
-    pub name_utf8: Vec<u8>,
-    pub demurrage_per_block: Demurrage,
+pub struct CommunityMetadata {
+    /// utf8 encoded name
+    pub name: Vec<u8>,
+    /// utf8 encoded abbreviation of the name
+    pub symbol: Vec<u8>,
+    /// multi-resolution resource for the community icon
+    pub icons: Vec<Favicon>,
+    /// optional color scheme or other customizable styles to shape app appearance
+    pub theme: Option<Theme>,
+    /// optional link to a community site
+    pub url: Option<Vec<u8>>,
+}
+
+pub type IpfsCid = Vec<u8>;
+
+#[derive(Encode, Decode, Clone, PartialEq, Eq, Default, RuntimeDebug)]
+pub struct Favicon {
+    src: IpfsCid,
+    sizes: Vec<u8>,
+    density: u8,
+}
+
+#[derive(Encode, Decode, Clone, PartialEq, Eq, Default, RuntimeDebug)]
+pub struct Theme {
+    // Todo: extend
+    /// primary theme color from which the accent colors are derived by the material app design guide line
+    primary_swatch: u32,
 }
 
 pub mod consts {

--- a/primitives/src/communities.rs
+++ b/primitives/src/communities.rs
@@ -54,6 +54,7 @@ pub struct CommunityMetadata {
 }
 
 #[derive(Encode, Decode, Clone, PartialEq, Eq, Default, RuntimeDebug)]
+/// Todo: Unfinalized. But check with the wallet-app first the exact data types that need to be used.
 pub struct Favicon {
     src: IpfsCid,
     sizes: PalletString,
@@ -61,6 +62,7 @@ pub struct Favicon {
 }
 
 #[derive(Encode, Decode, Clone, PartialEq, Eq, Default, RuntimeDebug)]
+/// Todo: Unfinalized. But check with the wallet-app first the exact data types that need to be used.
 pub struct Theme {
     // Todo: extend
     /// primary theme color from which the accent colors are derived by the material app design guide line

--- a/primitives/src/communities.rs
+++ b/primitives/src/communities.rs
@@ -3,6 +3,9 @@ use fixed::types::I64F64;
 use rstd::vec::Vec;
 use sp_core::{RuntimeDebug, H256};
 
+#[cfg(feature = "std")]
+use serde::{Deserialize, Serialize};
+
 use crate::balances::Demurrage;
 use crate::common::{IpfsCid, PalletString};
 
@@ -13,7 +16,7 @@ pub type LocationIndexType = u32;
 pub type Degree = I64F64;
 pub type NominalIncome = I64F64;
 pub type CommunityIdentifier = H256;
-
+0xFF000000
 /// Ensure that the demurrage is in a sane range.
 ///
 /// Todo: Other sanity checks, e.g., 0 < e^(demurrage_per_block*sum(phase_durations)) < 1?
@@ -40,6 +43,7 @@ pub struct Location {
 }
 
 #[derive(Encode, Decode, Clone, PartialEq, Eq, Default, RuntimeDebug)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub struct CommunityMetadata {
     /// utf8 encoded name
     pub name: PalletString,
@@ -54,18 +58,22 @@ pub struct CommunityMetadata {
 }
 
 #[derive(Encode, Decode, Clone, PartialEq, Eq, Default, RuntimeDebug)]
-/// Todo: Unfinalized. But check with the wallet-app first the exact data types that need to be used.
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub struct Favicon {
     src: IpfsCid,
+    /// e.g. "64x64", "128x128", ...
     sizes: PalletString,
+    /// e.g. 1, 2, 3, ...
     density: u8,
 }
 
 #[derive(Encode, Decode, Clone, PartialEq, Eq, Default, RuntimeDebug)]
-/// Todo: Unfinalized. But check with the wallet-app first the exact data types that need to be used.
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub struct Theme {
     // Todo: extend
     /// primary theme color from which the accent colors are derived by the material app design guide line
+    ///
+    /// e.g. black = 0xFF000000
     primary_swatch: u32,
 }
 

--- a/primitives/src/communities.rs
+++ b/primitives/src/communities.rs
@@ -1,6 +1,5 @@
 use codec::{Decode, Encode};
 use fixed::types::I64F64;
-use rstd::vec::Vec;
 use sp_core::{RuntimeDebug, H256};
 
 #[cfg(feature = "std")]
@@ -27,7 +26,7 @@ pub fn validate_demurrage(demurrage: &Demurrage) -> Result<(), ()> {
     Ok(())
 }
 
-/// Ensure that the demurrage is in a sane range.
+/// Ensure that the nominal is in a sane range.
 pub fn validate_nominal_income(nominal_income: &NominalIncome) -> Result<(), ()> {
     if nominal_income <= &NominalIncome::from_num(0) {
         return Err(());
@@ -49,22 +48,12 @@ pub struct CommunityMetadata {
     pub name: PalletString,
     /// utf8 encoded abbreviation of the name
     pub symbol: PalletString,
-    /// multi-resolution resource for the community icon
-    pub icons: Vec<Favicon>,
+    /// ipfs link to multi-resolution resource for the community icon
+    pub icons: IpfsCid,
     /// optional color scheme or other customizable styles to shape app appearance
     pub theme: Option<Theme>,
     /// optional link to a community site
     pub url: Option<PalletString>,
-}
-
-#[derive(Encode, Decode, Clone, PartialEq, Eq, Default, RuntimeDebug)]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-pub struct Favicon {
-    src: IpfsCid,
-    /// e.g. "64x64", "128x128", ...
-    sizes: PalletString,
-    /// e.g. 1, 2, 3, ...
-    density: u8,
 }
 
 #[derive(Encode, Decode, Clone, PartialEq, Eq, Default, RuntimeDebug)]

--- a/primitives/src/communities.rs
+++ b/primitives/src/communities.rs
@@ -177,6 +177,7 @@ pub mod consts {
 
 #[cfg(test)]
 mod tests {
+    use crate::common::{Bs58Error, IpfsValidationError};
     use crate::communities::{
         validate_demurrage, validate_nominal_income, CommunityMetadata, CommunityMetadataError,
         Demurrage, NominalIncome,
@@ -197,13 +198,7 @@ mod tests {
 
     #[test]
     fn validate_metadata_works() {
-        let meta = CommunityMetadata {
-            name: "Default".into(),
-            symbol: "DEF".into(),
-            url: Some("Default".into()),
-            ..Default::default()
-        };
-        assert_eq!(meta.validate(), Ok(()));
+        assert_eq!(CommunityMetadata::default().validate(), Ok(()));
     }
 
     #[test]
@@ -215,6 +210,20 @@ mod tests {
         assert_eq!(
             meta.validate(),
             Err(CommunityMetadataError::InvalidAscii(0))
+        );
+    }
+
+    #[test]
+    fn validate_metadata_fails_for_invalid_icons_cid() {
+        let meta = CommunityMetadata {
+            icons: "IhaveCorrectLengthButWrongSymbols1111111111111".into(),
+            ..Default::default()
+        };
+        assert_eq!(
+            meta.validate(),
+            Err(CommunityMetadataError::InvalidIpfsCid(
+                IpfsValidationError::InvalidBase58(Bs58Error::NonBs58Character(0))
+            ))
         );
     }
 }

--- a/primitives/src/communities.rs
+++ b/primitives/src/communities.rs
@@ -11,6 +11,17 @@ pub type Degree = I64F64;
 pub type Demurrage = I64F64;
 pub type CommunityIdentifier = H256;
 
+/// Ensure that the demurrage is in a sane range. Currently, it is only checked if the demurrage
+/// is bigger than zero.
+///
+/// Todo: Other sanity checks, e.g., 0 < e^(demurrage_per_block*sum(phase_durations)) < 1?
+pub fn validate_demurrage(demurrage: Demurrage) -> Result<(), ()> {
+    if demurrage <= Demurrage::from_num(0) {
+        return Err(());
+    }
+    Ok(())
+}
+
 // Location in lat/lon. Fixpoint value in degree with 8 decimal bits and 24 fractional bits
 #[derive(Encode, Decode, Copy, Clone, PartialEq, Eq, Default, RuntimeDebug)]
 pub struct Location {
@@ -73,4 +84,14 @@ pub mod consts {
     // dec2hex(6371000,8)
     // in meters
     pub const MEAN_EARTH_RADIUS: I32F0 = I32F0::from_bits(0x006136B8);
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::communities::{ensure_valid, Demurrage};
+
+    #[test]
+    fn demurrage_smaller_0_fails() {
+        assert_eq!(ensure_valid(Demurrage::from_num(-1)), Err(()));
+    }
 }

--- a/primitives/src/communities.rs
+++ b/primitives/src/communities.rs
@@ -105,9 +105,7 @@ impl CommunityMetadata {
         if let Some(u) = &self.url {
             validate_ascii(u).map_err(|e| CommunityMetadataError::InvalidAscii(e))?;
             if u.len() >= 20 {
-                return Err(CommunityMetadataError::TooManyCharactersInNameUrl(
-                    u.len() as u8
-                ));
+                return Err(CommunityMetadataError::TooManyCharactersInUrl(u.len() as u8));
             }
         }
         Ok(())
@@ -137,7 +135,7 @@ pub enum CommunityMetadataError {
     /// Invalid amount of characters symbol. Must be 3. Used: \[amount\]
     InvalidAmountCharactersInSymbol(u8),
     /// Too many characters in url. Allowed: 20. Used: \[amount\]
-    TooManyCharactersInNameUrl(u8),
+    TooManyCharactersInUrl(u8),
 }
 
 #[derive(Encode, Decode, Clone, PartialEq, Eq, Default, RuntimeDebug)]

--- a/primitives/src/communities.rs
+++ b/primitives/src/communities.rs
@@ -16,7 +16,7 @@ pub type LocationIndexType = u32;
 pub type Degree = I64F64;
 pub type NominalIncome = I64F64;
 pub type CommunityIdentifier = H256;
-0xFF000000
+
 /// Ensure that the demurrage is in a sane range.
 ///
 /// Todo: Other sanity checks, e.g., 0 < e^(demurrage_per_block*sum(phase_durations)) < 1?

--- a/primitives/src/communities.rs
+++ b/primitives/src/communities.rs
@@ -4,7 +4,7 @@ use rstd::vec::Vec;
 use sp_core::{RuntimeDebug, H256};
 
 use crate::balances::Demurrage;
-use crate::common::PalletString;
+use crate::common::{IpfsCid, PalletString};
 
 pub use fixed::traits::{LossyFrom, LossyInto};
 
@@ -52,8 +52,6 @@ pub struct CommunityMetadata {
     /// optional link to a community site
     pub url: Option<PalletString>,
 }
-
-pub type IpfsCid = Vec<u8>;
 
 #[derive(Encode, Decode, Clone, PartialEq, Eq, Default, RuntimeDebug)]
 pub struct Favicon {

--- a/primitives/src/communities.rs
+++ b/primitives/src/communities.rs
@@ -4,6 +4,7 @@ use rstd::vec::Vec;
 use sp_core::{RuntimeDebug, H256};
 
 use crate::balances::Demurrage;
+use crate::common::PalletString;
 
 pub use fixed::traits::{LossyFrom, LossyInto};
 
@@ -41,15 +42,15 @@ pub struct Location {
 #[derive(Encode, Decode, Clone, PartialEq, Eq, Default, RuntimeDebug)]
 pub struct CommunityMetadata {
     /// utf8 encoded name
-    pub name: Vec<u8>,
+    pub name: PalletString,
     /// utf8 encoded abbreviation of the name
-    pub symbol: Vec<u8>,
+    pub symbol: PalletString,
     /// multi-resolution resource for the community icon
     pub icons: Vec<Favicon>,
     /// optional color scheme or other customizable styles to shape app appearance
     pub theme: Option<Theme>,
     /// optional link to a community site
-    pub url: Option<Vec<u8>>,
+    pub url: Option<PalletString>,
 }
 
 pub type IpfsCid = Vec<u8>;
@@ -57,7 +58,7 @@ pub type IpfsCid = Vec<u8>;
 #[derive(Encode, Decode, Clone, PartialEq, Eq, Default, RuntimeDebug)]
 pub struct Favicon {
     src: IpfsCid,
-    sizes: Vec<u8>,
+    sizes: PalletString,
     density: u8,
 }
 

--- a/primitives/src/communities.rs
+++ b/primitives/src/communities.rs
@@ -3,12 +3,13 @@ use fixed::types::I64F64;
 use rstd::vec::Vec;
 use sp_core::{RuntimeDebug, H256};
 
+use crate::balances::Demurrage;
+
 pub use fixed::traits::{LossyFrom, LossyInto};
 
 pub type CommunityIndexType = u32;
 pub type LocationIndexType = u32;
 pub type Degree = I64F64;
-pub type Demurrage = I64F64;
 pub type NominalIncome = I64F64;
 pub type CommunityIdentifier = H256;
 

--- a/primitives/src/communities.rs
+++ b/primitives/src/communities.rs
@@ -95,6 +95,8 @@ impl CommunityMetadata {
             return Err(CommunityMetadataError::InvalidAmountCharactersInSymbol(res));
         }
 
+        // Todo: Be more strict, check only base58 characters.
+        // Might be supported by in no_std environment https://github.com/mycorrhiza/bs58-rs/
         res = Self::validate_ascii(&self.icons)?;
         if res != 46 {
             return Err(CommunityMetadataError::InvalidAmountCharactersInIpfsCid(

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod balances;
 pub mod bazaar;
 pub mod ceremonies;
+pub mod common;
 pub mod communities;
 pub mod scheduler;
 pub mod sybil;

--- a/scheduler/Cargo.toml
+++ b/scheduler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-encointer-scheduler"
-version = "0.3.9"
+version = "0.4.0"
 authors = ["encointer.org <alain@encointer.org>"]
 edition = "2018"
 

--- a/sybil-gate-template/Cargo.toml
+++ b/sybil-gate-template/Cargo.toml
@@ -73,11 +73,6 @@ default-features = false
 git = "https://github.com/paritytech/polkadot"
 branch = "master"
 
-[dev-dependencies.sp-keyring]
-package = "sp-keyring"
-git = "https://github.com/paritytech/substrate.git"
-branch = "master"
-
 [dev-dependencies.xcm-executor]
 git = "https://github.com/paritytech/polkadot.git"
 branch = "master"

--- a/sybil-gate-template/Cargo.toml
+++ b/sybil-gate-template/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-encointer-sybil-gate-template"
-version = "0.3.9"
+version = "0.4.0"
 authors = ["encointer.org <alain@encointer.org>"]
 edition = "2018"
 

--- a/sybil-gate-template/src/tests.rs
+++ b/sybil-gate-template/src/tests.rs
@@ -18,7 +18,6 @@ use super::*;
 use crate::{Config, Module};
 use frame_support::assert_ok;
 use sp_core::H256;
-use sp_keyring::AccountKeyring;
 use sp_runtime::{
     testing::Header,
     traits::{BlakeTwo256, IdentityLookup},

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test-utils"
-version = "0.3.9"
+version = "0.4.0"
 authors = ["encointer.org <alain@encointer.org>"]
 edition = "2018"
 

--- a/test-utils/src/helpers.rs
+++ b/test-utils/src/helpers.rs
@@ -1,0 +1,63 @@
+use crate::AccountId;
+use codec::Encode;
+use encointer_primitives::communities::{CommunityIdentifier, Degree, Location};
+use frame_support::traits::OriginTrait;
+use sp_core::{blake2_256, sr25519, Pair};
+use sp_keyring::AccountKeyring;
+
+/// shorthand to convert Pair to AccountId
+pub fn account_id(pair: &sr25519::Pair) -> AccountId {
+    pair.public().into()
+}
+
+/// All well-known keys are bootstrappers for easy testing afterwards
+pub fn bootstrappers() -> Vec<sr25519::Pair> {
+    return vec![
+        AccountKeyring::Alice,
+        AccountKeyring::Bob,
+        AccountKeyring::Charlie,
+        AccountKeyring::Dave,
+        AccountKeyring::Eve,
+        AccountKeyring::Ferdie,
+    ]
+    .iter()
+    .map(|k| k.pair())
+    .collect();
+}
+
+/// register a simple test community with N meetup locations and defined bootstrappers
+pub fn register_test_community<Runtime>(
+    custom_bootstrappers: Option<Vec<sr25519::Pair>>,
+    n_locations: u32,
+) -> CommunityIdentifier
+where
+    Runtime: encointer_communities::Config,
+    Runtime: frame_system::Config<AccountId = AccountId>,
+    <Runtime as frame_system::Config>::Origin: OriginTrait<AccountId = AccountId>,
+{
+    let bs: Vec<AccountId> = custom_bootstrappers
+        .unwrap_or_else(|| bootstrappers())
+        .into_iter()
+        .map(|b| account_id(&b))
+        .collect();
+
+    let prime = &bs[0];
+
+    let mut loc = Vec::with_capacity(n_locations as usize);
+    for l in 0..n_locations {
+        loc.push(Location {
+            lat: Degree::from_num(l),
+            lon: Degree::from_num(l),
+        })
+    }
+    encointer_communities::Module::<Runtime>::new_community(
+        Runtime::Origin::signed(prime.clone()),
+        loc.clone(),
+        bs.clone(),
+        Default::default(),
+        None,
+        None,
+    )
+    .unwrap();
+    CommunityIdentifier::from(blake2_256(&(loc, bs).encode()))
+}

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -32,6 +32,7 @@ pub use balances;
 pub use sp_core::H256;
 pub use sp_runtime::traits::BlakeTwo256;
 
+pub mod helpers;
 pub mod storage;
 
 pub const NONE: u64 = 0;
@@ -95,7 +96,7 @@ macro_rules! impl_frame_system {
             type SystemWeightInfo = ();
             type BlockWeights = ();
             type BlockLength = ();
-            type SS58Prefix = ();   
+            type SS58Prefix = ();
         }
     };
 }

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -32,6 +32,8 @@ pub use balances;
 pub use sp_core::H256;
 pub use sp_runtime::traits::BlakeTwo256;
 
+pub use sp_keyring::AccountKeyring;
+
 pub mod helpers;
 pub mod storage;
 

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -28,9 +28,17 @@ use std::cell::RefCell;
 use xcm::v0::NetworkId;
 use xcm_builder::SiblingParachainConvertsVia;
 
-pub use balances;
 pub use sp_core::H256;
 pub use sp_runtime::traits::BlakeTwo256;
+
+// reexports for macro resolution
+pub use balances;
+pub use encointer_balances;
+pub use encointer_ceremonies;
+pub use encointer_communities;
+pub use encointer_scheduler;
+pub use frame_system;
+pub use timestamp;
 
 pub use sp_keyring::AccountKeyring;
 

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -28,8 +28,8 @@ use std::cell::RefCell;
 use xcm::v0::NetworkId;
 use xcm_builder::SiblingParachainConvertsVia;
 
-pub use sp_core::H256;
-pub use sp_runtime::traits::BlakeTwo256;
+// convenience reexport such that the tests do not need to put sp-keyring in the Cargo.toml.
+pub use sp_keyring::AccountKeyring;
 
 // reexports for macro resolution
 pub use balances;
@@ -40,7 +40,8 @@ pub use encointer_scheduler;
 pub use frame_system;
 pub use timestamp;
 
-pub use sp_keyring::AccountKeyring;
+pub use sp_core::H256;
+pub use sp_runtime::traits::BlakeTwo256;
 
 pub mod helpers;
 pub mod storage;


### PR DESCRIPTION
-  Draft implementation of #28 
    - extend `new_community` extrinsic to include `CommunityMetadata` and `Demurrage`/`NominalIncome` overrides.
    - add sudo calls to override the above settings given in the `new_community` extrinsic

- add generic `register_test_currency` in `test-utils` to remove redundant definitions of it.
- constrain amount of bootstrapers. Closes #14
- some other small fixes.