### PR TITLE
migrate encointer-bazaar to frame v2

### DIFF
--- a/balances/src/tests.rs
+++ b/balances/src/tests.rs
@@ -24,17 +24,12 @@ use encointer_primitives::{
 };
 use frame_support::{assert_noop, assert_ok, traits::OnInitialize};
 use mock::{new_test_ext, EncointerBalances, System, TestRuntime};
-use test_utils::{helpers::register_test_community, AccountKeyring};
+use test_utils::{
+	helpers::{assert_last_event, register_test_community},
+	AccountKeyring,
+};
 
 use crate::mock::DefaultDemurrage;
-
-fn assert_last_event<T: Config>(generic_event: <T as Config>::Event) {
-	let events = frame_system::Pallet::<T>::events();
-	let system_event: <T as frame_system::Config>::Event = generic_event.into();
-	// compare to the last event record
-	let frame_system::EventRecord { event, .. } = &events[events.len() - 1];
-	assert_eq!(event, &system_event);
-}
 
 #[test]
 fn issue_should_work() {

--- a/bazaar/src/lib.rs
+++ b/bazaar/src/lib.rs
@@ -23,12 +23,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use frame_support::{
-	decl_error, decl_event, decl_module, decl_storage,
-	dispatch::DispatchResult,
-	ensure,
-	storage::{IterableStorageDoubleMap, StorageDoubleMap},
-};
+use frame_support::ensure;
 use frame_system::ensure_signed;
 use sp_std::prelude::*;
 
@@ -38,149 +33,226 @@ use encointer_primitives::{
 	communities::CommunityIdentifier,
 };
 
-pub trait Config: frame_system::Config + encointer_communities::Config {
-	type Event: From<Event<Self>> + Into<<Self as frame_system::Config>::Event>;
-}
+pub use pallet::*;
 
-decl_storage! {
-	trait Store for Module<T: Config> as Bazaar {
-		pub BusinessRegistry get(fn business_registry): double_map hasher(blake2_128_concat) CommunityIdentifier, hasher(blake2_128_concat) T::AccountId => BusinessData;
-		pub OfferingRegistry get(fn offering_registry): double_map hasher(blake2_128_concat) BusinessIdentifier<T::AccountId>, hasher(blake2_128_concat) OfferingIdentifier => OfferingData;
+#[frame_support::pallet]
+pub mod pallet {
+	use super::*;
+	use frame_support::pallet_prelude::*;
+	use frame_system::pallet_prelude::*;
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config + encointer_communities::Config {
+		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
 	}
-}
 
-decl_event! {
-	pub enum Event<T> where <T as frame_system::Config>::AccountId {
-		/// Event emitted when a business is created. [community, who]
-		BusinessCreated(CommunityIdentifier, AccountId),
-		/// Event emitted when a business is updated. [community, who]
-		BusinessUpdated(CommunityIdentifier, AccountId),
-		/// Event emitted when a business is deleted. [community, who]
-		BusinessDeleted(CommunityIdentifier, AccountId),
-		/// Event emitted when an offering is created. [community, who, oid]
-		OfferingCreated(CommunityIdentifier, AccountId, OfferingIdentifier),
-		/// Event emitted when an offering is updated. [community, who, oid]
-		OfferingUpdated(CommunityIdentifier, AccountId, OfferingIdentifier),
-		/// Event emitted when an offering is deleted. [community, who, oid]
-		OfferingDeleted(CommunityIdentifier, AccountId, OfferingIdentifier),
-	}
-}
+	#[pallet::pallet]
+	#[pallet::generate_store(pub (super) trait Store)]
+	pub struct Pallet<T>(PhantomData<T>);
 
-decl_error! {
-	pub enum Error for Module<T: Config> {
-		/// community identifier not found
-		InexistentCommunity,
-		/// business already registered for this cid
-		ExistingBusiness,
-		/// business does not exist
-		InexistentBusiness,
-		/// offering does not exist
-		InexistentOffering
-	}
-}
-
-decl_module! {
-	pub struct Module<T: Config> for enum Call where origin: T::Origin {
-		fn deposit_event() = default;
-		type Error = Error<T>;
-
-		#[weight = 10_000]
-		pub fn create_business(origin, cid: CommunityIdentifier, url: PalletString) -> DispatchResult {
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		#[pallet::weight(10_000)]
+		pub fn create_business(
+			origin: OriginFor<T>,
+			cid: CommunityIdentifier,
+			url: PalletString,
+		) -> DispatchResultWithPostInfo {
 			// Check that the extrinsic was signed and get the signer
 			let sender = ensure_signed(origin)?;
 			// Check that the supplied community is actually registered
-			ensure!(<encointer_communities::Module<T>>::community_identifiers().contains(&cid),
-				Error::<T>::InexistentCommunity);
+			ensure!(
+				<encointer_communities::Module<T>>::community_identifiers().contains(&cid),
+				Error::<T>::NonexistentCommunity
+			);
 
-			ensure!(!BusinessRegistry::<T>::contains_key(cid, &sender), Error::<T>::ExistingBusiness);
+			ensure!(
+				!BusinessRegistry::<T>::contains_key(cid, &sender),
+				Error::<T>::ExistingBusiness
+			);
 
 			BusinessRegistry::<T>::insert(cid, &sender, BusinessData::new(url, 1));
 
-			Self::deposit_event(RawEvent::BusinessCreated(cid, sender));
+			Self::deposit_event(Event::BusinessCreated(cid, sender));
 
-			Ok(())
+			Ok(().into())
 		}
 
-		#[weight = 10_000]
-		pub fn update_business(origin, cid: CommunityIdentifier, url: PalletString) -> DispatchResult {
+		#[pallet::weight(10_000)]
+		pub fn update_business(
+			origin: OriginFor<T>,
+			cid: CommunityIdentifier,
+			url: PalletString,
+		) -> DispatchResultWithPostInfo {
 			// Check that the extrinsic was signed and get the signer
 			let sender = ensure_signed(origin)?;
 
-			ensure!(BusinessRegistry::<T>::contains_key(cid, &sender), Error::<T>::InexistentBusiness);
+			ensure!(
+				BusinessRegistry::<T>::contains_key(cid, &sender),
+				Error::<T>::NonexistentBusiness
+			);
 
 			BusinessRegistry::<T>::mutate(cid, &sender, |b| b.url = url);
 
-			Self::deposit_event(RawEvent::BusinessUpdated(cid, sender));
+			Self::deposit_event(Event::BusinessUpdated(cid, sender));
 
-			Ok(())
+			Ok(().into())
 		}
 
-		#[weight = 10_000]
-		pub fn delete_business(origin, cid: CommunityIdentifier) -> DispatchResult {
+		#[pallet::weight(10_000)]
+		pub fn delete_business(
+			origin: OriginFor<T>,
+			cid: CommunityIdentifier,
+		) -> DispatchResultWithPostInfo {
 			// Check that the extrinsic was signed and get the signer
 			let sender = ensure_signed(origin)?;
 
-			ensure!(BusinessRegistry::<T>::contains_key(cid, &sender), Error::<T>::InexistentBusiness);
+			ensure!(
+				BusinessRegistry::<T>::contains_key(cid, &sender),
+				Error::<T>::NonexistentBusiness
+			);
 
 			BusinessRegistry::<T>::remove(cid, &sender);
-			OfferingRegistry::<T>::remove_prefix(BusinessIdentifier::new(cid, sender.clone()), None);
+			OfferingRegistry::<T>::remove_prefix(
+				BusinessIdentifier::new(cid, sender.clone()),
+				None,
+			);
 
-			Self::deposit_event(RawEvent::BusinessDeleted(cid, sender));
+			Self::deposit_event(Event::BusinessDeleted(cid, sender));
 
-			Ok(())
+			Ok(().into())
 		}
 
-		#[weight = 10_000]
-		pub fn create_offering(origin, cid: CommunityIdentifier, url: PalletString) -> DispatchResult {
+		#[pallet::weight(10_000)]
+		pub fn create_offering(
+			origin: OriginFor<T>,
+			cid: CommunityIdentifier,
+			url: PalletString,
+		) -> DispatchResultWithPostInfo {
 			// Check that the extrinsic was signed and get the signer
 			let sender = ensure_signed(origin)?;
 
-			ensure!(BusinessRegistry::<T>::contains_key(cid, &sender), Error::<T>::InexistentBusiness);
+			ensure!(
+				BusinessRegistry::<T>::contains_key(cid, &sender),
+				Error::<T>::NonexistentBusiness
+			);
 
 			let oid = BusinessRegistry::<T>::get(cid, &sender).last_oid;
 			BusinessRegistry::<T>::mutate(cid, &sender, |b| b.last_oid = b.last_oid + 1);
-			OfferingRegistry::<T>::insert(BusinessIdentifier::new(cid, sender.clone()), oid, OfferingData::new(url));
+			OfferingRegistry::<T>::insert(
+				BusinessIdentifier::new(cid, sender.clone()),
+				oid,
+				OfferingData::new(url),
+			);
 
-			Self::deposit_event(RawEvent::OfferingCreated(cid, sender, oid));
+			Self::deposit_event(Event::OfferingCreated(cid, sender, oid));
 
-			Ok(())
+			Ok(().into())
 		}
 
-		#[weight = 10_000]
-		pub fn update_offering(origin, cid: CommunityIdentifier, oid: OfferingIdentifier, url: PalletString) -> DispatchResult {
+		#[pallet::weight(10_000)]
+		pub fn update_offering(
+			origin: OriginFor<T>,
+			cid: CommunityIdentifier,
+			oid: OfferingIdentifier,
+			url: PalletString,
+		) -> DispatchResultWithPostInfo {
 			// Check that the extrinsic was signed and get the signer
 			let sender = ensure_signed(origin)?;
 
 			let business_identifier = BusinessIdentifier::new(cid, sender.clone());
 
-			ensure!(OfferingRegistry::<T>::contains_key(&business_identifier, &oid), Error::<T>::InexistentOffering);
+			ensure!(
+				OfferingRegistry::<T>::contains_key(&business_identifier, &oid),
+				Error::<T>::NonexistentOffering
+			);
 
 			OfferingRegistry::<T>::mutate(business_identifier, oid, |o| o.url = url);
 
-			Self::deposit_event(RawEvent::OfferingUpdated(cid, sender, oid));
+			Self::deposit_event(Event::OfferingUpdated(cid, sender, oid));
 
-			Ok(())
+			Ok(().into())
 		}
 
-		#[weight = 10_000]
-		pub fn delete_offering(origin, cid: CommunityIdentifier, oid: OfferingIdentifier) -> DispatchResult {
+		#[pallet::weight(10_000)]
+		pub fn delete_offering(
+			origin: OriginFor<T>,
+			cid: CommunityIdentifier,
+			oid: OfferingIdentifier,
+		) -> DispatchResultWithPostInfo {
 			// Check that the extrinsic was signed and get the signer
 			let sender = ensure_signed(origin)?;
 
 			let business_identifier = BusinessIdentifier::new(cid, sender.clone());
 
-			ensure!(OfferingRegistry::<T>::contains_key(&business_identifier, &oid), Error::<T>::InexistentOffering);
+			ensure!(
+				OfferingRegistry::<T>::contains_key(&business_identifier, &oid),
+				Error::<T>::NonexistentOffering
+			);
 
 			OfferingRegistry::<T>::remove(business_identifier, oid);
 
-			Self::deposit_event(RawEvent::OfferingDeleted(cid, sender, oid));
+			Self::deposit_event(Event::OfferingDeleted(cid, sender, oid));
 
-			Ok(())
+			Ok(().into())
 		}
 	}
+
+	#[pallet::event]
+	#[pallet::generate_deposit(pub(super) fn deposit_event)]
+	pub enum Event<T: Config> {
+		/// Event emitted when a business is created. [community, who]
+		BusinessCreated(CommunityIdentifier, T::AccountId),
+		/// Event emitted when a business is updated. [community, who]
+		BusinessUpdated(CommunityIdentifier, T::AccountId),
+		/// Event emitted when a business is deleted. [community, who]
+		BusinessDeleted(CommunityIdentifier, T::AccountId),
+		/// Event emitted when an offering is created. [community, who, oid]
+		OfferingCreated(CommunityIdentifier, T::AccountId, OfferingIdentifier),
+		/// Event emitted when an offering is updated. [community, who, oid]
+		OfferingUpdated(CommunityIdentifier, T::AccountId, OfferingIdentifier),
+		/// Event emitted when an offering is deleted. [community, who, oid]
+		OfferingDeleted(CommunityIdentifier, T::AccountId, OfferingIdentifier),
+	}
+
+	#[pallet::error]
+	pub enum Error<T> {
+		/// community identifier not found
+		NonexistentCommunity,
+		/// business already registered for this cid
+		ExistingBusiness,
+		/// business does not exist
+		NonexistentBusiness,
+		/// offering does not exist
+		NonexistentOffering,
+	}
+
+	#[pallet::storage]
+	#[pallet::getter(fn business_registry)]
+	pub type BusinessRegistry<T: Config> = StorageDoubleMap<
+		_,
+		Blake2_128Concat,
+		CommunityIdentifier,
+		Blake2_128Concat,
+		T::AccountId,
+		BusinessData,
+		ValueQuery,
+	>;
+
+	#[pallet::storage]
+	#[pallet::getter(fn offering_registry)]
+	pub type OfferingRegistry<T: Config> = StorageDoubleMap<
+		_,
+		Blake2_128Concat,
+		BusinessIdentifier<T::AccountId>,
+		Blake2_128Concat,
+		OfferingIdentifier,
+		OfferingData,
+		ValueQuery,
+	>;
 }
 
-impl<T: Config> Module<T> {
+impl<T: Config> Pallet<T> {
 	pub fn get_businesses(cid: &CommunityIdentifier) -> Vec<(T::AccountId, BusinessData)> {
 		return BusinessRegistry::<T>::iter_prefix(cid).collect()
 	}

--- a/bazaar/src/tests.rs
+++ b/bazaar/src/tests.rs
@@ -21,7 +21,10 @@ use frame_support::dispatch::DispatchResultWithPostInfo;
 use mock::{new_test_ext, EncointerBazaar, Origin, System, TestRuntime};
 
 use encointer_primitives::communities::CommunityIdentifier;
-use test_utils::{helpers::register_test_community, *};
+use test_utils::{
+	helpers::{assert_last_event, register_test_community},
+	*,
+};
 
 fn create_cid() -> CommunityIdentifier {
 	return register_test_community::<TestRuntime>(None, 0.0, 0.0)
@@ -56,14 +59,6 @@ fn assert_error(actual: DispatchResultWithPostInfo, expected: Error<TestRuntime>
 		.unwrap(),
 		expected.as_str()
 	);
-}
-
-fn assert_last_event<T: Config>(generic_event: <T as Config>::Event) {
-	let events = frame_system::Pallet::<T>::events();
-	let system_event: <T as frame_system::Config>::Event = generic_event.into();
-	// compare to the last event record
-	let frame_system::EventRecord { event, .. } = &events[events.len() - 1];
-	assert_eq!(event, &system_event);
 }
 
 #[test]

--- a/bazaar/src/tests.rs
+++ b/bazaar/src/tests.rs
@@ -92,7 +92,7 @@ fn create_business_with_invalid_cid_is_err() {
 				CommunityIdentifier::default(),
 				url(),
 			),
-			Error::<TestRuntime>::InexistentCommunity,
+			Error::<TestRuntime>::NonexistentCommunity,
 		);
 
 		assert_eq!(
@@ -155,7 +155,7 @@ fn update_inexistent_business_is_err() {
 
 		assert_error(
 			EncointerBazaar::update_business(Origin::signed(bob()), cid, url1()),
-			Error::<TestRuntime>::InexistentBusiness,
+			Error::<TestRuntime>::NonexistentBusiness,
 		);
 		assert_error(
 			EncointerBazaar::update_business(
@@ -163,7 +163,7 @@ fn update_inexistent_business_is_err() {
 				CommunityIdentifier::default(),
 				url1(),
 			),
-			Error::<TestRuntime>::InexistentBusiness,
+			Error::<TestRuntime>::NonexistentBusiness,
 		);
 
 		assert_eq!(EncointerBazaar::business_registry(cid, alice()), BusinessData::new(url(), 3));
@@ -203,11 +203,11 @@ fn delete_inexistent_business_is_err() {
 
 		assert_error(
 			EncointerBazaar::delete_business(Origin::signed(alice()), cid),
-			Error::<TestRuntime>::InexistentBusiness,
+			Error::<TestRuntime>::NonexistentBusiness,
 		);
 		assert_error(
 			EncointerBazaar::delete_business(Origin::signed(bob()), CommunityIdentifier::default()),
-			Error::<TestRuntime>::InexistentBusiness,
+			Error::<TestRuntime>::NonexistentBusiness,
 		);
 
 		assert_eq!(EncointerBazaar::business_registry(cid, alice()), BusinessData::default());
@@ -269,7 +269,7 @@ fn create_offering_for_inexistent_business_is_err() {
 
 		assert_error(
 			EncointerBazaar::create_offering(Origin::signed(bob()), cid, url1()),
-			Error::<TestRuntime>::InexistentBusiness,
+			Error::<TestRuntime>::NonexistentBusiness,
 		);
 
 		assert_eq!(System::events().len(), 1);
@@ -318,11 +318,11 @@ fn update_inexistent_offering_is_err() {
 
 		assert_error(
 			EncointerBazaar::update_offering(Origin::signed(bob()), cid, 1, url1()),
-			Error::<TestRuntime>::InexistentOffering,
+			Error::<TestRuntime>::NonexistentOffering,
 		);
 		assert_error(
 			EncointerBazaar::update_offering(Origin::signed(alice()), cid, 0, url1()),
-			Error::<TestRuntime>::InexistentOffering,
+			Error::<TestRuntime>::NonexistentOffering,
 		);
 		assert_error(
 			EncointerBazaar::update_offering(
@@ -331,7 +331,7 @@ fn update_inexistent_offering_is_err() {
 				1,
 				url1(),
 			),
-			Error::<TestRuntime>::InexistentOffering,
+			Error::<TestRuntime>::NonexistentOffering,
 		);
 
 		assert_eq!(System::events().len(), 1);
@@ -380,11 +380,11 @@ fn delete_inexistent_offering_is_err() {
 
 		assert_error(
 			EncointerBazaar::delete_offering(Origin::signed(bob()), cid, 1),
-			Error::<TestRuntime>::InexistentOffering,
+			Error::<TestRuntime>::NonexistentOffering,
 		);
 		assert_error(
 			EncointerBazaar::delete_offering(Origin::signed(alice()), cid, 0),
-			Error::<TestRuntime>::InexistentOffering,
+			Error::<TestRuntime>::NonexistentOffering,
 		);
 		assert_error(
 			EncointerBazaar::delete_offering(
@@ -392,7 +392,7 @@ fn delete_inexistent_offering_is_err() {
 				CommunityIdentifier::default(),
 				1,
 			),
-			Error::<TestRuntime>::InexistentOffering,
+			Error::<TestRuntime>::NonexistentOffering,
 		);
 
 		assert_eq!(System::events().len(), 1);

--- a/test-utils/src/helpers.rs
+++ b/test-utils/src/helpers.rs
@@ -71,3 +71,13 @@ where
 	.unwrap();
 	CommunityIdentifier::new(location, bs).unwrap()
 }
+
+pub fn assert_last_event<T: frame_system::Config>(
+	generic_event: <T as frame_system::Config>::Event,
+) {
+	let events = frame_system::Pallet::<T>::events();
+	let system_event: <T as frame_system::Config>::Event = generic_event.into();
+	// compare to the last event record
+	let frame_system::EventRecord { event, .. } = &events[events.len() - 1];
+	assert_eq!(event, &system_event);
+}


### PR DESCRIPTION
**Note:** The metadata says that the bazaar's storage prefix changed from `Bazaar` to `EncointerBazaar`.

The rest is identical, so this should not break anything.