### PR TITLE
refactor `new_community` to reduce complexity to O(1) using geohash buckets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1255,8 +1255,9 @@ dependencies = [
 [[package]]
 name = "geohash"
 version = "0.11.1-alpha.0"
-source = "git+https://github.com/encointer/geohash?branch=master#1fd88eb4cd3a2db448d3766677e043800c66385f"
+source = "git+https://github.com/encointer/geohash?branch=master#a4f31108934f0022420c4dbbdc76a3bf60a54a04"
 dependencies = [
+ "parity-scale-codec",
  "substrate-fixed",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1253,21 +1253,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "geo-types"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8bd2e95dd9f5c8ff74159ed9205ad7fd239a9569173a550863976421b45d2bb"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "geohash"
 version = "0.11.1-alpha.0"
-source = "git+https://github.com/pifragile/geohash.git?branch=master#92574eecb1744ba39bab7aca4d61de8f0281a95b"
+source = "git+https://github.com/encointer/geohash?branch=master#1fd88eb4cd3a2db448d3766677e043800c66385f"
 dependencies = [
- "geo-types",
- "num-traits",
  "substrate-fixed",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2643,6 +2643,7 @@ dependencies = [
  "frame-system",
  "geohash",
  "log",
+ "pallet-encointer-scheduler",
  "parity-scale-codec",
  "serde",
  "sp-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -771,7 +771,7 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "encointer-primitives"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -2533,7 +2533,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-balances"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "approx",
  "encointer-primitives",
@@ -2556,7 +2556,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-bazaar"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "approx",
  "encointer-primitives",
@@ -2607,7 +2607,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-ceremonies"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "approx",
  "encointer-primitives",
@@ -2634,7 +2634,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-communities"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "approx",
  "encointer-primitives",
@@ -2684,7 +2684,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-personhood-oracle"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -2710,7 +2710,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-scheduler"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -2732,7 +2732,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-sybil-gate-template"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -4958,7 +4958,7 @@ dependencies = [
 
 [[package]]
 name = "test-utils"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "encointer-primitives",
  "frame-support",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1264,7 +1264,7 @@ dependencies = [
 [[package]]
 name = "geohash"
 version = "0.11.1-alpha.0"
-source = "git+https://github.com/pifragile/geohash.git?branch=master#0e1c74ab0bbc72c38f804bb73dc119db3a6b2100"
+source = "git+https://github.com/pifragile/geohash.git?branch=master#92574eecb1744ba39bab7aca4d61de8f0281a95b"
 dependencies = [
  "geo-types",
  "num-traits",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1264,7 +1264,7 @@ dependencies = [
 [[package]]
 name = "geohash"
 version = "0.11.1-alpha.0"
-source = "git+https://github.com/pifragile/geohash.git?branch=master#c9fa3de03f7764c5dffc5c0320aff03b33cf5312"
+source = "git+https://github.com/pifragile/geohash.git?branch=master#0e1c74ab0bbc72c38f804bb73dc119db3a6b2100"
 dependencies = [
  "geo-types",
  "num-traits",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1253,6 +1253,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "geo-types"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8bd2e95dd9f5c8ff74159ed9205ad7fd239a9569173a550863976421b45d2bb"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "geohash"
+version = "0.11.1-alpha.0"
+source = "git+https://github.com/pifragile/geohash.git?branch=master#c9fa3de03f7764c5dffc5c0320aff03b33cf5312"
+dependencies = [
+ "geo-types",
+ "num-traits",
+ "substrate-fixed",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2632,6 +2651,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
+ "geohash",
  "log",
  "parity-scale-codec",
  "serde",

--- a/balances/Cargo.toml
+++ b/balances/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-encointer-balances"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["encointer.org <alain@encointer.org> and Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/balances/src/mock.rs
+++ b/balances/src/mock.rs
@@ -33,10 +33,16 @@ mod tokens {
 mod communities {
     pub use encointer_communities::Event;
 }
+
+mod scheduler {
+    pub use super::encointer_scheduler::Event;
+}
+
 impl_outer_event! {
     pub enum TestEvent for TestRuntime {
         tokens<T>,
         communities<T>,
+        scheduler,
         frame_system<T>,
     }
 }
@@ -50,6 +56,15 @@ impl_frame_system!(TestRuntime, TestEvent);
 
 pub type System = frame_system::Pallet<TestRuntime>;
 pub type EncointerBalances = Module<TestRuntime>;
+pub type EncointerScheduler = encointer_scheduler::Module<TestRuntime>;
+
+impl encointer_scheduler::Config for TestRuntime {
+    type Event = TestEvent;
+    type OnCeremonyPhaseChange = ();
+    type MomentsPerDay = ();
+}
+impl_timestamp!(TestRuntime, EncointerScheduler);
+
 
 impl encointer_communities::Config for TestRuntime {
     type Event = TestEvent;

--- a/balances/src/tests.rs
+++ b/balances/src/tests.rs
@@ -131,7 +131,7 @@ fn transfer_should_work() {
 fn demurrage_should_work() {
     ExtBuilder::default().build().execute_with(|| {
         let alice = AccountKeyring::Alice.to_account_id();
-        let cid = register_test_community::<TestRuntime>(None, 3);
+        let cid = register_test_community::<TestRuntime>(None, 0.0, 0.0);
         System::set_block_number(0);
         assert_ok!(EncointerBalances::issue(
             cid,
@@ -157,7 +157,7 @@ fn transfer_with_demurrage_exceeding_amount_should_fail() {
     let alice = AccountKeyring::Alice.to_account_id();
     let bob = AccountKeyring::Bob.to_account_id();
     ExtBuilder::default().build().execute_with(|| {
-        let cid = register_test_community::<TestRuntime>(None, 3);
+        let cid = register_test_community::<TestRuntime>(None, 0.0, 0.0);
         System::set_block_number(0);
         assert_ok!(EncointerBalances::issue(
             cid,

--- a/bazaar/Cargo.toml
+++ b/bazaar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-encointer-bazaar"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["encointer.org <alain@encointer.org>"]
 edition = "2018"
 

--- a/bazaar/src/mock.rs
+++ b/bazaar/src/mock.rs
@@ -31,10 +31,16 @@ mod tokens {
 mod communities {
     pub use encointer_communities::Event;
 }
+
+mod scheduler {
+    pub use super::encointer_scheduler::Event;
+}
+
 impl_outer_event! {
     pub enum TestEvent for TestRuntime {
         tokens<T>,
         communities<T>,
+        scheduler,
         frame_system<T>,
     }
 }
@@ -48,6 +54,16 @@ impl_frame_system!(TestRuntime, TestEvent);
 
 pub type System = frame_system::Pallet<TestRuntime>;
 pub type EncointerBazaar = Module<TestRuntime>;
+
+pub type EncointerScheduler = encointer_scheduler::Module<TestRuntime>;
+
+
+impl encointer_scheduler::Config for TestRuntime {
+    type Event = TestEvent;
+    type OnCeremonyPhaseChange = ();
+    type MomentsPerDay = ();
+}
+impl_timestamp!(TestRuntime, EncointerScheduler);
 
 impl encointer_communities::Config for TestRuntime {
     type Event = TestEvent;

--- a/bazaar/src/tests.rs
+++ b/bazaar/src/tests.rs
@@ -28,7 +28,7 @@ use encointer_primitives::{
 use test_utils::{helpers::register_test_community, *};
 
 fn create_cid() -> CommunityIdentifier {
-    return register_test_community::<TestRuntime>(None, 2);
+    return register_test_community::<TestRuntime>(None, 0.0, 0.0);
 }
 
 fn alice() -> AccountId { AccountKeyring::Alice.into() }

--- a/ceremonies/Cargo.toml
+++ b/ceremonies/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-encointer-ceremonies"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["encointer.org <alain@encointer.org>"]
 edition = "2018"
 

--- a/ceremonies/src/lib.rs
+++ b/ceremonies/src/lib.rs
@@ -373,9 +373,10 @@ impl<T: Config> Module<T> {
         for cid in cids.iter() {
             let pcount = <ParticipantCount>::get((cid, cindex));
             let ecount = <EndorseesCount>::get((cid, cindex));
-            // FIXME
-            //let n_locations = <encointer_communities::Module<T>>::locations(cid).len();
-            let n_locations = 1000;
+
+            let n_locations = <encointer_communities::Module<T>>::get_locations(cid).len();
+
+
 
             let mut bootstrappers =
                 Vec::with_capacity(<encointer_communities::Module<T>>::bootstrappers(cid).len());
@@ -611,9 +612,7 @@ impl<T: Config> Module<T> {
         cid: &CommunityIdentifier,
         meetup_idx: MeetupIndexType,
     ) -> Option<Location> {
-        // FIXME
-        // let locations = <encointer_communities::Module<T>>::locations(&cid);
-        let locations : Vec<Location> = Vec::new();
+        let locations = <encointer_communities::Module<T>>::get_locations(cid);
         if (meetup_idx > 0) && (meetup_idx <= locations.len() as MeetupIndexType) {
             Some(locations[(meetup_idx - 1) as usize])
         } else {

--- a/ceremonies/src/lib.rs
+++ b/ceremonies/src/lib.rs
@@ -229,7 +229,7 @@ decl_module! {
                         "ignoring claim with wrong meetup index: {}",
                         claim.meetup_index);
                     continue };
-                if !<encointer_communities::Module<T>>::is_valid_geolocation(
+                if !<encointer_communities::Module<T>>::is_valid_location(
                     &claim.location) {
                         warn!(target: LOG,
                             "ignoring claim with illegal geolocation: {:?}",
@@ -373,7 +373,9 @@ impl<T: Config> Module<T> {
         for cid in cids.iter() {
             let pcount = <ParticipantCount>::get((cid, cindex));
             let ecount = <EndorseesCount>::get((cid, cindex));
-            let n_locations = <encointer_communities::Module<T>>::locations(cid).len();
+            // FIXME
+            //let n_locations = <encointer_communities::Module<T>>::locations(cid).len();
+            let n_locations = 1000;
 
             let mut bootstrappers =
                 Vec::with_capacity(<encointer_communities::Module<T>>::bootstrappers(cid).len());
@@ -609,7 +611,9 @@ impl<T: Config> Module<T> {
         cid: &CommunityIdentifier,
         meetup_idx: MeetupIndexType,
     ) -> Option<Location> {
-        let locations = <encointer_communities::Module<T>>::locations(&cid);
+        // FIXME
+        // let locations = <encointer_communities::Module<T>>::locations(&cid);
+        let locations : Vec<Location> = Vec::new();
         if (meetup_idx > 0) && (meetup_idx <= locations.len() as MeetupIndexType) {
             Some(locations[(meetup_idx - 1) as usize])
         } else {

--- a/ceremonies/src/tests.rs
+++ b/ceremonies/src/tests.rs
@@ -372,7 +372,7 @@ fn fully_attest_meetup(
 #[test]
 fn registering_participant_works() {
     ExtBuilder::build().execute_with(|| {
-        let cid = register_test_community::<TestRuntime>(None, 1);
+        let cid = register_test_community::<TestRuntime>(None, 0.0, 0.0);
         let alice = AccountId::from(AccountKeyring::Alice);
         let bob = AccountId::from(AccountKeyring::Bob);
         let cindex = EncointerScheduler::current_ceremony_index();
@@ -401,7 +401,7 @@ fn registering_participant_works() {
 #[test]
 fn registering_participant_twice_fails() {
     ExtBuilder::build().execute_with(|| {
-        let cid = register_test_community::<TestRuntime>(None, 1);
+        let cid = register_test_community::<TestRuntime>(None, 0.0, 0.0);
         let alice = AccountId::from(AccountKeyring::Alice);
         assert_ok!(register(alice.clone(), cid, None));
         assert!(register(alice.clone(), cid, None).is_err());
@@ -411,7 +411,7 @@ fn registering_participant_twice_fails() {
 #[test]
 fn registering_participant_in_wrong_phase_fails() {
     ExtBuilder::build().execute_with(|| {
-        let cid = register_test_community::<TestRuntime>(None, 1);
+        let cid = register_test_community::<TestRuntime>(None, 0.0, 0.0);
         let alice = AccountId::from(AccountKeyring::Alice);
         run_to_next_phase();
         assert_eq!(
@@ -425,7 +425,7 @@ fn registering_participant_in_wrong_phase_fails() {
 #[test]
 fn attest_claims_works() {
     ExtBuilder::build().execute_with(|| {
-        let cid = register_test_community::<TestRuntime>(None, 1);
+        let cid = register_test_community::<TestRuntime>(None, 0.0, 0.0);
         let alice = AccountKeyring::Alice.pair();
         let bob = AccountKeyring::Bob.pair();
         let ferdie = AccountKeyring::Ferdie.pair();
@@ -489,7 +489,7 @@ fn attest_claims_works() {
 #[test]
 fn attest_claims_for_non_participant_fails_silently() {
     ExtBuilder::build().execute_with(|| {
-        let cid = register_test_community::<TestRuntime>(None, 1);
+        let cid = register_test_community::<TestRuntime>(None, 0.0, 0.0);
         let alice = AccountKeyring::Alice.pair();
         let bob = AccountKeyring::Bob.pair();
         let cindex = EncointerScheduler::current_ceremony_index();
@@ -518,7 +518,7 @@ fn attest_claims_for_non_participant_fails_silently() {
 #[test]
 fn attest_claims_for_non_participant_fails() {
     ExtBuilder::build().execute_with(|| {
-        let cid = register_test_community::<TestRuntime>(None, 1);
+        let cid = register_test_community::<TestRuntime>(None, 0.0, 0.0);
         let alice = AccountKeyring::Alice.pair();
         let ferdie = AccountKeyring::Ferdie.pair();
         let eve = AccountKeyring::Eve.pair();
@@ -565,7 +565,7 @@ fn attest_claims_for_non_participant_fails() {
 #[test]
 fn attest_claims_with_non_participant_fails_silently() {
     ExtBuilder::build().execute_with(|| {
-        let cid = register_test_community::<TestRuntime>(None, 1);
+        let cid = register_test_community::<TestRuntime>(None, 0.0, 0.0);
         let alice = AccountKeyring::Alice.pair();
         let bob = AccountKeyring::Bob.pair();
         let eve = AccountKeyring::Eve.pair();
@@ -594,7 +594,7 @@ fn attest_claims_with_non_participant_fails_silently() {
 #[test]
 fn attest_claims_with_wrong_meetup_index_fails() {
     ExtBuilder::build().execute_with(|| {
-        let cid = register_test_community::<TestRuntime>(None, 1);
+        let cid = register_test_community::<TestRuntime>(None, 0.0, 0.0);
         let alice = AccountKeyring::Alice.pair();
         let bob = AccountKeyring::Bob.pair();
         let ferdie = AccountKeyring::Ferdie.pair();
@@ -632,7 +632,7 @@ fn attest_claims_with_wrong_meetup_index_fails() {
 #[test]
 fn attest_claims_with_wrong_ceremony_index_fails() {
     ExtBuilder::build().execute_with(|| {
-        let cid = register_test_community::<TestRuntime>(None, 1);
+        let cid = register_test_community::<TestRuntime>(None, 0.0, 0.0);
         let alice = AccountKeyring::Alice.pair();
         let bob = AccountKeyring::Bob.pair();
         let ferdie = AccountKeyring::Ferdie.pair();
@@ -673,7 +673,7 @@ fn attest_claims_with_wrong_ceremony_index_fails() {
 #[test]
 fn attest_claims_with_wrong_timestamp_fails() {
     ExtBuilder::build().execute_with(|| {
-        let cid = register_test_community::<TestRuntime>(None, 1);
+        let cid = register_test_community::<TestRuntime>(None, 0.0, 0.0);
         let alice = AccountKeyring::Alice.pair();
         let bob = AccountKeyring::Bob.pair();
         let ferdie = AccountKeyring::Ferdie.pair();
@@ -720,7 +720,7 @@ fn attest_claims_with_wrong_timestamp_fails() {
 #[test]
 fn attest_claims_with_wrong_location_fails() {
     ExtBuilder::build().execute_with(|| {
-        let cid = register_test_community::<TestRuntime>(None, 1);
+        let cid = register_test_community::<TestRuntime>(None, 0.0, 0.0);
         let alice = AccountKeyring::Alice.pair();
         let bob = AccountKeyring::Bob.pair();
         let ferdie = AccountKeyring::Ferdie.pair();
@@ -766,7 +766,7 @@ fn attest_claims_with_wrong_location_fails() {
 #[test]
 fn ballot_meetup_n_votes_works() {
     ExtBuilder::build().execute_with(|| {
-        let cid = register_test_community::<TestRuntime>(None, 1);
+        let cid = register_test_community::<TestRuntime>(None, 0.0, 0.0);
         let alice = AccountKeyring::Alice.pair();
         let bob = AccountKeyring::Bob.pair();
         let charlie = AccountKeyring::Charlie.pair();
@@ -900,7 +900,7 @@ fn ballot_meetup_n_votes_works() {
 #[test]
 fn issue_reward_works() {
     ExtBuilder::build().execute_with(|| {
-        let cid = register_test_community::<TestRuntime>(None, 1);
+        let cid = register_test_community::<TestRuntime>(None, 0.0, 0.0);
         let alice = AccountKeyring::Alice.pair();
         let bob = AccountKeyring::Bob.pair();
         let charlie = AccountKeyring::Charlie.pair();
@@ -1140,7 +1140,7 @@ fn endorsing_newbie_works_until_no_more_tickets() {
 #[test]
 fn endorsing_newbie_for_second_next_ceremony_works() {
     ExtBuilder::build().execute_with(|| {
-        let cid = register_test_community::<TestRuntime>(None, 1);
+        let cid = register_test_community::<TestRuntime>(None, 0.0, 0.0);
         let alice = AccountId::from(AccountKeyring::Alice);
         let cindex = EncointerScheduler::current_ceremony_index();
         run_to_next_phase();
@@ -1286,7 +1286,7 @@ fn get_meetup_time_works() {
 #[test]
 fn ceremony_index_and_purging_registry_works() {
     ExtBuilder::build().execute_with(|| {
-        let cid = register_test_community::<TestRuntime>(None, 1);
+        let cid = register_test_community::<TestRuntime>(None, 0.0, 0.0);
         let alice = AccountId::from(AccountKeyring::Alice);
         let cindex = EncointerScheduler::current_ceremony_index();
         assert_ok!(register(alice.clone(), cid, None));
@@ -1326,7 +1326,7 @@ fn ceremony_index_and_purging_registry_works() {
 #[test]
 fn assigning_meetup_at_phase_change_and_purge_works() {
     ExtBuilder::build().execute_with(|| {
-        let cid = register_test_community::<TestRuntime>(None, 1);
+        let cid = register_test_community::<TestRuntime>(None, 0.0, 0.0);
         let alice = AccountId::from(AccountKeyring::Alice);
         let cindex = EncointerScheduler::current_ceremony_index();
         register_alice_bob_ferdie(cid);

--- a/communities/Cargo.toml
+++ b/communities/Cargo.toml
@@ -69,6 +69,11 @@ version = "1.0.101"
 [dev-dependencies]
 approx = "0.3.0"
 
+[dependencies.geohash]
+default-features = false
+git = "https://github.com/pifragile/geohash.git"
+branch = "master"
+
 [dev-dependencies.externalities]
 package = "sp-externalities"
 git = "https://github.com/paritytech/substrate.git" 

--- a/communities/Cargo.toml
+++ b/communities/Cargo.toml
@@ -71,7 +71,7 @@ approx = "0.3.0"
 
 [dependencies.geohash]
 default-features = false
-git = "https://github.com/pifragile/geohash.git"
+git = "https://github.com/encointer/geohash"
 branch = "master"
 
 [dev-dependencies.externalities]

--- a/communities/Cargo.toml
+++ b/communities/Cargo.toml
@@ -19,6 +19,11 @@ default-features = false
 package = "encointer-primitives"
 path = "../primitives"
 
+[dependencies.encointer-scheduler]
+default-features = false
+path = "../scheduler"
+package = "pallet-encointer-scheduler"
+
 [dependencies.fixed]
 default-features = false
 git = "https://github.com/encointer/substrate-fixed"

--- a/communities/Cargo.toml
+++ b/communities/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-encointer-communities"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["encointer.org <alain@encointer.org>"]
 edition = "2018"
 

--- a/communities/src/benchmarking.rs
+++ b/communities/src/benchmarking.rs
@@ -9,12 +9,11 @@ use encointer_primitives::{
 
 use log::{info, warn};
 
-const NUM_LOCATIONS : u32 =  500000;
+const NUM_LOCATIONS : u32 =  500_000;
 
 fn get_location(i:u32) -> Location {
     // splits the world into 1m locations
-    let max_locations = 1000000;
-    assert!(i < max_locations );
+    assert!(i < 1_000_000 );
 
     // lat from -40 to 40
     let lat = (i / 1000) as f64 * 0.08 - 40.0;

--- a/communities/src/benchmarking.rs
+++ b/communities/src/benchmarking.rs
@@ -1,12 +1,13 @@
 use crate::{*, Module as PalletModule};
 use frame_benchmarking::{benchmarks, whitelisted_caller, impl_benchmark_test_suite, account};
 use frame_system::RawOrigin;
+use frame_system::Origin;
 use encointer_primitives::{
     communities::{Location, CommunityMetadata, NominalIncome},
     balances:: {Demurrage, consts::DEFAULT_DEMURRAGE}
 };
 
-const NUM_LOCATIONS : u32 =  2000;
+const NUM_LOCATIONS : u32 =  20000;
 
 benchmarks! {
     new_community {
@@ -15,20 +16,27 @@ benchmarks! {
 
     // spread locations along the equator, ie. lat = 0, lon equally spread over [-150, 150]
     // using 150 to have a save distance from the dateline
-    let locations: Vec<Location> = (0..NUM_LOCATIONS)
+    let locations: Vec<Location> = (0..i + 1)
     .map(|x| Location{lat: Degree::from_num(0.0), lon: Degree::from_num(((x as f64 * 300.0) / (NUM_LOCATIONS as f64)) - 150.0)})
     .collect();
 
-    let bootrappers : Vec<T::AccountId> = (0..12).map(|n| account("dummy name", n, n)).collect();
-
+    let bootstrappers : Vec<T::AccountId> = (0..12).map(|n| account("dummy name", n, n)).collect();
     let mut community_metadata = CommunityMetadata::default();
     community_metadata.name = "20charsaaaaaaaaaaaaa".into();
     community_metadata.url = Some("19charsaaaaaaaaa.ch".into());
-
     let demurrage = Some(Demurrage::from_num(DEFAULT_DEMURRAGE));
     let nominal_income = Some(NominalIncome::from_num(1));
 
-	}: _(RawOrigin::Signed(caller), (&locations[..(i as usize)]).to_vec(), bootrappers, community_metadata, demurrage, nominal_income)
+    // setup test community
+    PalletModule::<T>::new_community(RawOrigin::Signed(caller.clone()).into(), locations[0usize], bootstrappers.clone(), community_metadata.clone(), demurrage.clone(), nominal_income.clone());
+    let cid = CommunityIdentifier::from(blake2_256(&(locations[0usize].clone(), bootstrappers.clone()).encode()));
+    for j in 1..i {
+        PalletModule::<T>::add_location(RawOrigin::Root.into(), cid, locations[j as usize]);
+    }
+
+
+
+	}: _(RawOrigin::Signed(caller), locations[i as usize], bootstrappers, community_metadata, demurrage, nominal_income)
 }
 
 

--- a/communities/src/benchmarking.rs
+++ b/communities/src/benchmarking.rs
@@ -28,7 +28,7 @@ fn get_location(i:u32) -> Location {
 benchmarks! {
     new_community {
     let i in 2 .. NUM_LOCATIONS;
-    warn!("starting benchmark.");
+    warn!("starting benchmark {:?}", i);
     let caller: T::AccountId = whitelisted_caller();
 
     let bootstrappers : Vec<T::AccountId> = (0..12).map(|n| account("dummy name", n, n)).collect();

--- a/communities/src/benchmarking.rs
+++ b/communities/src/benchmarking.rs
@@ -9,20 +9,18 @@ use encointer_primitives::{
 
 use log::{info, warn};
 
-const NUM_LOCATIONS : u32 =  1000000;
+const NUM_LOCATIONS : u32 =  500000;
 
 fn get_location(i:u32) -> Location {
     // splits the world into 1m locations
     let max_locations = 1000000;
     assert!(i < max_locations );
 
-    // lat from -50 to 50
-    // split latitude degrees in 100
-    let lat = (i / 100) as f64 / 100.0 - 50.0;
+    // lat from -40 to 40
+    let lat = (i / 1000) as f64 * 0.08 - 40.0;
 
-    // lon from -150 to 150
-    // per latitude have 100 locations
-    let lon = (i % 100) as f64 * 3.0  - 150.0;
+    // lon from -140 to 140
+    let lon = (i % 1000) as f64 * 0.28  - 140.0;
 
     Location{lat: Degree::from_num(lat), lon: Degree::from_num(lon)}
 }

--- a/communities/src/lib.rs
+++ b/communities/src/lib.rs
@@ -103,7 +103,7 @@ decl_module! {
 
             Self::validate_location(&location)?;
             // All checks done, now mutate state
-            let geo_hash = encode(location.lon, location.lat, GEO_HASH_LENGTH).map_err(|_| <Error<T>>::InvalidLocationForGeohash)?;
+            let geo_hash = encode(location.lat, location.lon, GEO_HASH_LENGTH).map_err(|_| <Error<T>>::InvalidLocationForGeohash)?;
             let mut locations: Vec<Location> = Vec::new();
 
             // insert cid into cids_by_geohash map
@@ -139,7 +139,7 @@ decl_module! {
         pub fn add_location(origin, cid: CommunityIdentifier, location: Location) {
             ensure_root(origin)?;
             Self::validate_location(&location)?;
-            let geo_hash = encode(location.lon, location.lat, GEO_HASH_LENGTH).map_err(|_| <Error<T>>::InvalidLocationForGeohash)?;
+            let geo_hash = encode(location.lat, location.lon, GEO_HASH_LENGTH).map_err(|_| <Error<T>>::InvalidLocationForGeohash)?;
             // insert location into locations
             let mut locations = Self::locations(&cid, &geo_hash);
             match locations.binary_search(&location) {
@@ -161,9 +161,9 @@ decl_module! {
         }
 
         #[weight = 10_000]
-        pub fn remove_locations(origin, cid: CommunityIdentifier,location: Location) {
+        pub fn remove_location(origin, cid: CommunityIdentifier,location: Location) {
             ensure_root(origin)?;
-            let geo_hash = encode(location.lon, location.lat, GEO_HASH_LENGTH).map_err(|_| <Error<T>>::InvalidLocationForGeohash)?;
+            let geo_hash = encode(location.lat, location.lon, GEO_HASH_LENGTH).map_err(|_| <Error<T>>::InvalidLocationForGeohash)?;
             //remove location from locations(cid,geohash)
             let mut locations = Self::locations(&cid, &geo_hash);
             let mut locations_len = 0;
@@ -413,7 +413,7 @@ impl<T: Config> Module<T> {
     }
     fn get_nearby_locations(location: &Location) -> Result<Vec<Location>, Error<T>> {
         let mut result: Vec<Location> = Vec::new();
-        let geo_hash = encode(location.lon, location.lat, GEO_HASH_LENGTH).map_err(|_| <Error<T>>::InvalidLocationForGeohash)?;
+        let geo_hash = encode(location.lat, location.lon, GEO_HASH_LENGTH).map_err(|_| <Error<T>>::InvalidLocationForGeohash)?;
         let mut relevant_buckets = Self::get_relevant_neighbor_buckets(&geo_hash, location)?;
         relevant_buckets.push(geo_hash);
 

--- a/communities/src/lib.rs
+++ b/communities/src/lib.rs
@@ -103,7 +103,7 @@ decl_module! {
 
             Self::validate_location(&location)?;
             // All checks done, now mutate state
-            let geo_hash = GeoHash::try_from_params(location.lat, location.lon, GEO_HASH_LENGTH).map_err(|_| <Error<T>>::InvalidLocationForGeohash)?;
+            let geo_hash = GeoHash::try_from_params(location.lat, location.lon, BUCKET_RESOLUTION).map_err(|_| <Error<T>>::InvalidLocationForGeohash)?;
             let mut locations: Vec<Location> = Vec::new();
 
             // insert cid into cids_by_geohash map
@@ -139,7 +139,7 @@ decl_module! {
         pub fn add_location(origin, cid: CommunityIdentifier, location: Location) {
             ensure_root(origin)?;
             Self::validate_location(&location)?;
-            let geo_hash = GeoHash::try_from_params(location.lat, location.lon, GEO_HASH_LENGTH).map_err(|_| <Error<T>>::InvalidLocationForGeohash)?;
+            let geo_hash = GeoHash::try_from_params(location.lat, location.lon, BUCKET_RESOLUTION).map_err(|_| <Error<T>>::InvalidLocationForGeohash)?;
             // insert location into locations
             let mut locations = Self::locations(&cid, &geo_hash);
             match locations.binary_search(&location) {
@@ -163,7 +163,7 @@ decl_module! {
         #[weight = 10_000]
         pub fn remove_location(origin, cid: CommunityIdentifier,location: Location) {
             ensure_root(origin)?;
-            let geo_hash = GeoHash::try_from_params(location.lat, location.lon, GEO_HASH_LENGTH).map_err(|_| <Error<T>>::InvalidLocationForGeohash)?;
+            let geo_hash = GeoHash::try_from_params(location.lat, location.lon, BUCKET_RESOLUTION).map_err(|_| <Error<T>>::InvalidLocationForGeohash)?;
             //remove location from locations(cid,geohash)
             let mut locations = Self::locations(&cid, &geo_hash);
             let mut locations_len = 0;
@@ -362,7 +362,7 @@ impl<T: Config> Module<T> {
         }
 
         // if we assume MIN_SOLAR_TIME = 1 second and maximum latitude = 78 degrees
-        // and maximum human speed 83 m/s and a GEO_HASH_LENGTH of 5
+        // and maximum human speed 83 m/s and a BUCKET_RESOLUTION of 5
         // it is save to only consider the direct neighbours of the current bucket,
         // because it takes more more than 1 second solar time to traverse 1 bucket.
 
@@ -413,7 +413,7 @@ impl<T: Config> Module<T> {
     }
     fn get_nearby_locations(location: &Location) -> Result<Vec<Location>, Error<T>> {
         let mut result: Vec<Location> = Vec::new();
-        let geo_hash = GeoHash::try_from_params(location.lat, location.lon, GEO_HASH_LENGTH).map_err(|_| <Error<T>>::InvalidLocationForGeohash)?;
+        let geo_hash = GeoHash::try_from_params(location.lat, location.lon, BUCKET_RESOLUTION).map_err(|_| <Error<T>>::InvalidLocationForGeohash)?;
         let mut relevant_buckets = Self::get_relevant_neighbor_buckets(&geo_hash, location)?;
         relevant_buckets.push(geo_hash);
 

--- a/communities/src/tests.rs
+++ b/communities/src/tests.rs
@@ -202,7 +202,7 @@ fn new_community_works() {
         ));
         let cid = CommunityIdentifier::from(blake2_256(&(location.clone(), bs.clone()).encode()));
         let cids = EncointerCommunities::community_identifiers();
-        let geo_hash = GeoHash::try_from_params(location.lat, location.lon, GEO_HASH_LENGTH).unwrap();
+        let geo_hash = GeoHash::try_from_params(location.lat, location.lon, BUCKET_RESOLUTION).unwrap();
         assert!(cids.contains(&cid));
         assert_eq!(EncointerCommunities::locations(&cid, &geo_hash), vec![location]);
         assert_eq!(EncointerCommunities::cids_by_geohash(&geo_hash), vec![cid]);
@@ -232,12 +232,12 @@ fn two_communities_in_same_bucket_works() {
             lat: T::from_num(0i32),
             lon: T::from_num(0i32),
         };
-        let geo_hash = GeoHash::try_from_params(location.lat, location.lon, GEO_HASH_LENGTH).unwrap();
+        let geo_hash = GeoHash::try_from_params(location.lat, location.lon, BUCKET_RESOLUTION).unwrap();
         let location2 = Location {
             lat: T::from_num(0),
             lon: T::from_num(-0.015),
         };
-        let geo_hash2 = GeoHash::try_from_params(location2.lat, location2.lon, GEO_HASH_LENGTH).unwrap();
+        let geo_hash2 = GeoHash::try_from_params(location2.lat, location2.lon, BUCKET_RESOLUTION).unwrap();
         assert_eq!(geo_hash, geo_hash2);
 
         assert_ok!(EncointerCommunities::new_community(
@@ -322,7 +322,7 @@ fn add_location_works() {
             lat: T::from_num(0i32),
             lon: T::from_num(0i32),
         };
-        let geo_hash = GeoHash::try_from_params(location.lat, location.lon, GEO_HASH_LENGTH).unwrap();
+        let geo_hash = GeoHash::try_from_params(location.lat, location.lon, BUCKET_RESOLUTION).unwrap();
         assert_eq!(EncointerCommunities::locations(&cid, &geo_hash), vec![location]);
         assert_eq!(EncointerCommunities::cids_by_geohash(&geo_hash), vec![cid]);
 
@@ -331,7 +331,7 @@ fn add_location_works() {
             lat: T::from_num(0),
             lon: T::from_num(-0.015),
         };
-        let geo_hash2 = GeoHash::try_from_params(location2.lat, location2.lon, GEO_HASH_LENGTH).unwrap();
+        let geo_hash2 = GeoHash::try_from_params(location2.lat, location2.lon, BUCKET_RESOLUTION).unwrap();
         assert_eq!(geo_hash, geo_hash2);
 
         EncointerCommunities::add_location(Origin::root(), cid, location2);
@@ -347,7 +347,7 @@ fn add_location_works() {
             lat: T::from_num(0),
             lon: T::from_num(0.015),
         };
-        let geo_hash3 = GeoHash::try_from_params(location3.lat, location3.lon, GEO_HASH_LENGTH).unwrap();
+        let geo_hash3 = GeoHash::try_from_params(location3.lat, location3.lon, BUCKET_RESOLUTION).unwrap();
 
         EncointerCommunities::add_location(Origin::root(), cid, location3);
         assert_eq!(EncointerCommunities::locations(&cid, &geo_hash3), vec![location3]);
@@ -363,7 +363,7 @@ fn remove_location_works() {
             lat: T::from_num(0i32),
             lon: T::from_num(0i32),
         };
-        let geo_hash = GeoHash::try_from_params(location.lat, location.lon, GEO_HASH_LENGTH).unwrap();
+        let geo_hash = GeoHash::try_from_params(location.lat, location.lon, BUCKET_RESOLUTION).unwrap();
         assert_eq!(EncointerCommunities::locations(&cid, &geo_hash), vec![location]);
         assert_eq!(EncointerCommunities::cids_by_geohash(&geo_hash), vec![cid]);
 
@@ -372,7 +372,7 @@ fn remove_location_works() {
             lat: T::from_num(0),
             lon: T::from_num(-0.015),
         };
-        let geo_hash2 = GeoHash::try_from_params(location2.lat, location2.lon, GEO_HASH_LENGTH).unwrap();
+        let geo_hash2 = GeoHash::try_from_params(location2.lat, location2.lon, BUCKET_RESOLUTION).unwrap();
         assert_eq!(geo_hash, geo_hash2);
 
         EncointerCommunities::add_location(Origin::root(), cid, location2);

--- a/communities/src/tests.rs
+++ b/communities/src/tests.rs
@@ -176,19 +176,11 @@ fn new_community_works() {
         let alice = AccountId::from(AccountKeyring::Alice);
         let bob = AccountId::from(AccountKeyring::Bob);
         let charlie = AccountId::from(AccountKeyring::Charlie);
-        let a = Location {
+        let location = Location {
             lat: T::from_num(1i32),
             lon: T::from_num(1i32),
         };
-        let b = Location {
-            lat: T::from_num(1i32),
-            lon: T::from_num(2i32),
-        };
-        assert!(EncointerCommunities::is_valid_location(&a));
-        assert!(EncointerCommunities::is_valid_location(&b));
-        println!("testing Location {:?} and {:?}", a, b);
-        println!("north pole at {:?}", NORTH_POLE);
-        let loc = vec![a, b];
+        assert!(EncointerCommunities::is_valid_location(&location));
         let bs = vec![alice.clone(), bob.clone(), charlie.clone()];
         let community_meta: CommunityMetadataType = CommunityMetadataType {
             name: "Default".into(),
@@ -197,16 +189,19 @@ fn new_community_works() {
         };
         assert_ok!(EncointerCommunities::new_community(
             Origin::signed(alice.clone()),
-            loc.clone(),
+            location,
             bs.clone(),
             community_meta.clone(),
             None,
             None
         ));
-        let cid = CommunityIdentifier::from(blake2_256(&(loc.clone(), bs.clone()).encode()));
+        let cid = CommunityIdentifier::from(blake2_256(&(location.clone(), bs.clone()).encode()));
         let cids = EncointerCommunities::community_identifiers();
+        let geo_hash = geohash::encode(location.lat, location.lon, GEO_HASH_LENGTH).unwrap();
         assert!(cids.contains(&cid));
-        assert_eq!(EncointerCommunities::locations(&cid), loc);
+        assert_eq!(EncointerCommunities::locations(&cid, &geo_hash), vec![location]);
+        assert_eq!(EncointerCommunities::cids_by_geohash(&geo_hash), vec![cid]);
+        assert_eq!(EncointerCommunities::bootstrappers(&cid), bs);
         assert_eq!(EncointerCommunities::bootstrappers(&cid), bs);
         assert_eq!(
             EncointerCommunities::community_metadata(&cid),
@@ -216,9 +211,74 @@ fn new_community_works() {
 }
 
 #[test]
+fn two_communities_in_same_bucket_works() {
+    ExtBuilder::build().execute_with(|| {
+        let alice = AccountId::from(AccountKeyring::Alice);
+        let bob = AccountId::from(AccountKeyring::Bob);
+        let charlie = AccountId::from(AccountKeyring::Charlie);
+        let bs = vec![alice.clone(), bob.clone(), charlie.clone()];
+        let community_meta: CommunityMetadataType = CommunityMetadataType {
+            name: "Default".into(),
+            symbol: "DEF".into(),
+            ..Default::default()
+        };
+
+        let location = Location {
+            lat: T::from_num(0i32),
+            lon: T::from_num(0i32),
+        };
+        let geo_hash = geohash::encode(location.lat, location.lon, GEO_HASH_LENGTH).unwrap();
+        let location2 = Location {
+            lat: T::from_num(0),
+            lon: T::from_num(-0.015),
+        };
+        let geo_hash2 = geohash::encode(location2.lat, location2.lon, GEO_HASH_LENGTH).unwrap();
+        assert_eq!(geo_hash, geo_hash2);
+
+        assert_ok!(EncointerCommunities::new_community(
+            Origin::signed(alice.clone()),
+            location,
+            bs.clone(),
+            community_meta.clone(),
+            None,
+            None
+        ));
+
+        assert_ok!(EncointerCommunities::new_community(
+            Origin::signed(alice.clone()),
+            location2,
+            bs.clone(),
+            community_meta.clone(),
+            None,
+            None
+        ));
+
+        let cid = CommunityIdentifier::from(blake2_256(&(location.clone(), bs.clone()).encode()));
+        let cid2 = CommunityIdentifier::from(blake2_256(&(location2.clone(), bs.clone()).encode()));
+        let cids = EncointerCommunities::community_identifiers();
+
+        assert!(cids.contains(&cid));
+        assert!(cids.contains(&cid2));
+
+        assert_eq!(EncointerCommunities::locations(&cid, &geo_hash), vec![location]);
+        assert_eq!(EncointerCommunities::locations(&cid2, &geo_hash2), vec![location2]);
+
+        let mut cids_by_geohash = EncointerCommunities::cids_by_geohash(&geo_hash);
+        let mut expected_cids_by_geohash = vec![cid, cid2];
+
+        cids_by_geohash.sort();
+        expected_cids_by_geohash.sort();
+
+        assert_eq!(cids_by_geohash, expected_cids_by_geohash);
+
+    });
+}
+
+
+#[test]
 fn updating_nominal_income_works() {
     ExtBuilder::build().execute_with(|| {
-        let cid = register_test_community::<TestRuntime>(None, 1);
+        let cid = register_test_community::<TestRuntime>(None, 0.0, 0.0);
         assert!(NominalIncome::try_get(cid).is_err());
         assert_ok!(EncointerCommunities::update_nominal_income(
             Origin::root(),
@@ -235,7 +295,7 @@ fn updating_nominal_income_works() {
 #[test]
 fn updating_demurrage_works() {
     ExtBuilder::build().execute_with(|| {
-        let cid = register_test_community::<TestRuntime>(None, 1);
+        let cid = register_test_community::<TestRuntime>(None, 0.0, 0.0);
         assert!(DemurragePerBlock::try_get(cid).is_err());
         assert_ok!(EncointerCommunities::update_demurrage(
             Origin::root(),
@@ -250,32 +310,84 @@ fn updating_demurrage_works() {
 }
 
 #[test]
-fn new_community_with_too_close_inner_locations_fails() {
+fn add_location_works() {
     ExtBuilder::build().execute_with(|| {
-        let alice = AccountId::from(AccountKeyring::Alice);
-        let bob = AccountId::from(AccountKeyring::Bob);
-        let charlie = AccountId::from(AccountKeyring::Charlie);
-        let a = Location {
-            lat: T::from_num(1i32),
-            lon: T::from_num(1i32),
+        let cid = register_test_community::<TestRuntime>(None, 0.0, 0.0);
+        let location = Location {
+            lat: T::from_num(0i32),
+            lon: T::from_num(0i32),
         };
-        let b = Location {
-            lat: T::from_num(1i32),
-            lon: T::from_num(1.000001_f64),
-        };
-        // a and b roughly 11cm apart
-        let loc = vec![a, b];
-        let bs = vec![alice.clone(), bob.clone(), charlie.clone()];
+        let geo_hash = geohash::encode(location.lat, location.lon, GEO_HASH_LENGTH).unwrap();
+        assert_eq!(EncointerCommunities::locations(&cid, &geo_hash), vec![location]);
+        assert_eq!(EncointerCommunities::cids_by_geohash(&geo_hash), vec![cid]);
 
-        assert!(EncointerCommunities::new_community(
-            Origin::signed(alice.clone()),
-            loc,
-            bs,
-            Default::default(),
-            None,
-            None
-        )
-        .is_err());
+        // add location in same bucket
+        let location2 = Location {
+            lat: T::from_num(0),
+            lon: T::from_num(-0.015),
+        };
+        let geo_hash2 = geohash::encode(location2.lat, location2.lon, GEO_HASH_LENGTH).unwrap();
+        assert_eq!(geo_hash, geo_hash2);
+
+        EncointerCommunities::add_location(Origin::root(), cid, location2);
+        let mut locations = EncointerCommunities::locations(&cid, &geo_hash);
+        let mut expected_locations = vec![location, location2];
+        locations.sort();
+        expected_locations.sort();
+        assert_eq!(locations, expected_locations);
+        assert_eq!(EncointerCommunities::cids_by_geohash(&geo_hash), vec![cid]);
+
+        // add location in different bucket
+        let location3 = Location {
+            lat: T::from_num(0),
+            lon: T::from_num(0.015),
+        };
+        let geo_hash3 = geohash::encode(location3.lat, location3.lon, GEO_HASH_LENGTH).unwrap();
+
+        EncointerCommunities::add_location(Origin::root(), cid, location3);
+        assert_eq!(EncointerCommunities::locations(&cid, &geo_hash3), vec![location3]);
+        assert_eq!(EncointerCommunities::cids_by_geohash(&geo_hash3), vec![cid]);
+    });
+}
+
+#[test]
+fn remove_location_works() {
+    ExtBuilder::build().execute_with(|| {
+        let cid = register_test_community::<TestRuntime>(None, 0.0, 0.0);
+        let location = Location {
+            lat: T::from_num(0i32),
+            lon: T::from_num(0i32),
+        };
+        let geo_hash = geohash::encode(location.lat, location.lon, GEO_HASH_LENGTH).unwrap();
+        assert_eq!(EncointerCommunities::locations(&cid, &geo_hash), vec![location]);
+        assert_eq!(EncointerCommunities::cids_by_geohash(&geo_hash), vec![cid]);
+
+        // add location in same bucket
+        let location2 = Location {
+            lat: T::from_num(0),
+            lon: T::from_num(-0.015),
+        };
+        let geo_hash2 = geohash::encode(location2.lat, location2.lon, GEO_HASH_LENGTH).unwrap();
+        assert_eq!(geo_hash, geo_hash2);
+
+        EncointerCommunities::add_location(Origin::root(), cid, location2);
+        let mut locations = EncointerCommunities::locations(&cid, &geo_hash);
+        let mut expected_locations = vec![location, location2];
+        locations.sort();
+        expected_locations.sort();
+        assert_eq!(locations, expected_locations);
+        assert_eq!(EncointerCommunities::cids_by_geohash(&geo_hash), vec![cid]);
+
+        // remove first location
+        EncointerCommunities::remove_location(Origin::root(), cid, location);
+        assert_eq!(EncointerCommunities::locations(&cid, &geo_hash), vec![location2]);
+        assert_eq!(EncointerCommunities::cids_by_geohash(&geo_hash), vec![cid]);
+
+        // remove second location
+        EncointerCommunities::remove_location(Origin::root(), cid, location2);
+        assert_eq!(EncointerCommunities::locations(&cid, &geo_hash), vec![]);
+        assert_eq!(EncointerCommunities::cids_by_geohash(&geo_hash), vec![]);
+
     });
 }
 
@@ -285,19 +397,14 @@ fn new_community_too_close_to_existing_community_fails() {
         let alice = AccountId::from(AccountKeyring::Alice);
         let bob = AccountId::from(AccountKeyring::Bob);
         let charlie = AccountId::from(AccountKeyring::Charlie);
-        let a = Location {
+        let location = Location {
             lat: T::from_num(1i32),
             lon: T::from_num(1i32),
         };
-        let b = Location {
-            lat: T::from_num(1i32),
-            lon: T::from_num(2i32),
-        };
-        let loc = vec![a, b];
         let bs = vec![alice.clone(), bob.clone(), charlie.clone()];
         assert_ok!(EncointerCommunities::new_community(
             Origin::signed(alice.clone()),
-            loc.clone(),
+            location,
             bs.clone(),
             Default::default(),
             None,
@@ -305,18 +412,13 @@ fn new_community_too_close_to_existing_community_fails() {
         ));
 
         // second community
-        let a = Location {
+        let location = Location {
             lat: T::from_num(1.000001_f64),
             lon: T::from_num(1.000001_f64),
         };
-        let b = Location {
-            lat: T::from_num(1.000001_f64),
-            lon: T::from_num(2.000001_f64),
-        };
-        let loc = vec![a, b];
         assert!(EncointerCommunities::new_community(
             Origin::signed(alice.clone()),
-            loc.clone(),
+            location,
             bs.clone(),
             Default::default(),
             None,
@@ -334,18 +436,13 @@ fn new_community_with_near_pole_locations_fails() {
         let charlie = AccountId::from(AccountKeyring::Charlie);
         let bs = vec![alice.clone(), bob.clone(), charlie.clone()];
 
-        let a = Location {
+        let location = Location {
             lat: T::from_num(89),
             lon: T::from_num(60),
         };
-        let b = Location {
-            lat: T::from_num(89),
-            lon: T::from_num(-60),
-        };
-        let loc = vec![a, b];
         assert!(EncointerCommunities::new_community(
             Origin::signed(alice.clone()),
-            loc,
+            location,
             bs.clone(),
             Default::default(),
             None,
@@ -357,14 +454,10 @@ fn new_community_with_near_pole_locations_fails() {
             lat: T::from_num(-89),
             lon: T::from_num(60),
         };
-        let b = Location {
-            lat: T::from_num(-89),
-            lon: T::from_num(-60),
-        };
-        let loc = vec![a, b];
+
         assert!(EncointerCommunities::new_community(
             Origin::signed(alice.clone()),
-            loc,
+            location,
             bs,
             Default::default(),
             None,
@@ -382,18 +475,14 @@ fn new_community_near_dateline_fails() {
         let charlie = AccountId::from(AccountKeyring::Charlie);
         let bs = vec![alice.clone(), bob.clone(), charlie.clone()];
 
-        let a = Location {
+        let location = Location {
             lat: T::from_num(10),
             lon: T::from_num(179),
         };
-        let b = Location {
-            lat: T::from_num(11),
-            lon: T::from_num(179),
-        };
-        let loc = vec![a, b];
+
         assert!(EncointerCommunities::new_community(
             Origin::signed(alice.clone()),
-            loc,
+            location,
             bs.clone(),
             Default::default(),
             None,
@@ -404,43 +493,235 @@ fn new_community_near_dateline_fails() {
 }
 
 #[test]
-fn new_currency_with_very_close_location_works() {
-    // This panicked before using I64F64 for degree due to an overflow in fixed::transcendental::sqrt
+fn get_relevant_neighbor_buckets_works() {
+    /// for the following test we are looking at the following neighboring geo hashes
+    /// sbh2m	sbh2q	sbh2r
+    /// sbh2j	sbh2n	sbh2p
+    /// kzurv	kzury	kzurz
+    /// the hash in the center(sbh2n) has the following specs:
+    /// center: lat: 0.02197265625 , lon: 40.01220703125
+    /// lat min: 0
+    /// lat max: 0.0439453125
+    /// lon min: 39.990234375
+    /// lon max: 40.0341796875
+    ///
     ExtBuilder::build().execute_with(|| {
-        let alice = AccountId::from(AccountKeyring::Alice);
-        let bob = AccountId::from(AccountKeyring::Bob);
-        let charlie = AccountId::from(AccountKeyring::Charlie);
-        let bs = vec![alice.clone(), bob.clone(), charlie.clone()];
+        // center location should not make it necessary to check any other buckets
+        type S = geohash::String;
+        let bucket = S::from("sbh2n");
+        let center = Location {
+            lat: T::from_num(0.02197265625),
+            lon: T::from_num(40.01220703125),
+        };
+        let result = EncointerCommunities::get_relevant_neighbor_buckets(&bucket, &center).unwrap();
+        assert_eq!(result.len(), 0);
 
-        // |a - b| ~ 300 m
-        let a = Location {
-            lat: T::from_num(47.2705520547),
-            lon: T::from_num(8.6401677132),
+        // location in the top right corner should make it necessary to check sbh2q, sbh2r and sbh2p
+        let location = Location {
+            lat: T::from_num(0.043945312),
+            lon: T::from_num(40.034179687),
         };
-        let b = Location {
-            lat: T::from_num(47.2696129372),
-            lon: T::from_num(8.6439979076),
+        let mut result = EncointerCommunities::get_relevant_neighbor_buckets(&bucket, &location).unwrap();
+        let mut expected_result = vec![S::from("sbh2q"), S::from("sbh2r"), S::from("sbh2p")];
+        result.sort();
+        expected_result.sort();
+        assert_eq!(result, expected_result);
+
+        // location in the right should make it necessary to check sbh2p
+        let location = Location {
+            lat: T::from_num(0.02197265625),
+            lon: T::from_num(40.034179687),
         };
-        let loc = vec![a, b];
-        assert!(EncointerCommunities::new_community(
-            Origin::signed(alice.clone()),
-            loc,
-            bs.clone(),
-            Default::default(),
-            None,
-            None
-        )
-        .is_ok());
+        let mut result = EncointerCommunities::get_relevant_neighbor_buckets(&bucket, &location).unwrap();
+        let mut expected_result = vec![S::from("sbh2p")];
+        result.sort();
+        expected_result.sort();
+        assert_eq!(result, expected_result);
+
+        // location in the bottom right should make it necessary to check sbh2p, kzury, kzurz
+        let location = Location {
+            lat: T::from_num(0.0000000001),
+            lon: T::from_num(40.034179687),
+        };
+        let mut result = EncointerCommunities::get_relevant_neighbor_buckets(&bucket, &location).unwrap();
+        let mut expected_result = vec![S::from("sbh2p"), S::from("kzury"), S::from("kzurz")];
+        result.sort();
+        expected_result.sort();
+        assert_eq!(result, expected_result);
+
+        // bottom
+        let location = Location {
+            lat: T::from_num(0.0000000001),
+            lon: T::from_num(40.01220703125),
+        };
+        let mut result = EncointerCommunities::get_relevant_neighbor_buckets(&bucket, &location).unwrap();
+        let mut expected_result = vec![S::from("kzury")];
+        result.sort();
+        expected_result.sort();
+        assert_eq!(result, expected_result);
+
+        // bottom left
+        let location = Location {
+            lat: T::from_num(0.0000000001),
+            lon: T::from_num(39.990234376),
+        };
+        let mut result = EncointerCommunities::get_relevant_neighbor_buckets(&bucket, &location).unwrap();
+        let mut expected_result = vec![S::from("kzury"), S::from("kzurv"), S::from("sbh2j")];
+        result.sort();
+        expected_result.sort();
+        assert_eq!(result, expected_result);
+
+        // left
+        let location = Location {
+            lat: T::from_num(0.02197265625),
+            lon: T::from_num(39.990234376),
+        };
+        let mut result = EncointerCommunities::get_relevant_neighbor_buckets(&bucket, &location).unwrap();
+        let mut expected_result = vec![S::from("sbh2j")];
+        result.sort();
+        expected_result.sort();
+        assert_eq!(result, expected_result);
+
+
+        // top left
+        let location = Location {
+            lat: T::from_num(0.043945312),
+            lon: T::from_num(39.990234376),
+        };
+        let mut result = EncointerCommunities::get_relevant_neighbor_buckets(&bucket, &location).unwrap();
+        let mut expected_result = vec![S::from("sbh2m"), S::from("sbh2q"), S::from("sbh2j")];
+        result.sort();
+        expected_result.sort();
+        assert_eq!(result, expected_result);
+
+        // top
+        let location = Location {
+            lat: T::from_num(0.043945312),
+            lon: T::from_num(40.01220703125),
+        };
+        let mut result = EncointerCommunities::get_relevant_neighbor_buckets(&bucket, &location).unwrap();
+        let mut expected_result = vec![S::from("sbh2q")];
+        result.sort();
+        expected_result.sort();
+        assert_eq!(result, expected_result);
+
+    });
+}
+
+
+#[test]
+fn get_nearby_locations_works() {
+    /// for the following test we are looking at the following neighboring geo hashes
+    /// sbh2m	sbh2q	sbh2r
+    /// sbh2j	sbh2n	sbh2p
+    /// kzurv	kzury	kzurz
+    /// the hash in the center(sbh2n) has the following specs:
+    /// center: lat: 0.02197265625 , lon: 40.01220703125
+    /// lat min: 0
+    /// lat max: 0.0439453125
+    /// lon min: 39.990234375
+    /// lon max: 40.0341796875
+    ///
+    ExtBuilder::build().execute_with(|| {
+        let cid = register_test_community::<TestRuntime>(None, 0.0, 0.0);
+        let cid2 = register_test_community::<TestRuntime>(None, 1.0, 1.0);
+
+
+        // location in top right corner of sbh2n
+        let location = Location {
+            lat: T::from_num(0.043945312),
+            lon: T::from_num(40.034179687),
+        };
+        // locations in sbh2n
+        let location2 = Location {
+            lat: T::from_num(0.02197265625),
+            lon: T::from_num(40.01220703125),
+        };
+        let location3 = Location {
+            lat: T::from_num(0.0000000001),
+            lon: T::from_num(39.990234376),
+        };
+        // location in sbh2r
+        let location4 = Location {
+            lat: T::from_num(0.066),
+            lon: T::from_num(40.056),
+        };
+        // location in sbh2q
+        let location5 = Location {
+            lat: T::from_num(0.066),
+            lon: T::from_num(40.012),
+        };
+        // location in sbh2p
+        let location6 = Location {
+            lat: T::from_num(0.022),
+            lon: T::from_num(40.056),
+        };
+        // location in kzurz
+        let location7 = Location {
+            lat: T::from_num(-0.022),
+            lon: T::from_num(40.056),
+        };
+        // location far away
+        let location8 = Location {
+            lat: T::from_num(45),
+            lon: T::from_num(45),
+        };
+
+        // same bucket, same cid
+        EncointerCommunities::add_location(Origin::root(), cid, location2);
+        // same bucket different cid
+        EncointerCommunities::add_location(Origin::root(), cid2, location3);
+        //different bucket, same cid
+        EncointerCommunities::add_location(Origin::root(), cid, location4);
+        // different bucket, different cid
+        EncointerCommunities::add_location(Origin::root(), cid2, location5);
+        // different bucket, different cid
+        EncointerCommunities::add_location(Origin::root(), cid2, location6);
+        // location far away, same cid
+        EncointerCommunities::add_location(Origin::root(), cid, location7);
+        // location far away different cid
+        EncointerCommunities::add_location(Origin::root(), cid2, location8);
+
+        let mut result = EncointerCommunities::get_nearby_locations(&location).unwrap();
+        let mut expected_result = vec![location2, location3, location4, location5, location6];
+        result.sort();
+        expected_result.sort();
+        assert_eq!(result, expected_result);
+
+
     });
 }
 
 #[test]
-fn get_nearby_locations_works() {
+fn validate_location_works() {
     ExtBuilder::build().execute_with(|| {
-        let b = Location {
-            lat: T::from_num(47.2696129372),
-            lon: T::from_num(8.6439979076),
+        let cid = register_test_community::<TestRuntime>(None, 0.0, 0.0);
+
+        // close location
+        let location = Location {
+            lat: T::from_num(0.000000001),
+            lon: T::from_num(0.000000001),
         };
-        assert!(EncointerCommunities::get_nearby_locations(&b).is_ok());
+        assert!(EncointerCommunities::validate_location(&location).is_err());
+
+        // ok location
+        let location = Location {
+            lat: T::from_num(-0.043945312),
+            lon: T::from_num(-0.043945312),
+        };
+        assert!(EncointerCommunities::validate_location(&location).is_ok());
+
+        // locations too close to dateline
+        let location = Location {
+            lat: T::from_num(0),
+            lon: T::from_num(179.9),
+        };
+        assert!(EncointerCommunities::validate_location(&location).is_err());
+        let location = Location {
+            lat: T::from_num(0),
+            lon: T::from_num(-179.9),
+        };
+        assert!(EncointerCommunities::validate_location(&location).is_err());
+
     });
 }

--- a/communities/src/tests.rs
+++ b/communities/src/tests.rs
@@ -184,8 +184,8 @@ fn new_community_works() {
             lat: T::from_num(1i32),
             lon: T::from_num(2i32),
         };
-        assert!(EncointerCommunities::is_valid_geolocation(&a));
-        assert!(EncointerCommunities::is_valid_geolocation(&b));
+        assert!(EncointerCommunities::is_valid_location(&a));
+        assert!(EncointerCommunities::is_valid_location(&b));
         println!("testing Location {:?} and {:?}", a, b);
         println!("north pole at {:?}", NORTH_POLE);
         let loc = vec![a, b];

--- a/communities/src/tests.rs
+++ b/communities/src/tests.rs
@@ -433,3 +433,14 @@ fn new_currency_with_very_close_location_works() {
         .is_ok());
     });
 }
+
+#[test]
+fn get_nearby_locations_works() {
+    ExtBuilder::build().execute_with(|| {
+        let b = Location {
+            lat: T::from_num(47.2696129372),
+            lon: T::from_num(8.6439979076),
+        };
+        assert!(EncointerCommunities::get_nearby_locations(&b).is_ok());
+    });
+}

--- a/personhood-oracle/Cargo.toml
+++ b/personhood-oracle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-encointer-personhood-oracle"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["encointer.org <alain@encointer.org>"]
 edition = "2018"
 

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "encointer-primitives"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["encointer.org <alain@encointer.org>"]
 edition = "2018"
 

--- a/primitives/src/communities.rs
+++ b/primitives/src/communities.rs
@@ -51,7 +51,7 @@ pub fn validate_nominal_income(nominal_income: &NominalIncome) -> Result<(), ()>
 }
 
 // Location in lat/lon. Fixpoint value in degree with 8 decimal bits and 24 fractional bits
-#[derive(Encode, Decode, Copy, Clone, PartialEq, Eq, Default, RuntimeDebug)]
+#[derive(Encode, Decode, Copy, Clone, PartialEq, Eq, Default, RuntimeDebug, PartialOrd, Ord)]
 pub struct Location {
     pub lat: Degree,
     pub lon: Degree,
@@ -190,10 +190,10 @@ pub mod consts {
     // above a latitude with absolute value > 79.6917, a human can travel faster than the sun
     // so those areas have to be excluded, because no matter the distance between two locations
     // an attacker can be at the new location faster than the sun.
-    pub const MAX_ABS_LATITUDE: Degree = Degree::from_bits(79i128 << 64);
+    // as the northern most population is at 78 degrees, we use 78
+    pub const MAX_ABS_LATITUDE: Degree = Degree::from_bits(78i128 << 64);
 
-
-    pub const DATELINE_DISTANCE_M: u32 = 1_000_000; // meetups may not be closer to dateline (or poles) than this
+    pub const DATELINE_DISTANCE_M: u32 = 1_000_000; // meetups may not be closer to dateline than this
 
     pub const NORTH_POLE: Location = Location {
         lon: Degree::from_bits(0i128),
@@ -211,6 +211,12 @@ pub mod consts {
     // dec2hex(6371000,8)
     // in meters
     pub const MEAN_EARTH_RADIUS: I32F0 = I32F0::from_bits(0x006136B8);
+
+    // dec2hex(111319,8)
+    // in meters
+    pub const METERS_PER_DEGREE_AT_EQUATOR : I32F0 = I32F0::from_bits(0x0001B2D7);
+
+    pub const GEO_HASH_LENGTH : usize = 7usize;
 
     /// Dirty bit key for offfchain storage
     pub const CACHE_DIRTY_KEY: &[u8] = b"dirty";

--- a/primitives/src/communities.rs
+++ b/primitives/src/communities.rs
@@ -188,8 +188,7 @@ pub mod consts {
     // (cos(x) * 111.3194) / (v/1000)
     // (cos(x) * 111.3194) / (83/1000) = 240, solve for x ==> x == 79.6917
     // above a latitude with absolute value > 79.6917, a human can travel faster than the sun
-    // so those areas have to be excluded, because no matter the distance between two locations
-    // an attacker can be at the new location faster than the sun.
+    // when he moves along the same latitude, so it simplifies things to exclude those locations.
     // as the northern most population is at 78 degrees, we use 78
     pub const MAX_ABS_LATITUDE: Degree = Degree::from_bits(78i128 << 64);
 

--- a/primitives/src/communities.rs
+++ b/primitives/src/communities.rs
@@ -182,6 +182,17 @@ pub mod consts {
     pub const MAX_SPEED_MPS: i32 = 83; // [m/s] max speed over ground of adversary
     pub const MIN_SOLAR_TRIP_TIME_S: i32 = 1; // [s] minimum adversary trip time between two locations measured in local (solar) time.
 
+    // sun travels at a speed of 24h * 3600s / 360° = 240s/°
+    // 1 degree of longitude in km at latitude x = cos(x) * 111.3194
+    // seconds per degree with speed v in m/s =
+    // (cos(x) * 111.3194) / (v/1000)
+    // (cos(x) * 111.3194) / (83/1000) = 240, solve for x ==> x == 79.6917
+    // above a latitude with absolute value > 79.6917, a human can travel faster than the sun
+    // so those areas have to be excluded, because no matter the distance between two locations
+    // an attacker can be at the new location faster than the sun.
+    pub const MAX_ABS_LATITUDE: Degree = Degree::from_bits(79i128 << 64);
+
+
     pub const DATELINE_DISTANCE_M: u32 = 1_000_000; // meetups may not be closer to dateline (or poles) than this
 
     pub const NORTH_POLE: Location = Location {

--- a/primitives/src/communities.rs
+++ b/primitives/src/communities.rs
@@ -215,7 +215,7 @@ pub mod consts {
     // in meters
     pub const METERS_PER_DEGREE_AT_EQUATOR : I32F0 = I32F0::from_bits(0x0001B2D7);
 
-    pub const GEO_HASH_LENGTH : usize = 5usize;
+    pub const BUCKET_RESOLUTION : usize = 5usize;
 
     /// Dirty bit key for offfchain storage
     pub const CACHE_DIRTY_KEY: &[u8] = b"dirty";

--- a/primitives/src/communities.rs
+++ b/primitives/src/communities.rs
@@ -216,7 +216,7 @@ pub mod consts {
     // in meters
     pub const METERS_PER_DEGREE_AT_EQUATOR : I32F0 = I32F0::from_bits(0x0001B2D7);
 
-    pub const GEO_HASH_LENGTH : usize = 7usize;
+    pub const GEO_HASH_LENGTH : usize = 5usize;
 
     /// Dirty bit key for offfchain storage
     pub const CACHE_DIRTY_KEY: &[u8] = b"dirty";

--- a/scheduler/Cargo.toml
+++ b/scheduler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-encointer-scheduler"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["encointer.org <alain@encointer.org>"]
 edition = "2018"
 

--- a/sybil-gate-template/Cargo.toml
+++ b/sybil-gate-template/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-encointer-sybil-gate-template"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["encointer.org <alain@encointer.org>"]
 edition = "2018"
 

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test-utils"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["encointer.org <alain@encointer.org>"]
 edition = "2018"
 

--- a/test-utils/src/helpers.rs
+++ b/test-utils/src/helpers.rs
@@ -41,7 +41,7 @@ pub fn bootstrappers() -> Vec<sr25519::Pair> {
     .collect();
 }
 
-/// register a simple test community with N meetup locations and defined bootstrappers
+/// register a simple test community with a specified location and defined bootstrappers
 pub fn register_test_community<Runtime>(
     custom_bootstrappers: Option<Vec<sr25519::Pair>>,
     lat: f64,

--- a/test-utils/src/helpers.rs
+++ b/test-utils/src/helpers.rs
@@ -44,7 +44,8 @@ pub fn bootstrappers() -> Vec<sr25519::Pair> {
 /// register a simple test community with N meetup locations and defined bootstrappers
 pub fn register_test_community<Runtime>(
     custom_bootstrappers: Option<Vec<sr25519::Pair>>,
-    n_locations: u32,
+    lat: f64,
+    lon: f64,
 ) -> CommunityIdentifier
 where
     Runtime: encointer_communities::Config,
@@ -59,21 +60,18 @@ where
 
     let prime = &bs[0];
 
-    let mut loc = Vec::with_capacity(n_locations as usize);
-    for l in 0..n_locations {
-        loc.push(Location {
-            lat: Degree::from_num(l),
-            lon: Degree::from_num(l),
-        })
-    }
+    let location = Location {
+            lat: Degree::from_num(lat),
+            lon: Degree::from_num(lon),
+        };
     encointer_communities::Module::<Runtime>::new_community(
         Runtime::Origin::signed(prime.clone()),
-        loc.clone(),
+        location.clone(),
         bs.clone(),
         Default::default(),
         None,
         None,
     )
     .unwrap();
-    CommunityIdentifier::from(blake2_256(&(loc, bs).encode()))
+    CommunityIdentifier::from(blake2_256(&(location.clone(), bs.clone()).encode()))
 }

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -22,7 +22,7 @@ use encointer_primitives::balances::BalanceType;
 use frame_support::parameter_types;
 use frame_support::traits::{Get, PalletInfo};
 use polkadot_parachain::primitives::Sibling;
-use sp_runtime::traits::{IdentifyAccount, Verify};
+use sp_runtime::traits::{IdentifyAccount};
 use sp_runtime::{MultiSignature, Perbill};
 use std::cell::RefCell;
 use xcm::v0::NetworkId;
@@ -42,7 +42,7 @@ pub use timestamp;
 pub use frame_support_test;
 
 pub use sp_core::H256;
-pub use sp_runtime::traits::BlakeTwo256;
+pub use sp_runtime::traits::{BlakeTwo256, Verify};
 
 pub mod helpers;
 pub mod storage;


### PR DESCRIPTION
This PR replaces https://github.com/encointer/pallets/pull/50.
closes #9 

* organize meetup location storage in buckets, addressed by geohash
* reduce minimal distance checks to adjacent buckets

It incorporates all changes discussed in the above PR and adds one more feature:
https://github.com/encointer/pallets/commit/b61b39617e157cfde9026c3bec3e60d225953d77 incorporates the datastructure changes from `communities` (due to geohash) into `ceremonies`. The main problem here was that we can no longer retrieve a simple list of all locations from a community, because there is a layer for geohashes in between. I solved the problem as follows:

1.  Add a function `pub fn get_locations(cid:&CommunityIdentifier) -> Vec<Location>` that uses `iter_prefix_values` on the `Locations` double map in simply concatenates all the vectors corresponding to the geohashes of one community.
2. Because we rely on the indices of the elements in the above retrieved vector in allocation and issuance, I prevented locations from being added/removed in phases other that `CeremonyPhaseType::REGISTERING`.

also, what is crucial for this to work is that `iter_prefix_values` reliably returns its elements in the same order (if the underlying datastructure does not change). Can we rely on that?

note that those changes are somewhat transitional, as the algorithms for issuance and assignment will change again. but i wanted to have a version that works with the current `communities` pallet in order for this PR to be merged.
