### PR TITLE
Fix location serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -993,7 +993,6 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "substrate-fixed",
  "test-utils",
  "xcm",
 ]
@@ -1028,6 +1027,7 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "sp-std",
+ "substrate-fixed",
 ]
 
 [[package]]

--- a/communities/rpc/runtime-api/src/lib.rs
+++ b/communities/rpc/runtime-api/src/lib.rs
@@ -21,17 +21,16 @@
 #[cfg(not(feature = "std"))]
 use sp_std::vec::Vec;
 
-use encointer_primitives::{common::PalletString, communities::CommunityIdentifier};
-
-// we only need this because serde can't serialize i128
-// https://github.com/paritytech/substrate/issues/4641
-pub type LocationSerialized = [u8; 32];
+use encointer_primitives::{
+	common::PalletString,
+	communities::{CommunityIdentifier, Location},
+};
 
 sp_api::decl_runtime_apis! {
 
 	pub trait CommunitiesApi {
 		fn get_cids() -> Vec<CommunityIdentifier>;
 		fn get_name(cid: &CommunityIdentifier) -> Option<PalletString>;
-		fn get_locations(cid: &CommunityIdentifier) -> Vec<LocationSerialized>;
+		fn get_locations(cid: &CommunityIdentifier) -> Vec<Location>;
 	}
 }

--- a/communities/rpc/src/lib.rs
+++ b/communities/rpc/src/lib.rs
@@ -24,9 +24,7 @@ use sp_blockchain::HeaderBackend;
 use sp_runtime::{generic::BlockId, traits::Block as BlockT};
 use std::sync::Arc;
 
-use encointer_communities_rpc_runtime_api::{
-	CommunitiesApi as CommunitiesRuntimeApi, LocationSerialized,
-};
+use encointer_communities_rpc_runtime_api::CommunitiesApi as CommunitiesRuntimeApi;
 use encointer_primitives::communities::{
 	consts::CACHE_DIRTY_KEY, CidName, CommunityIdentifier, Location,
 };
@@ -45,7 +43,7 @@ pub trait CommunitiesApi<BlockHash> {
 		&self,
 		cid: CommunityIdentifier,
 		at: Option<BlockHash>,
-	) -> Result<Vec<LocationSerialized>>;
+	) -> Result<Vec<Location>>;
 }
 
 pub struct Communities<Client, Block, S> {
@@ -152,7 +150,7 @@ where
 		&self,
 		cid: CommunityIdentifier,
 		at: Option<<Block as BlockT>::Hash>,
-	) -> Result<Vec<LocationSerialized>> {
+	) -> Result<Vec<Location>> {
 		if !self.offchain_indexing {
 			return Err(offchain_indexing_disabled_error("communities_getAll"))
 		}
@@ -165,15 +163,7 @@ where
 		match self.get_storage::<Vec<Location>>(cache_key) {
 			Some(loc) => {
 				log::info!("Using cached location list with len {}", loc.len());
-				let loc_ser = loc
-					.iter()
-					.map(|l| {
-						let mut ls = LocationSerialized::default();
-						ls.copy_from_slice(&l.encode()[0..32]);
-						ls
-					})
-					.collect();
-				Ok(loc_ser)
+				Ok(loc)
 			},
 			None => Err(storage_not_found_error(cache_key)),
 		}

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -9,7 +9,6 @@ bs58 = { version = "0.4.0", default-features = false, features = ["alloc"] }
 codec = { package = "parity-scale-codec", version = "2.3.1", default-features = false, features = ["derive"] }
 concat-arrays = { version = "0.1.2", default-features = false }
 crc = "2.0.0"
-fixed = { package = "substrate-fixed", tag = "v0.5.7", default-features = false, git = "https://github.com/encointer/substrate-fixed" }
 geohash = { git = "https://github.com/encointer/geohash", branch = "master" }
 log = { version = "0.4.14", default-features = false }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
@@ -36,14 +35,12 @@ default = ["std", "serde_derive"]
 sybil = ["xcm"]
 serde_derive = [
     "ep-core/serde_derive",
-    "fixed/serde",
     "serde",
 ]
 std = [
     "bs58/std",
     "codec/std",
     "ep-core/std",
-    "fixed/std",
     "scale-info/std",
     "serde/std",
     "sp-core/std",

--- a/primitives/core/Cargo.toml
+++ b/primitives/core/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.3.1", default-features = false, features = ["derive"] }
 impl-serde = { version = "0.3.0", optional = true, default-features = false }
+fixed = { package = "substrate-fixed", tag = "v0.5.7", default-features = false, git = "https://github.com/encointer/substrate-fixed" }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.101", optional = true, default-features = false, features = ["derive","alloc"] }
 
@@ -21,11 +22,13 @@ serde_json = "1.0.72"
 default = ["std", "serde_derive"]
 serde_derive = [
     "impl-serde",
+    "fixed/serde",
     "serde",
 ]
 std = [
     "codec/std",
     "impl-serde/std",
+    "fixed/std",
     "scale-info/std",
     "serde/std",
     "sp-std/std",

--- a/primitives/core/src/lib.rs
+++ b/primitives/core/src/lib.rs
@@ -23,6 +23,8 @@ pub mod random_permutation;
 #[cfg(feature = "serde_derive")]
 pub mod serde;
 
+pub use fixed;
+
 pub use bs58_verify::*;
 pub use random_number_generator::*;
 pub use random_permutation::*;

--- a/primitives/core/src/serde.rs
+++ b/primitives/core/src/serde.rs
@@ -25,6 +25,16 @@ pub mod serialize_array {
 		Ok(arr)
 	}
 }
+//
+// // i-/u128 and hence all the 128bit substrate-fixed types do not serialize well into JSON for
+// // custom RPCs, so we serialize it as a String.
+// pub fn string_serialize<S, Number: Into<u128> + Copy>(x: &Number, s: S) -> Result<S::Ok, S::Error>
+// where
+// 	S: serde::Serializer,
+// {
+// 	let n: u128 = (*x).into();
+// 	s.serialize_str(&n.to_string())
+// }
 
 #[cfg(test)]
 mod tests {

--- a/primitives/core/src/serde.rs
+++ b/primitives/core/src/serde.rs
@@ -25,27 +25,49 @@ pub mod serialize_array {
 		Ok(arr)
 	}
 }
-//
-// // i-/u128 and hence all the 128bit substrate-fixed types do not serialize well into JSON for
-// // custom RPCs, so we serialize it as a String.
-// pub fn string_serialize<S, Number: Into<u128> + Copy>(x: &Number, s: S) -> Result<S::Ok, S::Error>
-// where
-// 	S: serde::Serializer,
-// {
-// 	let n: u128 = (*x).into();
-// 	s.serialize_str(&n.to_string())
-// }
+
+/// Serialization shim for fixed point numbers that is consistent with `polkadot-js`'s implementation.
+///
+/// This is needed in particular for fixed point types that map to a i-/u128 as serde has problems
+/// with it: https://github.com/paritytech/substrate/issues/4641
+pub mod serialize_fixed {
+	use fixed::traits::Fixed;
+	use serde::{de::Error, Deserializer};
+
+	use impl_serde::serde::Deserialize;
+
+	pub use deserialize_fixed as deserialize;
+	pub use serialize_fixed as serialize;
+
+	// i-/u128 and hence all the 128bit substrate-fixed types do not serialize well into JSON for
+	// custom RPCs, so we serialize it as a String.
+	pub fn serialize_fixed<S, F: Fixed>(f: &F, s: S) -> Result<S::Ok, S::Error>
+	where
+		S: serde::Serializer,
+	{
+		s.serialize_str(&f.to_string())
+	}
+
+	pub fn deserialize_fixed<'de, D, F: Fixed>(d: D) -> Result<F, D::Error>
+	where
+		D: Deserializer<'de>,
+	{
+		let s = String::deserialize(d)?;
+		F::from_str(&s).map_err(D::Error::custom)
+	}
+}
 
 #[cfg(test)]
 mod tests {
-	use super::serialize_array;
+	use super::{serialize_array, serialize_fixed};
+	use fixed::{traits::Fixed, types::I64F64};
 
-	fn deserialize<const T: usize>(arr: &str) -> [u8; T] {
+	fn deserialize_array<const T: usize>(arr: &str) -> [u8; T] {
 		let mut der = serde_json::Deserializer::new(serde_json::de::StrRead::new(arr));
 		serialize_array::deserialize(&mut der).unwrap()
 	}
 
-	fn serialize<const T: usize>(arr: [u8; T]) -> String {
+	fn serialize_array<const T: usize>(arr: [u8; T]) -> String {
 		let mut v = vec![];
 
 		let mut ser = serde_json::Serializer::new(std::io::Cursor::new(&mut v));
@@ -54,17 +76,61 @@ mod tests {
 		String::from_utf8(v).unwrap()
 	}
 
-	#[test]
-	fn deserialize_works() {
-		assert_eq!(deserialize("\"0x0000\""), [0x00, 0x00]);
-		assert_eq!(deserialize("\"0x0100\""), [0x01, 0x00]);
-		assert_eq!(deserialize("\"0x0010\""), [0x00, 0x10]);
+	fn serialize_fixed_point<F: Fixed>(f: F) -> String {
+		let mut v = vec![];
+
+		let mut ser = serde_json::Serializer::new(std::io::Cursor::new(&mut v));
+		serialize_fixed::serialize(&f, &mut ser).unwrap();
+
+		String::from_utf8(v).unwrap()
+	}
+
+	fn deserialize_fixed_point<F: Fixed>(f: &str) -> F {
+		let mut der = serde_json::Deserializer::new(serde_json::de::StrRead::new(f));
+		serialize_fixed::deserialize(&mut der).unwrap()
 	}
 
 	#[test]
-	fn serialize_works() {
-		assert_eq!(serialize([0x00, 0x00]), "\"0x0000\"".to_owned());
-		assert_eq!(serialize([0x01, 0x00]), "\"0x0100\"".to_owned());
-		assert_eq!(serialize([0x00, 0x10]), "\"0x0010\"".to_owned());
+	fn deserialize_array_works() {
+		assert_eq!(deserialize_array("\"0x0000\""), [0x00, 0x00]);
+		assert_eq!(deserialize_array("\"0x0100\""), [0x01, 0x00]);
+		assert_eq!(deserialize_array("\"0x0010\""), [0x00, 0x10]);
+	}
+
+	#[test]
+	fn serialize_array_works() {
+		assert_eq!(serialize_array([0x00, 0x00]), "\"0x0000\"".to_owned());
+		assert_eq!(serialize_array([0x01, 0x00]), "\"0x0100\"".to_owned());
+		assert_eq!(serialize_array([0x00, 0x10]), "\"0x0010\"".to_owned());
+	}
+
+	#[test]
+	fn serialize_fixed_works() {
+		assert_eq!(
+			serialize_fixed_point(I64F64::from_num(18.6808776855468714473)),
+			"\"18.6808776855468714473\"".to_owned()
+		);
+
+		assert_eq!(
+			serialize_fixed_point(I64F64::from_num(0.6808776855468714473)),
+			"\"0.6808776855468714473\"".to_owned()
+		);
+
+		assert_eq!(serialize_fixed_point(I64F64::from_num(1)), "\"1\"".to_owned());
+	}
+
+	#[test]
+	fn deserialize_fixed_works() {
+		assert_eq!(
+			deserialize_fixed_point::<I64F64>("\"18.6808776855468714473\""),
+			I64F64::from_num(18.6808776855468714473)
+		);
+
+		assert_eq!(
+			deserialize_fixed_point::<I64F64>("\"0.6808776855468714473\""),
+			I64F64::from_num(0.6808776855468714473)
+		);
+
+		assert_eq!(deserialize_fixed_point::<I64F64>("\"1\""), I64F64::from_num(1));
 	}
 }

--- a/primitives/core/src/serde.rs
+++ b/primitives/core/src/serde.rs
@@ -36,6 +36,12 @@ pub mod serialize_fixed {
 
 	use impl_serde::serde::Deserialize;
 
+	#[cfg(not(feature = "std"))]
+	extern crate alloc;
+
+	#[cfg(not(feature = "std"))]
+	use alloc::ToString;
+
 	pub use deserialize_fixed as deserialize;
 	pub use serialize_fixed as serialize;
 

--- a/primitives/core/src/serde.rs
+++ b/primitives/core/src/serde.rs
@@ -28,7 +28,7 @@ pub mod serialize_array {
 
 /// Serialization shim for fixed point numbers that is consistent with `polkadot-js`'s implementation.
 ///
-/// This is needed in particular for fixed point types that map to a i-/u128 as serde has problems
+/// This is needed in particular for fixed point types that map to a i-/u128, as serde has problems
 /// with it: https://github.com/paritytech/substrate/issues/4641
 pub mod serialize_fixed {
 	use fixed::traits::Fixed;
@@ -45,8 +45,6 @@ pub mod serialize_fixed {
 	pub use deserialize_fixed as deserialize;
 	pub use serialize_fixed as serialize;
 
-	// i-/u128 and hence all the 128bit substrate-fixed types do not serialize well into JSON for
-	// custom RPCs, so we serialize it as a String.
 	pub fn serialize_fixed<S, F: Fixed>(f: &F, s: S) -> Result<S::Ok, S::Error>
 	where
 		S: serde::Serializer,

--- a/primitives/src/balances.rs
+++ b/primitives/src/balances.rs
@@ -15,7 +15,7 @@
 // along with Encointer.  If not, see <http://www.gnu.org/licenses/>.
 
 use codec::{Decode, Encode};
-use fixed::types::I64F64;
+use ep_core::fixed::types::I64F64;
 use scale_info::TypeInfo;
 use sp_core::RuntimeDebug;
 

--- a/primitives/src/communities.rs
+++ b/primitives/src/communities.rs
@@ -157,7 +157,9 @@ fn decorate_bs58_err(err: bs58::decode::Error) -> bs58::decode::Error {
 )]
 #[cfg_attr(feature = "serde_derive", derive(Serialize, Deserialize))]
 pub struct Location {
+	// #[cfg_attr(feature = "serde_derive", serde(serialize_with = "string_serialize"))]
 	pub lat: Degree,
+	// #[cfg_attr(feature = "serde_derive", serde(serialize_with = "string_serialize"))]
 	pub lon: Degree,
 }
 

--- a/primitives/src/communities.rs
+++ b/primitives/src/communities.rs
@@ -28,7 +28,7 @@ use sp_std::{fmt, fmt::Formatter, prelude::Vec, str::FromStr};
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "serde_derive")]
-use ep_core::serde::{serialize_array, string_serialize};
+use ep_core::serde::{serialize_array, serialize_fixed};
 
 use crate::{
 	balances::Demurrage,
@@ -157,9 +157,9 @@ fn decorate_bs58_err(err: bs58::decode::Error) -> bs58::decode::Error {
 )]
 #[cfg_attr(feature = "serde_derive", derive(Serialize, Deserialize))]
 pub struct Location {
-	// #[cfg_attr(feature = "serde_derive", serde(serialize_with = "string_serialize"))]
+	#[cfg_attr(feature = "serde_derive", serde(with = "serialize_fixed"))]
 	pub lat: Degree,
-	// #[cfg_attr(feature = "serde_derive", serde(serialize_with = "string_serialize"))]
+	#[cfg_attr(feature = "serde_derive", serde(with = "serialize_fixed"))]
 	pub lon: Degree,
 }
 

--- a/primitives/src/communities.rs
+++ b/primitives/src/communities.rs
@@ -18,7 +18,7 @@ use bs58;
 use codec::{Decode, Encode};
 use concat_arrays::concat_arrays;
 use crc::{Crc, CRC_32_CKSUM};
-use fixed::types::I64F64;
+use ep_core::fixed::types::I64F64;
 use geohash::GeoHash;
 use scale_info::TypeInfo;
 use sp_core::RuntimeDebug;
@@ -28,7 +28,7 @@ use sp_std::{fmt, fmt::Formatter, prelude::Vec, str::FromStr};
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "serde_derive")]
-use ep_core::serde::serialize_array;
+use ep_core::serde::{serialize_array, string_serialize};
 
 use crate::{
 	balances::Demurrage,
@@ -38,7 +38,7 @@ use crate::{
 };
 
 use crate::error::CommunityIdentifierError;
-pub use fixed::traits::{LossyFrom, LossyInto};
+pub use ep_core::fixed::traits::{LossyFrom, LossyInto};
 
 pub type CommunityIndexType = u32;
 pub type LocationIndexType = u32;
@@ -285,7 +285,7 @@ pub struct Theme {
 
 pub mod consts {
 	use super::{Degree, Location};
-	use fixed::types::{I32F0, U0F64};
+	use ep_core::fixed::types::{I32F0, U0F64};
 
 	pub const MAX_SPEED_MPS: i32 = 83; // [m/s] max speed over ground of adversary
 	pub const MIN_SOLAR_TRIP_TIME_S: i32 = 1; // [s] minimum adversary trip time between two locations measured in local (solar) time.

--- a/primitives/src/sybil.rs
+++ b/primitives/src/sybil.rs
@@ -15,7 +15,7 @@
 // along with Encointer.  If not, see <http://www.gnu.org/licenses/>.
 
 use codec::{Decode, Encode};
-use fixed::traits::Fixed;
+use ep_core::fixed::traits::Fixed;
 use scale_info::TypeInfo;
 use sp_core::{RuntimeDebug, H256};
 use sp_runtime::traits::{BlakeTwo256, Hash};


### PR DESCRIPTION
The approach before was hacky, and enforced specific handling on all other endpoints (encointer-client, encointer-js, etc).

This PR introduces a simple fixed point serialization shim. Tested with encointer-js.