### PR TITLE
Make `CommunityIdentifier` serialization compatible with polkadot-js

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -988,6 +988,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
+ "serde_json",
  "sp-core",
  "sp-io",
  "sp-runtime",
@@ -1019,11 +1020,14 @@ checksum = "68b91989ae21441195d7d9b9993a2f9295c7e1a8c96255d8b729accddc124797"
 name = "ep-core"
 version = "0.1.0"
 dependencies = [
+ "impl-serde",
  "parity-scale-codec",
  "scale-info",
  "serde",
+ "serde_json",
  "sp-core",
  "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -4745,9 +4749,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.68"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
+checksum = "d0ffa0837f2dfa6fb90868c2b5468cad482e175f7dad97e7421951e663f2b527"
 dependencies = [
  "itoa",
  "ryu",
@@ -5975,7 +5979,7 @@ version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f559b464de2e2bdabcac6a210d12e9b5a5973c251e102c44c585c71d51bd78e"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "rand 0.8.4",
  "static_assertions",
 ]

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -29,6 +29,7 @@ xcm = { optional = true, default-features = false, git = "https://github.com/par
 
 [dev-dependencies]
 test-utils = { path = "../test-utils" }
+serde_json = "1.0.72"
 
 [features]
 default = ["std", "serde_derive"]

--- a/primitives/core/Cargo.toml
+++ b/primitives/core/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 codec = { package = "parity-scale-codec", version = "2.3.1", default-features = false, features = ["derive"] }
 impl-serde = { version = "0.3.0", optional = true, default-features = false }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-serde = { version = "1.0.101", default-features = false, features = ["derive","alloc"] }
+serde = { version = "1.0.101", optional = true, default-features = false, features = ["derive","alloc"] }
 
 sp-std = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", default-features = false, branch = "master" }
 sp-core = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", default-features = false, branch = "master" }
@@ -21,6 +21,7 @@ serde_json = "1.0.72"
 default = ["std", "serde_derive"]
 serde_derive = [
     "impl-serde",
+    "serde",
 ]
 std = [
     "codec/std",

--- a/primitives/core/Cargo.toml
+++ b/primitives/core/Cargo.toml
@@ -6,22 +6,28 @@ edition = "2021"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.3.1", default-features = false, features = ["derive"] }
+impl-serde = { version = "0.3.0", optional = true, default-features = false }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-serde = { version = "1.0.101", optional = true, default-features = false, features = ["derive","alloc"] }
+serde = { version = "1.0.101", default-features = false, features = ["derive","alloc"] }
 
+sp-std = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", default-features = false, branch = "master" }
 sp-core = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", default-features = false, branch = "master" }
 sp-runtime = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", default-features = false, branch = "master" }
 
+[dev-dependencies]
+serde_json = "1.0.72"
 
 [features]
-default = ["std"]
+default = ["std", "serde_derive"]
 serde_derive = [
-    "serde",
+    "impl-serde",
 ]
 std = [
     "codec/std",
+    "impl-serde/std",
     "scale-info/std",
     "serde/std",
+    "sp-std/std",
     "sp-core/std",
     "sp-runtime/std",
 ]

--- a/primitives/core/src/lib.rs
+++ b/primitives/core/src/lib.rs
@@ -20,6 +20,9 @@ pub mod bs58_verify;
 pub mod random_number_generator;
 pub mod random_permutation;
 
+#[cfg(feature = "serde_derive")]
+pub mod serde;
+
 pub use bs58_verify::*;
 pub use random_number_generator::*;
 pub use random_permutation::*;

--- a/primitives/core/src/serde.rs
+++ b/primitives/core/src/serde.rs
@@ -9,10 +9,10 @@ pub mod serialize_array {
 	use impl_serde::serialize::{deserialize_check_len, ExpectedLen};
 	use serde::Deserializer;
 
-	pub use deserialize_array as deserialize;
-
 	// default serialize is fine
 	pub use impl_serde::serialize::serialize;
+
+	pub use deserialize_array as deserialize;
 
 	pub fn deserialize_array<'de, D, const T: usize>(deserializer: D) -> Result<[u8; T], D::Error>
 	where

--- a/primitives/core/src/serde.rs
+++ b/primitives/core/src/serde.rs
@@ -1,0 +1,60 @@
+//! Custom serde serialization helpers
+
+/// Serialization shim for arbitrary arrays that is consistent with `polkadot-js`'s implementation.
+///
+/// `polkadot-js` sends us a `0x01020304`, but the default rust implementation for arrays expects a
+/// `[0x01, 0x02, 0x03, 0x04]`. Here, we use a similar serialization as substrate uses for `vec`,
+/// but we transform it to an array before returning.
+pub mod serialize_array {
+	use impl_serde::serialize::{deserialize_check_len, ExpectedLen};
+	use serde::Deserializer;
+
+	pub use deserialize_array as deserialize;
+
+	// default serialize is fine
+	pub use impl_serde::serialize::serialize;
+
+	pub fn deserialize_array<'de, D, const T: usize>(deserializer: D) -> Result<[u8; T], D::Error>
+	where
+		D: Deserializer<'de>,
+	{
+		// All hail the stable const generics!
+		let mut arr = [0u8; T];
+		deserialize_check_len(deserializer, ExpectedLen::Exact(&mut arr[..]))?;
+
+		Ok(arr)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::serialize_array;
+
+	fn deserialize<const T: usize>(arr: &str) -> [u8; T] {
+		let mut der = serde_json::Deserializer::new(serde_json::de::StrRead::new(arr));
+		serialize_array::deserialize(&mut der).unwrap()
+	}
+
+	fn serialize<const T: usize>(arr: [u8; T]) -> String {
+		let mut v = vec![];
+
+		let mut ser = serde_json::Serializer::new(std::io::Cursor::new(&mut v));
+		serialize_array::serialize(&arr, &mut ser).unwrap();
+
+		String::from_utf8(v).unwrap()
+	}
+
+	#[test]
+	fn deserialize_works() {
+		assert_eq!(deserialize("\"0x0000\""), [0x00, 0x00]);
+		assert_eq!(deserialize("\"0x0100\""), [0x01, 0x00]);
+		assert_eq!(deserialize("\"0x0010\""), [0x00, 0x10]);
+	}
+
+	#[test]
+	fn serialize_works() {
+		assert_eq!(serialize([0x00, 0x00]), "\"0x0000\"".to_owned());
+		assert_eq!(serialize([0x01, 0x00]), "\"0x0100\"".to_owned());
+		assert_eq!(serialize([0x00, 0x10]), "\"0x0010\"".to_owned());
+	}
+}

--- a/primitives/src/communities.rs
+++ b/primitives/src/communities.rs
@@ -66,9 +66,9 @@ pub fn validate_nominal_income(nominal_income: &NominalIncome) -> Result<(), ()>
 #[derive(Encode, Decode, Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord, TypeInfo)]
 #[cfg_attr(feature = "serde_derive", derive(Serialize, Deserialize))]
 pub struct CommunityIdentifier {
-	#[cfg_attr(feature = "std", serde(with = "serialize_array"))]
+	#[cfg_attr(feature = "serde_derive", serde(with = "serialize_array"))]
 	geohash: [u8; 5],
-	#[cfg_attr(feature = "std", serde(with = "serialize_array"))]
+	#[cfg_attr(feature = "serde_derive", serde(with = "serialize_array"))]
 	digest: [u8; 4],
 }
 
@@ -415,9 +415,6 @@ mod tests {
 
 	#[test]
 	fn cid_from_str_works() {
-		use codec::Encode;
-		println!("[Cid] {:?}", CommunityIdentifier::from_str("gbsuv7YXq9G").unwrap().encode());
-
 		assert_eq!(CommunityIdentifier::from_str("gbsuv7YXq9G").unwrap().to_string(), "gbsuv7YXq9G")
 	}
 


### PR DESCRIPTION
See pr: https://github.com/encointer/encointer-js/pull/29

And discussion in https://github.com/polkadot-js/api/issues/4283.

Tested that it works with encointer-js.