### PR TITLE
show pallet parameters as constants in the metadata.

### DIFF
--- a/balances/src/lib.rs
+++ b/balances/src/lib.rs
@@ -65,6 +65,8 @@ decl_event!(
 
 decl_module! {
 	pub struct Module<T: Config> for enum Call where origin: T::Origin {
+		const DefaultDemurrage: Demurrage = T::DefaultDemurrage::get();
+
 		fn deposit_event() = default;
 		type Error = Error<T>;
 

--- a/ceremonies/src/lib.rs
+++ b/ceremonies/src/lib.rs
@@ -126,6 +126,9 @@ decl_storage! {
 
 decl_module! {
 	pub struct Module<T: Config> for enum Call where origin: T::Origin {
+		const ReputationLifetime: u32 = T::ReputationLifetime::get();
+		const AmountNewbieTickets: u8 = T::AmountNewbieTickets::get();
+
 		fn deposit_event() = default;
 		type Error = Error<T>;
 

--- a/communities/src/lib.rs
+++ b/communities/src/lib.rs
@@ -76,6 +76,9 @@ decl_storage! {
 
 decl_module! {
 	pub struct Module<T: Config> for enum Call where origin: T::Origin {
+		const MinSolarTripTimeS: u32 = T::MinSolarTripTimeS::get();
+		const MaxSpeedMps: u32 = T::MaxSpeedMps::get();
+
 		fn deposit_event() = default;
 		type Error = Error<T>;
 		#[weight = 10_000]


### PR DESCRIPTION
Tested that they appear in the metadata now.