### PR TITLE
migrate scheduler to frame v2

### DIFF
--- a/ceremonies/src/lib.rs
+++ b/ceremonies/src/lib.rs
@@ -705,11 +705,9 @@ pub mod pallet {
 		<T as pallet_timestamp::Config>::Moment: MaybeSerializeDeserialize,
 	{
 		fn build(&self) {
-			{
-				<CeremonyReward<T>>::put(&self.ceremony_reward);
-				<LocationTolerance<T>>::put(&self.location_tolerance);
-				<TimeTolerance<T>>::put(&self.time_tolerance);
-			}
+			<CeremonyReward<T>>::put(&self.ceremony_reward);
+			<LocationTolerance<T>>::put(&self.location_tolerance);
+			<TimeTolerance<T>>::put(&self.time_tolerance);
 		}
 	}
 }

--- a/ceremonies/src/lib.rs
+++ b/ceremonies/src/lib.rs
@@ -94,10 +94,10 @@ pub mod pallet {
 		) -> DispatchResultWithPostInfo {
 			let sender = ensure_signed(origin)?;
 			ensure!(
-				sender == <encointer_scheduler::Module<T>>::ceremony_master(),
+				sender == <encointer_scheduler::Pallet<T>>::ceremony_master(),
 				Error::<T>::AuthorizationRequired
 			);
-			let cindex = <encointer_scheduler::Module<T>>::current_ceremony_index();
+			let cindex = <encointer_scheduler::Pallet<T>>::current_ceremony_index();
 			<ParticipantReputation<T>>::insert(
 				&(cid, cindex - 1),
 				reputable,
@@ -115,7 +115,7 @@ pub mod pallet {
 		) -> DispatchResultWithPostInfo {
 			let sender = ensure_signed(origin)?;
 			ensure!(
-				<encointer_scheduler::Module<T>>::current_phase() == CeremonyPhaseType::REGISTERING,
+				<encointer_scheduler::Pallet<T>>::current_phase() == CeremonyPhaseType::REGISTERING,
 				Error::<T>::RegisteringPhaseRequired
 			);
 
@@ -124,7 +124,7 @@ pub mod pallet {
 				Error::<T>::InexistentCommunity
 			);
 
-			let cindex = <encointer_scheduler::Module<T>>::current_ceremony_index();
+			let cindex = <encointer_scheduler::Pallet<T>>::current_ceremony_index();
 
 			if Self::is_registered(cid, cindex, &sender) {
 				return Err(<Error<T>>::ParticipantAlreadyRegistered.into())
@@ -179,10 +179,10 @@ pub mod pallet {
 		) -> DispatchResultWithPostInfo {
 			let sender = ensure_signed(origin)?;
 			ensure!(
-				<encointer_scheduler::Module<T>>::current_phase() == CeremonyPhaseType::ATTESTING,
+				<encointer_scheduler::Pallet<T>>::current_phase() == CeremonyPhaseType::ATTESTING,
 				Error::<T>::AttestationPhaseRequired
 			);
-			let cindex = <encointer_scheduler::Module<T>>::current_ceremony_index();
+			let cindex = <encointer_scheduler::Pallet<T>>::current_ceremony_index();
 			ensure!(!claims.is_empty(), Error::<T>::NoValidClaims);
 			let cid = claims[0].community_identifier; //safe; claims not empty checked above
 			ensure!(
@@ -349,8 +349,8 @@ pub mod pallet {
 				Error::<T>::NoMoreNewbieTickets
 			);
 
-			let mut cindex = <encointer_scheduler::Module<T>>::current_ceremony_index();
-			if <encointer_scheduler::Module<T>>::current_phase() != CeremonyPhaseType::REGISTERING {
+			let mut cindex = <encointer_scheduler::Pallet<T>>::current_ceremony_index();
+			if <encointer_scheduler::Pallet<T>>::current_phase() != CeremonyPhaseType::REGISTERING {
 				cindex += 1; //safe; cindex comes from within, will not overflow at +1/d
 			}
 			ensure!(
@@ -899,7 +899,7 @@ impl<T: Config> Pallet<T> {
 
 	fn generate_all_meetup_assignment_params() {
 		let cids = <encointer_communities::Pallet<T>>::community_identifiers();
-		let cindex = <encointer_scheduler::Module<T>>::current_ceremony_index();
+		let cindex = <encointer_scheduler::Pallet<T>>::current_ceremony_index();
 
 		// we don't need to pass a subject here, as this is only called once in a block.
 		let mut random_source =
@@ -1037,11 +1037,11 @@ impl<T: Config> Pallet<T> {
 		participant: &T::AccountId,
 		cid: &CommunityIdentifier,
 	) -> DispatchResultWithPostInfo {
-		if <encointer_scheduler::Module<T>>::current_phase() != CeremonyPhaseType::REGISTERING {
+		if <encointer_scheduler::Pallet<T>>::current_phase() != CeremonyPhaseType::REGISTERING {
 			return Err(<Error<T>>::WrongPhaseForClaimingRewards.into())
 		}
 
-		let cindex = <encointer_scheduler::Module<T>>::current_ceremony_index() - 1; //safe; cindex comes from within
+		let cindex = <encointer_scheduler::Pallet<T>>::current_ceremony_index() - 1; //safe; cindex comes from within
 		let reward = Self::nominal_income(cid);
 		let meetup_index = Self::get_meetup_index((*cid, cindex), participant)
 			.ok_or(<Error<T>>::ParticipantIsNotRegistered)?;
@@ -1157,13 +1157,13 @@ impl<T: Config> Pallet<T> {
 
 	// this function only works during ATTESTING, so we're keeping it for private use
 	fn get_meetup_time(location: Location) -> Option<T::Moment> {
-		if !(<encointer_scheduler::Module<T>>::current_phase() == CeremonyPhaseType::ATTESTING) {
+		if !(<encointer_scheduler::Pallet<T>>::current_phase() == CeremonyPhaseType::ATTESTING) {
 			return None
 		}
 
 		let duration =
-			<encointer_scheduler::Module<T>>::phase_durations(CeremonyPhaseType::ATTESTING);
-		let next = <encointer_scheduler::Module<T>>::next_phase_timestamp();
+			<encointer_scheduler::Pallet<T>>::phase_durations(CeremonyPhaseType::ATTESTING);
+		let next = <encointer_scheduler::Pallet<T>>::next_phase_timestamp();
 		let start = next - duration;
 
 		Some(meetup_time(location, start, T::MomentsPerDay::get()))
@@ -1191,7 +1191,7 @@ impl<T: Config> OnCeremonyPhaseChange for Pallet<T> {
 			},
 			CeremonyPhaseType::ATTESTING => {},
 			CeremonyPhaseType::REGISTERING => {
-				let cindex = <encointer_scheduler::Module<T>>::current_ceremony_index();
+				let cindex = <encointer_scheduler::Pallet<T>>::current_ceremony_index();
 				// Clean up with a time delay, such that participants can claim their UBI in the following cycle.
 				if cindex > T::ReputationLifetime::get() {
 					Self::purge_registry(cindex - T::ReputationLifetime::get() - 1);

--- a/communities/src/lib.rs
+++ b/communities/src/lib.rs
@@ -366,26 +366,16 @@ pub mod pallet {
 	}
 
 	#[cfg(feature = "std")]
-	impl<T: Config> Default for GenesisConfig<T>
-	// TODO_MAYBE_WHERE_CLAUSE
-	{
+	impl<T: Config> Default for GenesisConfig<T> {
 		fn default() -> Self {
 			Self { community_master: Default::default() }
 		}
 	}
 
 	#[pallet::genesis_build]
-	impl<T: Config> GenesisBuild<T> for GenesisConfig<T>
-	// TODO_MAYBE_WHERE_CLAUSE
-	{
+	impl<T: Config> GenesisBuild<T> for GenesisConfig<T> {
 		fn build(&self) {
-			{
-				let data = &self.community_master;
-				let v: &T::AccountId = data;
-				<CommunityMaster<T> as frame_support::storage::StorageValue<T::AccountId>>::put::<
-					&T::AccountId,
-				>(v);
-			}
+			<CommunityMaster<T>>::put(&self.community_master);
 		}
 	}
 }

--- a/communities/src/lib.rs
+++ b/communities/src/lib.rs
@@ -138,7 +138,7 @@ pub mod pallet {
 		) -> DispatchResultWithPostInfo {
 			let sender = ensure_signed(origin)?;
 			ensure!(
-				<encointer_scheduler::Module<T>>::current_phase() == CeremonyPhaseType::REGISTERING,
+				<encointer_scheduler::Pallet<T>>::current_phase() == CeremonyPhaseType::REGISTERING,
 				Error::<T>::RegistrationPhaseRequired
 			);
 			Self::ensure_cid_exists(&cid)?;
@@ -176,7 +176,7 @@ pub mod pallet {
 		) -> DispatchResultWithPostInfo {
 			let sender = ensure_signed(origin)?;
 			ensure!(
-				<encointer_scheduler::Module<T>>::current_phase() == CeremonyPhaseType::REGISTERING,
+				<encointer_scheduler::Pallet<T>>::current_phase() == CeremonyPhaseType::REGISTERING,
 				Error::<T>::RegistrationPhaseRequired
 			);
 			Self::ensure_cid_exists(&cid)?;

--- a/personhood-oracle/src/lib.rs
+++ b/personhood-oracle/src/lib.rs
@@ -158,7 +158,7 @@ impl<T: Config> Pallet<T> {
 	pub fn verify(
 		request: Vec<ProofOfAttendance<<T as Ceremonies>::Signature, T::AccountId>>,
 	) -> Result<PersonhoodUniquenessRating, DispatchError> {
-		let mut c_index_min = <encointer_scheduler::Module<T>>::current_ceremony_index();
+		let mut c_index_min = <encointer_scheduler::Pallet<T>>::current_ceremony_index();
 		let mut n_attested = 0;
 		let mut attested = Vec::new();
 
@@ -178,7 +178,7 @@ impl<T: Config> Pallet<T> {
 				attested.push(proof.hash())
 			}
 		}
-		let last_n_ceremonies = <encointer_scheduler::Module<T>>::current_ceremony_index()
+		let last_n_ceremonies = <encointer_scheduler::Pallet<T>>::current_ceremony_index()
 			.checked_sub(c_index_min)
 			.expect("Proofs can't be valid with bogus ceremony index; qed");
 

--- a/scheduler/src/lib.rs
+++ b/scheduler/src/lib.rs
@@ -110,7 +110,10 @@ pub mod pallet {
 		StorageMap<_, Blake2_128Concat, CeremonyPhaseType, T::Moment, ValueQuery>;
 
 	#[pallet::genesis_config]
-	pub struct GenesisConfig<T: Config> {
+	pub struct GenesisConfig<T: Config>
+	where
+		<T as pallet_timestamp::Config>::Moment: MaybeSerializeDeserialize,
+	{
 		pub current_ceremony_index: CeremonyIndexType,
 		pub current_phase: CeremonyPhaseType,
 		pub ceremony_master: T::AccountId,
@@ -118,7 +121,10 @@ pub mod pallet {
 	}
 
 	#[cfg(feature = "std")]
-	impl<T: Config> Default for GenesisConfig<T> {
+	impl<T: Config> Default for GenesisConfig<T>
+	where
+		<T as pallet_timestamp::Config>::Moment: MaybeSerializeDeserialize,
+	{
 		fn default() -> Self {
 			Self {
 				current_ceremony_index: Default::default(),
@@ -130,37 +136,18 @@ pub mod pallet {
 	}
 
 	#[pallet::genesis_build]
-	impl<T: Config> GenesisBuild<T> for GenesisConfig<T> {
+	impl<T: Config> GenesisBuild<T> for GenesisConfig<T>
+	where
+		<T as pallet_timestamp::Config>::Moment: MaybeSerializeDeserialize,
+	{
 		fn build(&self) {
 			{
-				let data = &self.current_ceremony_index;
-				let v: &CeremonyIndexType = data;
-				<CurrentCeremonyIndex<T> as frame_support::storage::StorageValue<
-					CeremonyIndexType,
-				>>::put::<&CeremonyIndexType>(v);
-			}
-			{
-				let data = &self.current_phase;
-				let v: &CeremonyPhaseType = data;
-				<CurrentPhase<T> as frame_support::storage::StorageValue<CeremonyPhaseType>>::put::<
-					&CeremonyPhaseType,
-				>(v);
-			}
-			{
-				let data = &self.ceremony_master;
-				let v: &T::AccountId = data;
-				<CeremonyMaster<T> as frame_support::storage::StorageValue<T::AccountId>>::put::<
-					&T::AccountId,
-				>(v);
-			}
-			{
-				let data = &self.phase_durations;
-				let data: &frame_support::sp_std::vec::Vec<(CeremonyPhaseType, T::Moment)> = data;
-				data.iter().for_each(|(k, v)| {
-					<PhaseDurations<T> as frame_support::storage::StorageMap<
-						CeremonyPhaseType,
-						T::Moment,
-					>>::insert::<&CeremonyPhaseType, &T::Moment>(k, v);
+				<CurrentCeremonyIndex<T>>::put(&self.current_ceremony_index);
+				<CurrentPhase<T>>::put(&self.current_phase);
+				<CeremonyMaster<T>>::put(&self.ceremony_master);
+
+				self.phase_durations.iter().for_each(|(k, v)| {
+					<PhaseDurations<T>>::insert(k, v);
 				});
 			}
 		}

--- a/scheduler/src/lib.rs
+++ b/scheduler/src/lib.rs
@@ -141,15 +141,13 @@ pub mod pallet {
 		<T as pallet_timestamp::Config>::Moment: MaybeSerializeDeserialize,
 	{
 		fn build(&self) {
-			{
-				<CurrentCeremonyIndex<T>>::put(&self.current_ceremony_index);
-				<CurrentPhase<T>>::put(&self.current_phase);
-				<CeremonyMaster<T>>::put(&self.ceremony_master);
+			<CurrentCeremonyIndex<T>>::put(&self.current_ceremony_index);
+			<CurrentPhase<T>>::put(&self.current_phase);
+			<CeremonyMaster<T>>::put(&self.ceremony_master);
 
-				self.phase_durations.iter().for_each(|(k, v)| {
-					<PhaseDurations<T>>::insert(k, v);
-				});
-			}
+			self.phase_durations.iter().for_each(|(k, v)| {
+				<PhaseDurations<T>>::insert(k, v);
+			});
 		}
 	}
 

--- a/scheduler/src/lib.rs
+++ b/scheduler/src/lib.rs
@@ -61,13 +61,13 @@ pub mod pallet {
 	#[pallet::event]
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
 	pub enum Event {
-		/// Phase changed to. `[new phase]`
+		/// Phase changed to `[new phase]`
 		PhaseChangedTo(CeremonyPhaseType),
 	}
 
 	#[pallet::error]
 	pub enum Error<T> {
-		/// sender doesn't have the necessary authority to perform action
+		/// Sender doesn't have the necessary authority to perform action
 		AuthorizationRequired,
 	}
 

--- a/scheduler/src/mock.rs
+++ b/scheduler/src/mock.rs
@@ -17,10 +17,9 @@
 //! Mock runtime for the encointer_scheduler module
 
 pub use crate as dut;
-
-use test_utils::*;
-
 use encointer_primitives::scheduler::CeremonyPhaseType;
+use frame_support::pallet_prelude::GenesisBuild;
+use test_utils::*;
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<TestRuntime>;
 type Block = frame_system::mocking::MockBlock<TestRuntime>;

--- a/scheduler/src/tests.rs
+++ b/scheduler/src/tests.rs
@@ -18,19 +18,17 @@ use crate::{
 	mock::{master, new_test_ext, Origin, System, TestRuntime, Timestamp},
 	CeremonyPhaseType,
 };
-
 use frame_support::{
 	assert_ok,
 	traits::{OnFinalize, OnInitialize},
 };
 use std::ops::Rem;
-
 use test_utils::*;
 
 const TEN_MIN: u64 = 600_000;
 const ONE_DAY: u64 = 86_400_000;
 
-type EncointerScheduler = crate::Module<TestRuntime>;
+type EncointerScheduler = crate::Pallet<TestRuntime>;
 
 /// Run until a particular block.
 pub fn run_to_block(n: u64) {


### PR DESCRIPTION
Metadata changed only in one detail: the error type was `null` because we forgot to put the error type in the `decl_module` before. Now it is defined, which is a good thing. Nothing should break with this.