### PR TITLE
Fix/bazaar rpc

### DIFF
--- a/bazaar/rpc/src/lib.rs
+++ b/bazaar/rpc/src/lib.rs
@@ -44,14 +44,13 @@ pub struct Bazaar<Client, Block, AccountId> {
 }
 
 impl<Client, Block, AccountId> Bazaar<Client, Block, AccountId>
-    where
 {
     /// Create new `Bazaar` instance with the given reference to the client.
-    pub fn new(client: Arc<Client>) -> Self {
+    pub fn new(client: Arc<Client>, deny_unsafe: DenyUnsafe) -> Self {
         Bazaar {
             client,
             _marker: Default::default(),
-            deny_unsafe: DenyUnsafe::Yes
+            deny_unsafe
         }
     }
 }

--- a/bazaar/rpc/src/lib.rs
+++ b/bazaar/rpc/src/lib.rs
@@ -57,7 +57,7 @@ impl<Client, Block, AccountId> Bazaar<Client, Block, AccountId>
 
 impl<Client, Block, AccountId> BazaarApi<<Block as BlockT>::Hash, AccountId> for Bazaar<Client, Block, AccountId>
     where
-        AccountId: 'static + Encode + Decode + Send + Sync + Copy,
+        AccountId: 'static + Clone + Encode + Decode + Send + Sync,
         Block: BlockT,
         Client: Send + Sync + 'static + ProvideRuntimeApi<Block> + HeaderBackend<Block>,
         Client::Api: BazaarRuntimeApi<Block, AccountId> {
@@ -79,7 +79,7 @@ impl<Client, Block, AccountId> BazaarApi<<Block as BlockT>::Hash, AccountId> for
         let at = BlockId::hash(at.unwrap_or_else(|| self.client.info().best_hash));
         return Ok(api.get_businesses(&at, &cid)
             .map_err(runtime_error_into_rpc_err)?.iter()
-            .flat_map(|bid| api.get_offerings(&at, &BusinessIdentifier::new(cid, bid.0)))
+            .flat_map(|bid| api.get_offerings(&at, &BusinessIdentifier::new(cid, bid.0.clone())))
             .flatten()
             .collect());
     }


### PR DESCRIPTION
The bazaar was forgotten to be wired up in the node and was never tested before. Thus, two issues, which are fixed in this PR,  were not found:

* `Copy` trait bound on `AccountId` will never be satisfied with the actual `AccountId` type.
* Hard-coded `DenyUnsafe::Yes` prevented exposure of the new bazaar rpcs even if the flag `rpc-methods unsafe` was set.

Tested: With these patches, I could successfully register a business and retrieve the businesses with the new rpc.