### PR TITLE
Extract assignment logic to separate crate.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -980,6 +980,7 @@ name = "encointer-ceremonies-assignment"
 version = "0.1.0"
 dependencies = [
  "encointer-primitives",
+ "sp-core",
  "sp-runtime",
  "sp-std",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -976,6 +976,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
+name = "encointer-ceremonies-assignment"
+version = "0.1.0"
+dependencies = [
+ "encointer-primitives",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "encointer-primitives"
 version = "0.8.0"
 dependencies = [
@@ -3217,6 +3226,7 @@ name = "pallet-encointer-ceremonies"
 version = "0.8.0"
 dependencies = [
  "approx",
+ "encointer-ceremonies-assignment",
  "encointer-primitives",
  "frame-support",
  "frame-system",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     'bazaar/rpc',
     'bazaar/rpc/runtime-api',
     'ceremonies',
+    'ceremonies/assignment',
     'communities',
     'communities/rpc',
     'communities/rpc/runtime-api',

--- a/ceremonies/Cargo.toml
+++ b/ceremonies/Cargo.toml
@@ -12,6 +12,7 @@ scale-info = { version = "1.0", default-features = false }
 # local deps
 encointer-primitives = { path = "../primitives", default-features = false }
 encointer-balances = { package = "pallet-encointer-balances", path = "../balances", default-features = false }
+encointer-ceremonies-assignment = { path = "assignment", default-features = false }
 encointer-communities = { package = "pallet-encointer-communities", path = "../communities", default-features = false }
 encointer-scheduler = { package = "pallet-encointer-scheduler", path = "../scheduler", default-features = false }
 
@@ -41,6 +42,7 @@ std = [
 	"sp-std/std",
 	"pallet-timestamp/std",
 	"encointer-balances/std",
+	"encointer-ceremonies-assignment/std",
 	"encointer-communities/std",
 	"encointer-primitives/std",
 	"encointer-scheduler/std",

--- a/ceremonies/assignment/Cargo.toml
+++ b/ceremonies/assignment/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "encointer-ceremonies-assignment"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+
+# local deps
+encointer-primitives = { path = "../../primitives", default-features = false }
+
+# substrate deps
+sp-runtime = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", default-features = false, branch = "master" }
+sp-std = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", default-features = false, branch = "master" }
+
+
+[features]
+default = ["std"]
+std = [
+    "encointer-primitives/std",
+    "sp-std/std",
+    "sp-runtime/std",
+]

--- a/ceremonies/assignment/Cargo.toml
+++ b/ceremonies/assignment/Cargo.toml
@@ -12,6 +12,8 @@ encointer-primitives = { path = "../../primitives", default-features = false }
 sp-runtime = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", default-features = false, branch = "master" }
 sp-std = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", default-features = false, branch = "master" }
 
+[dev-dependencies]
+sp-core = { version = "4.1.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "master" }
 
 [features]
 default = ["std"]

--- a/ceremonies/assignment/src/lib.rs
+++ b/ceremonies/assignment/src/lib.rs
@@ -54,6 +54,7 @@ pub fn generate_assignment_function_params<Hashing: Hash>(
 	return AssignmentParams { m: m as u64, s1: s1 as u64, s2: s2 as u64 }
 }
 
+// Todo add documentation to this function.
 fn validate_equal_mapping(
 	num_participants: u64,
 	assignment_params: AssignmentParams,

--- a/ceremonies/assignment/src/lib.rs
+++ b/ceremonies/assignment/src/lib.rs
@@ -16,13 +16,13 @@ pub mod math;
 pub fn assignment_fn(
 	participant_index: ParticipantIndexType,
 	assignment_params: AssignmentParams,
-	n: u64,
+	meetup_count: u64,
 ) -> Option<MeetupIndexType> {
 	participant_index
 		.checked_mul(assignment_params.s1)?
 		.checked_add(assignment_params.s2)
 		.and_then(|div| checked_modulo(div, assignment_params.m))
-		.and_then(|div| checked_modulo(div, n))
+		.and_then(|div| checked_modulo(div, meetup_count))
 }
 
 /// Generates randomized `[AssignmentParams]` for `num_participants` to be distributed across
@@ -58,18 +58,18 @@ pub fn generate_assignment_function_params<Hashing: Hash>(
 fn validate_equal_mapping(
 	num_participants: u64,
 	assignment_params: AssignmentParams,
-	n: u64,
+	meetup_count: u64,
 ) -> bool {
 	if num_participants < 2 {
 		return true
 	}
 
-	let mut meetup_index_count: Vec<u64> = vec![0; n as usize];
+	let mut meetup_index_count: Vec<u64> = vec![0; meetup_count as usize];
 	let meetup_index_count_max =
-		checked_ceil_division(num_participants - assignment_params.m, n).unwrap_or(0);
+		checked_ceil_division(num_participants - assignment_params.m, meetup_count).unwrap_or(0);
 
 	for i in assignment_params.m..num_participants {
-		let meetup_index = match assignment_fn(i, assignment_params, n) {
+		let meetup_index = match assignment_fn(i, assignment_params, meetup_count) {
 			Some(i) => i as usize,
 			None => return false,
 		};

--- a/ceremonies/assignment/src/lib.rs
+++ b/ceremonies/assignment/src/lib.rs
@@ -80,3 +80,29 @@ fn validate_equal_mapping(
 	}
 	true
 }
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn assignment_fn_works() {
+		new_test_ext().execute_with(|| {
+			assert_eq!(assignment_fn(6, AssignmentParams { m: 4, s1: 5, s2: 3 }, 5).unwrap(), 1)
+		});
+	}
+
+	#[test]
+	fn validate_equal_mapping_works() {
+		new_test_ext().execute_with(|| {
+			assert_eq!(
+				validate_equal_mapping(2761, AssignmentParams { m: 2753, s1: 2326, s2: 1099 }, 427),
+				false
+			);
+			assert_eq!(
+				validate_equal_mapping(2761, AssignmentParams { m: 2753, s1: 2325, s2: 1099 }, 427),
+				true
+			);
+		});
+	}
+}

--- a/ceremonies/assignment/src/lib.rs
+++ b/ceremonies/assignment/src/lib.rs
@@ -16,13 +16,13 @@ pub mod math;
 pub fn assignment_fn(
 	participant_index: ParticipantIndexType,
 	assignment_params: AssignmentParams,
-	meetup_count: u64,
+	assignment_count: u64,
 ) -> Option<MeetupIndexType> {
 	participant_index
 		.checked_mul(assignment_params.s1)?
 		.checked_add(assignment_params.s2)
 		.and_then(|div| checked_modulo(div, assignment_params.m))
-		.and_then(|div| checked_modulo(div, meetup_count))
+		.and_then(|div| checked_modulo(div, assignment_count))
 }
 
 /// Generates randomized `[AssignmentParams]` for `num_participants` to be distributed across
@@ -89,24 +89,25 @@ fn validate_equal_mapping(
 pub fn assignment_fn_inverse(
 	meetup_index: u64,
 	assignment_params: AssignmentParams,
-	meetup_count: u64,
+	assignment_count: u64,
 	participant_count: u64,
 ) -> Vec<ParticipantIndexType> {
-	if meetup_count <= 0 {
+	if assignment_count <= 0 {
 		return vec![]
 	}
 
-	let mut max_index = assignment_params.m.checked_sub(meetup_index).unwrap_or(0) / meetup_count;
+	let mut max_index =
+		assignment_params.m.checked_sub(meetup_index).unwrap_or(0) / assignment_count;
 	let mut result: Vec<ParticipantIndexType> = Vec::with_capacity(max_index as usize);
 	// ceil
-	if (assignment_params.m as i64 - meetup_index as i64).rem_euclid(meetup_count as i64) != 0 {
+	if (assignment_params.m as i64 - meetup_index as i64).rem_euclid(assignment_count as i64) != 0 {
 		max_index += 1; //safe; m prime below num_participants
 	}
 
 	for i in 0..max_index {
 		let t2 = mod_inv(assignment_params.s1 as i64, assignment_params.m as i64);
 
-		let t3 = match t3(meetup_count, i, meetup_index, assignment_params, t2) {
+		let t3 = match t3(assignment_count, i, meetup_index, assignment_params, t2) {
 			Some(t3) => t3,
 			None => continue,
 		};

--- a/ceremonies/assignment/src/lib.rs
+++ b/ceremonies/assignment/src/lib.rs
@@ -1,0 +1,82 @@
+//! Everything regarding meetup assignments
+
+use crate::math::{checked_ceil_division, checked_modulo, find_prime_below};
+use encointer_primitives::{
+	ceremonies::{AssignmentParams, MeetupIndexType, ParticipantIndexType},
+	RandomNumberGenerator,
+};
+use sp_runtime::traits::Hash;
+
+pub mod math;
+
+/// Assigns a participant to a meetup.
+///
+/// Returns an error if the checked math operations fail.
+pub fn assignment_fn(
+	participant_index: ParticipantIndexType,
+	assignment_params: AssignmentParams,
+	n: u64,
+) -> Option<MeetupIndexType> {
+	participant_index
+		.checked_mul(assignment_params.s1)?
+		.checked_add(assignment_params.s2)
+		.and_then(|div| checked_modulo(div, assignment_params.m))
+		.and_then(|div| checked_modulo(div, n))
+}
+
+/// Generates randomized `[AssignmentParams]` for `num_participants` to be distributed across
+/// `num_meetups`.
+///
+pub fn generate_assignment_function_params<Hashing: Hash>(
+	num_participants: u64,
+	num_meetups: u64,
+	random_source: &mut RandomNumberGenerator<Hashing>,
+) -> AssignmentParams {
+	let max_skips = 200;
+	let m = find_prime_below(num_participants) as u32;
+	let mut skip_count = 0;
+	let mut s1 = random_source.pick_non_zero_u32(m - 1); //safe; m > 1, since prime
+	let mut s2 = random_source.pick_non_zero_u32(m - 1);
+
+	while skip_count <= max_skips {
+		s1 = random_source.pick_non_zero_u32(m - 1);
+		s2 = random_source.pick_non_zero_u32(m - 1);
+		if validate_equal_mapping(
+			num_participants,
+			AssignmentParams { m: m as u64, s1: s1 as u64, s2: s2 as u64 },
+			num_meetups,
+		) {
+			break
+		} else {
+			skip_count += 1;
+		}
+	}
+	return AssignmentParams { m: m as u64, s1: s1 as u64, s2: s2 as u64 }
+}
+
+fn validate_equal_mapping(
+	num_participants: u64,
+	assignment_params: AssignmentParams,
+	n: u64,
+) -> bool {
+	if num_participants < 2 {
+		return true
+	}
+
+	let mut meetup_index_count: Vec<u64> = vec![0; n as usize];
+	let meetup_index_count_max =
+		checked_ceil_division(num_participants - assignment_params.m, n).unwrap_or(0);
+
+	for i in assignment_params.m..num_participants {
+		let meetup_index = match assignment_fn(i, assignment_params, n) {
+			Some(i) => i as usize,
+			None => return false,
+		};
+
+		meetup_index_count[meetup_index] += 1; // safe; <= num_participants
+		if meetup_index_count[meetup_index] > meetup_index_count_max {
+			return false
+		}
+	}
+	true
+}

--- a/ceremonies/assignment/src/lib.rs
+++ b/ceremonies/assignment/src/lib.rs
@@ -140,6 +140,14 @@ fn t3(
 	return Some(t3 as u64)
 }
 
+pub fn meetup_index(
+	participant_index: ParticipantIndexType,
+	params: AssignmentParams,
+	meetup_count: MeetupIndexType,
+) -> Option<MeetupIndexType> {
+	Some(assignment_fn(participant_index, params, meetup_count)? + 1)
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;

--- a/ceremonies/assignment/src/lib.rs
+++ b/ceremonies/assignment/src/lib.rs
@@ -5,6 +5,7 @@
 use crate::math::{checked_ceil_division, checked_modulo, find_prime_below, mod_inv};
 use encointer_primitives::{
 	ceremonies::{AssignmentParams, MeetupIndexType, ParticipantIndexType},
+	communities::Location,
 	RandomNumberGenerator,
 };
 use sp_runtime::traits::Hash;
@@ -146,6 +147,21 @@ pub fn meetup_index(
 	meetup_count: MeetupIndexType,
 ) -> Option<MeetupIndexType> {
 	Some(assignment_fn(participant_index, params, meetup_count)? + 1)
+}
+
+pub fn meetup_location(
+	meetup_index: MeetupIndexType,
+	locations: Vec<Location>,
+	location_assignment_params: AssignmentParams,
+) -> Option<Location> {
+	let location_idx =
+		assignment_fn(meetup_index, location_assignment_params, locations.len() as u64)?;
+
+	if location_idx < locations.len() as u64 {
+		Some(locations[(location_idx) as usize])
+	} else {
+		None
+	}
 }
 
 #[cfg(test)]

--- a/ceremonies/assignment/src/lib.rs
+++ b/ceremonies/assignment/src/lib.rs
@@ -147,52 +147,46 @@ mod tests {
 
 	#[test]
 	fn assignment_fn_works() {
-		new_test_ext().execute_with(|| {
-			assert_eq!(assignment_fn(6, AssignmentParams { m: 4, s1: 5, s2: 3 }, 5).unwrap(), 1)
-		});
+		assert_eq!(assignment_fn(6, AssignmentParams { m: 4, s1: 5, s2: 3 }, 5).unwrap(), 1)
 	}
 
 	#[test]
 	fn validate_equal_mapping_works() {
-		new_test_ext().execute_with(|| {
-			assert_eq!(
-				validate_equal_mapping(2761, AssignmentParams { m: 2753, s1: 2326, s2: 1099 }, 427),
-				false
-			);
-			assert_eq!(
-				validate_equal_mapping(2761, AssignmentParams { m: 2753, s1: 2325, s2: 1099 }, 427),
-				true
-			);
-		});
+		assert_eq!(
+			validate_equal_mapping(2761, AssignmentParams { m: 2753, s1: 2326, s2: 1099 }, 427),
+			false
+		);
+		assert_eq!(
+			validate_equal_mapping(2761, AssignmentParams { m: 2753, s1: 2325, s2: 1099 }, 427),
+			true
+		);
 	}
 
 	#[test]
 	fn assignment_fn_inverse_works() {
-		new_test_ext().execute_with(|| {
-			let mut s1 = 78u64;
-			let mut s2 = 23u64;
-			let mut n = 12u64;
-			let mut num_participants = 118u64;
-			let mut m = 113u64;
+		let mut s1 = 78u64;
+		let mut s2 = 23u64;
+		let mut n = 12u64;
+		let mut num_participants = 118u64;
+		let mut m = 113u64;
 
-			let mut assignment_params = AssignmentParams { m, s1, s2 };
-			check_assignment(num_participants, assignment_params, n);
+		let mut assignment_params = AssignmentParams { m, s1, s2 };
+		check_assignment(num_participants, assignment_params, n);
 
-			s1 = 1u64;
-			s2 = 1u64;
-			n = 2u64;
-			num_participants = 20u64;
-			m = 19u64;
-			assignment_params = AssignmentParams { m, s1, s2 };
-			check_assignment(num_participants, assignment_params, n);
-			s1 = 1u64;
-			s2 = 1u64;
-			n = 1u64;
-			num_participants = 10u64;
-			m = 7u64;
-			assignment_params = AssignmentParams { m, s1, s2 };
-			check_assignment(num_participants, assignment_params, n);
-		});
+		s1 = 1u64;
+		s2 = 1u64;
+		n = 2u64;
+		num_participants = 20u64;
+		m = 19u64;
+		assignment_params = AssignmentParams { m, s1, s2 };
+		check_assignment(num_participants, assignment_params, n);
+		s1 = 1u64;
+		s2 = 1u64;
+		n = 1u64;
+		num_participants = 10u64;
+		m = 7u64;
+		assignment_params = AssignmentParams { m, s1, s2 };
+		check_assignment(num_participants, assignment_params, n);
 	}
 
 	fn check_assignment(num_participants: u64, assignment_params: AssignmentParams, n: u64) {

--- a/ceremonies/assignment/src/lib.rs
+++ b/ceremonies/assignment/src/lib.rs
@@ -9,6 +9,7 @@ use encointer_primitives::{
 	RandomNumberGenerator,
 };
 use sp_runtime::traits::Hash;
+use sp_std::{prelude::Vec, vec};
 
 pub mod math;
 

--- a/ceremonies/assignment/src/lib.rs
+++ b/ceremonies/assignment/src/lib.rs
@@ -165,4 +165,57 @@ mod tests {
 			);
 		});
 	}
+
+	#[test]
+	fn assignment_fn_inverse_works() {
+		new_test_ext().execute_with(|| {
+			let mut s1 = 78u64;
+			let mut s2 = 23u64;
+			let mut n = 12u64;
+			let mut num_participants = 118u64;
+			let mut m = 113u64;
+
+			let mut assignment_params = AssignmentParams { m, s1, s2 };
+			check_assignment(num_participants, assignment_params, n);
+
+			s1 = 1u64;
+			s2 = 1u64;
+			n = 2u64;
+			num_participants = 20u64;
+			m = 19u64;
+			assignment_params = AssignmentParams { m, s1, s2 };
+			check_assignment(num_participants, assignment_params, n);
+			s1 = 1u64;
+			s2 = 1u64;
+			n = 1u64;
+			num_participants = 10u64;
+			m = 7u64;
+			assignment_params = AssignmentParams { m, s1, s2 };
+			check_assignment(num_participants, assignment_params, n);
+		});
+	}
+
+	fn check_assignment(num_participants: u64, assignment_params: AssignmentParams, n: u64) {
+		let mut locations: Vec<u64> = vec![0; num_participants as usize];
+
+		for i in 0..num_participants {
+			locations[i as usize] = assignment_fn(i, assignment_params, n).unwrap();
+		}
+
+		let mut assigned_participants: Vec<bool> = vec![false; num_participants as usize];
+
+		// inverse function yields the same result
+		for i in 0..n {
+			let participants = assignment_fn_inverse(i, assignment_params, n, num_participants);
+			for p in participants {
+				assigned_participants[p as usize] = true;
+				assert_eq!(locations[p as usize], i)
+			}
+		}
+
+		// all participants were assigned
+		for val in assigned_participants {
+			assert!(val);
+		}
+	}
 }

--- a/ceremonies/assignment/src/lib.rs
+++ b/ceremonies/assignment/src/lib.rs
@@ -94,8 +94,8 @@ pub fn assignment_fn_inverse(
 		return vec![]
 	}
 
-	let mut result: Vec<ParticipantIndexType> = vec![];
 	let mut max_index = assignment_params.m.checked_sub(meetup_index).unwrap_or(0) / n;
+	let mut result: Vec<ParticipantIndexType> = Vec::with_capacity(max_index as usize);
 	// ceil
 	if (assignment_params.m as i64 - meetup_index as i64).rem_euclid(n as i64) != 0 {
 		max_index += 1; //safe; m prime below num_participants
@@ -103,13 +103,11 @@ pub fn assignment_fn_inverse(
 
 	for i in 0..max_index {
 		let t2 = mod_inv(assignment_params.s1 as i64, assignment_params.m as i64);
-		let maybe_t3 = t3(n, i, meetup_index, assignment_params, t2);
 
-		if maybe_t3.is_none() {
-			continue
-		}
-
-		let t3 = maybe_t3.unwrap();
+		let t3 = match t3(n, i, meetup_index, assignment_params, t2) {
+			Some(t3) => t3,
+			None => continue,
+		};
 
 		if t3 >= num_participants {
 			continue

--- a/ceremonies/assignment/src/lib.rs
+++ b/ceremonies/assignment/src/lib.rs
@@ -1,5 +1,7 @@
 //! Everything regarding meetup assignments
 
+#![cfg_attr(not(feature = "std"), no_std)]
+
 use crate::math::{checked_ceil_division, checked_modulo, find_prime_below, mod_inv};
 use encointer_primitives::{
 	ceremonies::{AssignmentParams, MeetupIndexType, ParticipantIndexType},

--- a/ceremonies/assignment/src/math.rs
+++ b/ceremonies/assignment/src/math.rs
@@ -17,7 +17,7 @@
 //! Math functions used in the ceremonies pallet.
 
 use encointer_primitives::{RandomNumberGenerator, RandomPermutation};
-use frame_support::sp_runtime::traits::Hash;
+use sp_runtime::traits::Hash;
 use sp_std::vec::Vec;
 
 pub fn checked_modulo(dividend: u64, divisor: u64) -> Option<u64> {

--- a/ceremonies/src/lib.rs
+++ b/ceremonies/src/lib.rs
@@ -27,7 +27,7 @@
 
 use codec::{Decode, Encode};
 use encointer_ceremonies_assignment::{
-	assignment_fn, assignment_fn_inverse, generate_assignment_function_params,
+	assignment_fn_inverse, generate_assignment_function_params,
 	math::{checked_ceil_division, find_prime_below, find_random_coprime_below},
 	meetup_index, meetup_location,
 };

--- a/ceremonies/src/lib.rs
+++ b/ceremonies/src/lib.rs
@@ -28,7 +28,7 @@
 use codec::{Decode, Encode};
 use encointer_ceremonies_assignment::{
 	assignment_fn, assignment_fn_inverse, generate_assignment_function_params,
-	math::{checked_ceil_division, find_prime_below, find_random_coprime_below, mod_inv},
+	math::{checked_ceil_division, find_prime_below, find_random_coprime_below},
 };
 use encointer_primitives::{
 	balances::BalanceType,

--- a/ceremonies/src/lib.rs
+++ b/ceremonies/src/lib.rs
@@ -29,6 +29,7 @@ use codec::{Decode, Encode};
 use encointer_ceremonies_assignment::{
 	assignment_fn, assignment_fn_inverse, generate_assignment_function_params,
 	math::{checked_ceil_division, find_prime_below, find_random_coprime_below},
+	meetup_index,
 };
 use encointer_primitives::{
 	balances::BalanceType,
@@ -602,36 +603,31 @@ impl<T: Config> Module<T> {
 
 		if <BootstrapperIndex<T>>::contains_key(community_ceremony, &participant) {
 			let participant_index = Self::bootstrapper_index(community_ceremony, &participant) - 1;
-			return Some(
-				assignment_fn(
-					participant_index,
-					assignment.bootstrappers_reputables,
-					meetup_count,
-				)? + 1,
-			) //safe; smaller than number of locations
+
+			return meetup_index(
+				participant_index,
+				assignment.bootstrappers_reputables,
+				meetup_count,
+			)
 		}
 		if <ReputableIndex<T>>::contains_key(community_ceremony, &participant) {
 			let participant_index = Self::reputable_index(community_ceremony, &participant) - 1;
-			return Some(
-				assignment_fn(
-					participant_index + Self::assignment_counts(community_ceremony).bootstrappers,
-					assignment.bootstrappers_reputables,
-					meetup_count,
-				)? + 1,
-			) //safe; smaller than number of locations
+
+			return meetup_index(
+				participant_index + Self::assignment_counts(community_ceremony).bootstrappers,
+				assignment.bootstrappers_reputables,
+				meetup_count,
+			)
 		}
 
 		if <EndorseeIndex<T>>::contains_key(community_ceremony, &participant) {
 			let participant_index = Self::endorsee_index(community_ceremony, &participant) - 1;
-			return Some(
-				assignment_fn(participant_index, assignment.endorsees, meetup_count)? + 1, //safe; smaller than number of locations
-			)
+			return meetup_index(participant_index, assignment.endorsees, meetup_count)
 		}
 
 		if <NewbieIndex<T>>::contains_key(community_ceremony, &participant) {
 			let participant_index = Self::newbie_index(community_ceremony, &participant) - 1;
-			return Some(assignment_fn(participant_index, assignment.newbies, meetup_count)? + 1)
-			//safe; smaller than number of locations
+			return meetup_index(participant_index, assignment.newbies, meetup_count)
 		}
 
 		None

--- a/ceremonies/src/lib.rs
+++ b/ceremonies/src/lib.rs
@@ -29,7 +29,7 @@ use codec::{Decode, Encode};
 use encointer_ceremonies_assignment::{
 	assignment_fn, assignment_fn_inverse, generate_assignment_function_params,
 	math::{checked_ceil_division, find_prime_below, find_random_coprime_below},
-	meetup_index,
+	meetup_index, meetup_location,
 };
 use encointer_primitives::{
 	balances::BalanceType,
@@ -811,12 +811,8 @@ impl<T: Config> Module<T> {
 	) -> Option<Location> {
 		let locations = <encointer_communities::Module<T>>::get_locations(&cc.0);
 		let assignment_params = Self::assignments(cc).locations;
-		let location_idx = assignment_fn(meetup_idx, assignment_params, locations.len() as u64)?;
-		if location_idx < locations.len() as u64 {
-			Some(locations[(location_idx) as usize])
-		} else {
-			None
-		}
+
+		meetup_location(meetup_idx, locations, assignment_params)
 	}
 
 	// this function only works during ATTESTING, so we're keeping it for private use

--- a/ceremonies/src/lib.rs
+++ b/ceremonies/src/lib.rs
@@ -642,7 +642,13 @@ impl<T: Config> Module<T> {
 
 		//safe; meetup index conversion from 1 based to 0 based
 		meetup_index -= 1;
-		assert!(meetup_index < meetup_count);
+		if meetup_index > meetup_count {
+			error!(
+				target: LOG,
+				"Invalid meetup index > meetup count: {}, {}", meetup_index, meetup_count
+			);
+			return vec![]
+		}
 
 		let params = Self::assignments(community_ceremony);
 

--- a/ceremonies/src/tests.rs
+++ b/ceremonies/src/tests.rs
@@ -1077,10 +1077,11 @@ fn get_meetup_time_works(lat_micro: i64, lon_micro: i64) {
 				(lon_micro.abs() * ONE_DAY as i64 / 360_000_000) as u64
 		};
 
+		let location = EncointerCeremonies::get_meetup_location((cid, cindex), 1).unwrap();
+
 		let tol = 60_000; // [ms]
 		assert!(
-			tol > (EncointerCeremonies::get_meetup_time((cid, cindex), 1).unwrap() as i64 -
-				mtime as i64)
+			tol > (EncointerCeremonies::get_meetup_time(location).unwrap() as i64 - mtime as i64)
 				.abs() as u64
 		);
 	});

--- a/ceremonies/src/tests.rs
+++ b/ceremonies/src/tests.rs
@@ -1251,58 +1251,6 @@ fn get_assignment_params_works() {
 	});
 }
 
-fn check_assignment(num_participants: u64, assignment_params: AssignmentParams, n: u64) {
-	let mut locations: Vec<u64> = vec![0; num_participants as usize];
-
-	for i in 0..num_participants {
-		locations[i as usize] = assignment_fn(i, assignment_params, n).unwrap();
-	}
-
-	let mut assigned_participants: Vec<bool> = vec![false; num_participants as usize];
-
-	// inverse function yields the same result
-	for i in 0..n {
-		let participants = assignment_fn_inverse(i, assignment_params, n, num_participants);
-		for p in participants {
-			assigned_participants[p as usize] = true;
-			assert_eq!(locations[p as usize], i)
-		}
-	}
-
-	// all participants were assigned
-	for val in assigned_participants {
-		assert!(val);
-	}
-}
-#[test]
-fn assignment_fn_inverse_works() {
-	new_test_ext().execute_with(|| {
-		let mut s1 = 78u64;
-		let mut s2 = 23u64;
-		let mut n = 12u64;
-		let mut num_participants = 118u64;
-		let mut m = 113u64;
-
-		let mut assignment_params = AssignmentParams { m, s1, s2 };
-		check_assignment(num_participants, assignment_params, n);
-
-		s1 = 1u64;
-		s2 = 1u64;
-		n = 2u64;
-		num_participants = 20u64;
-		m = 19u64;
-		assignment_params = AssignmentParams { m, s1, s2 };
-		check_assignment(num_participants, assignment_params, n);
-		s1 = 1u64;
-		s2 = 1u64;
-		n = 1u64;
-		num_participants = 10u64;
-		m = 7u64;
-		assignment_params = AssignmentParams { m, s1, s2 };
-		check_assignment(num_participants, assignment_params, n);
-	});
-}
-
 #[test]
 fn get_meetup_index_works() {
 	new_test_ext().execute_with(|| {

--- a/ceremonies/src/tests.rs
+++ b/ceremonies/src/tests.rs
@@ -1219,28 +1219,6 @@ fn grow_population_works() {
 }
 
 #[test]
-fn validate_equal_mapping_works() {
-	new_test_ext().execute_with(|| {
-		assert_eq!(
-			EncointerCeremonies::validate_equal_mapping(
-				2761,
-				AssignmentParams { m: 2753, s1: 2326, s2: 1099 },
-				427
-			),
-			false
-		);
-		assert_eq!(
-			EncointerCeremonies::validate_equal_mapping(
-				2761,
-				AssignmentParams { m: 2753, s1: 2325, s2: 1099 },
-				427
-			),
-			true
-		);
-	});
-}
-
-#[test]
 fn get_assignment_params_works() {
 	new_test_ext().execute_with(|| {
 		let cid = perform_bootstrapping_ceremony(None, 1);
@@ -1273,23 +1251,11 @@ fn get_assignment_params_works() {
 	});
 }
 
-#[test]
-fn assignment_fn_works() {
-	new_test_ext().execute_with(|| {
-		assert_eq!(
-			EncointerCeremonies::assignment_fn(6, AssignmentParams { m: 4, s1: 5, s2: 3 }, 5)
-				.unwrap(),
-			1
-		)
-	});
-}
-
 fn check_assignment(num_participants: u64, assignment_params: AssignmentParams, n: u64) {
 	let mut locations: Vec<u64> = vec![0; num_participants as usize];
 
 	for i in 0..num_participants {
-		locations[i as usize] =
-			EncointerCeremonies::assignment_fn(i, assignment_params, n).unwrap();
+		locations[i as usize] = assignment_fn(i, assignment_params, n).unwrap();
 	}
 
 	let mut assigned_participants: Vec<bool> = vec![false; num_participants as usize];

--- a/ceremonies/src/tests.rs
+++ b/ceremonies/src/tests.rs
@@ -1262,8 +1262,7 @@ fn check_assignment(num_participants: u64, assignment_params: AssignmentParams, 
 
 	// inverse function yields the same result
 	for i in 0..n {
-		let participants =
-			EncointerCeremonies::assignment_fn_inverse(i, assignment_params, n, num_participants);
+		let participants = assignment_fn_inverse(i, assignment_params, n, num_participants);
 		for p in participants {
 			assigned_participants[p as usize] = true;
 			assert_eq!(locations[p as usize], i)

--- a/primitives/src/ceremonies.rs
+++ b/primitives/src/ceremonies.rs
@@ -237,7 +237,7 @@ impl AssignmentCount {
 	}
 }
 
-#[derive(Encode, Decode, Copy, Clone, PartialEq, Eq, RuntimeDebug, TypeInfo)]
+#[derive(Encode, Decode, Default, Copy, Clone, PartialEq, Eq, RuntimeDebug, TypeInfo)]
 pub struct Assignment {
 	pub bootstrappers_reputables: AssignmentParams,
 	pub endorsees: AssignmentParams,
@@ -245,28 +245,14 @@ pub struct Assignment {
 	pub locations: AssignmentParams,
 }
 
-impl Default for Assignment {
-	fn default() -> Self {
-		Assignment {
-			bootstrappers_reputables: AssignmentParams::default(),
-			endorsees: AssignmentParams::default(),
-			newbies: AssignmentParams::default(),
-			locations: AssignmentParams::default(),
-		}
-	}
-}
-
-#[derive(Encode, Decode, Copy, Clone, PartialEq, Eq, RuntimeDebug, TypeInfo)]
+// Todo: abstract AssignmentParams trait and use two different structs: AssignmentParams, LocationAssignmentParams
+#[derive(Encode, Decode, Default, Copy, Clone, PartialEq, Eq, RuntimeDebug, TypeInfo)]
 pub struct AssignmentParams {
-	/// Random prime below number of meetup participants
+	/// Random prime below number of meetup participants. For locations this is the amount of locations.
 	pub m: u64,
-	/// First random group element (0, m)
+	/// First random group element in the interval (0, m). For locations this is a random coprime < m.
 	pub s1: u64,
-	/// Second random group element (0, m)
+	/// Second random group element in the interval (0, m). For locations the closest prime to m,
+	/// with s2 < m.
 	pub s2: u64,
-}
-impl Default for AssignmentParams {
-	fn default() -> Self {
-		AssignmentParams { m: 0, s1: 0, s2: 0 }
-	}
 }

--- a/primitives/src/ceremonies.rs
+++ b/primitives/src/ceremonies.rs
@@ -258,8 +258,11 @@ impl Default for Assignment {
 
 #[derive(Encode, Decode, Copy, Clone, PartialEq, Eq, RuntimeDebug, TypeInfo)]
 pub struct AssignmentParams {
+	/// Random prime below number of meetup participants
 	pub m: u64,
+	/// First random group element (0, m)
 	pub s1: u64,
+	/// Second random group element (0, m)
 	pub s2: u64,
 }
 impl Default for AssignmentParams {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2021-12-22"
+channel = "nightly-2021-12-10"
 targets = ["wasm32-unknown-unknown"]
 profile = "default" # include rustfmt, clippy


### PR DESCRIPTION
I extracted most of the assignment functions that don't need state-access to a separate crate to re-use them in the encointer-client.