### PR TITLE
[cermonies] fix the purging of the registry

### DIFF
--- a/ceremonies/src/lib.rs
+++ b/ceremonies/src/lib.rs
@@ -861,8 +861,8 @@ impl<T: Config> OnCeremonyPhaseChange for Module<T> {
 			CeremonyPhaseType::REGISTERING => {
 				let cindex = <encointer_scheduler::Module<T>>::current_ceremony_index();
 				// Clean up with a time delay, such that participants can claim their UBI in the following cycle.
-				if cindex > T::ReputationLifetime::get() + 1 {
-					Self::purge_registry(cindex - 2);
+				if cindex > T::ReputationLifetime::get() {
+					Self::purge_registry(cindex - T::ReputationLifetime::get() - 1);
 				}
 			},
 		}

--- a/ceremonies/src/mock.rs
+++ b/ceremonies/src/mock.rs
@@ -49,7 +49,7 @@ frame_support::construct_runtime!(
 );
 
 parameter_types! {
-	pub const ReputationLifetime: u32 = 1;
+	pub const ReputationLifetime: u32 = 2;
 	pub const AmountNewbieTickets: u8 = 50;
 	pub const MinSolarTripTimeS: u32 = 1;
 	pub const MaxSpeedMps: u32 = 83;

--- a/ceremonies/src/tests.rs
+++ b/ceremonies/src/tests.rs
@@ -1109,13 +1109,20 @@ fn ceremony_index_and_purging_registry_works() {
 		// still not purged
 		assert_eq!(EncointerCeremonies::bootstrapper_registry((cid, cindex), &1), alice);
 
-		// only after the next cycle everything should be purged
+		// only after 2 cycles everything should be purged
+		run_to_next_phase();
+		run_to_next_phase();
+		run_to_next_phase();
+
+		// still not purged
+		assert_eq!(EncointerCeremonies::bootstrapper_registry((cid, cindex), &1), alice);
+
 		run_to_next_phase();
 		run_to_next_phase();
 		run_to_next_phase();
 		// now again registering
 		let new_cindex = EncointerScheduler::current_ceremony_index();
-		assert_eq!(new_cindex, cindex + 2);
+		assert_eq!(new_cindex, cindex + 3);
 		assert_eq!(EncointerCeremonies::bootstrapper_count((cid, cindex)), 0);
 		assert_eq!(
 			EncointerCeremonies::bootstrapper_registry((cid, cindex), &1),


### PR DESCRIPTION
While introducing the parameter types, there was an erroneously introduced parameter.

Randomly found this while chasing a `ProofOutdated` error in the encointer-wallet.