### PR TITLE
[Ceremonies] Fix handling of reputation lifetime.

### DIFF
--- a/ceremonies/src/lib.rs
+++ b/ceremonies/src/lib.rs
@@ -161,7 +161,7 @@ decl_module! {
 				// we accept proofs from other communities as well. no need to ensure cid
 				ensure!(sender == p.prover_public, Error::<T>::WrongProofSubject);
 				ensure!(p.ceremony_index < cindex, Error::<T>::ProofAcausal);
-				ensure!(p.ceremony_index >= cindex-T::ReputationLifetime::get(), Error::<T>::ProofOutdated);
+				ensure!(p.ceremony_index >= cindex.checked_sub(T::ReputationLifetime::get()).unwrap_or(0), Error::<T>::ProofOutdated);
 				ensure!(Self::participant_reputation(&(p.community_identifier, p.ceremony_index),
 					&p.attendee_public) == Reputation::VerifiedUnlinked,
 					Error::<T>::AttendanceUnverifiedOrAlreadyUsed);

--- a/ceremonies/src/mock.rs
+++ b/ceremonies/src/mock.rs
@@ -49,7 +49,7 @@ frame_support::construct_runtime!(
 );
 
 parameter_types! {
-	pub const ReputationLifetime: u32 = 2;
+	pub const ReputationLifetime: u32 = 6;
 	pub const AmountNewbieTickets: u8 = 50;
 	pub const MinSolarTripTimeS: u32 = 1;
 	pub const MaxSpeedMps: u32 = 83;


### PR DESCRIPTION
An integer underrun caused an erroneous `ProofOutdated` error when trying to register with a proof of attendance on the app side. (because we increased the reputation lifetime to 337 recently).

Interestingly, the code panics when this happens in the unit tests, whereas nothing was observed when running the node, except for the above `ProofOutdated` error.

**Todo**
* First merge #111 