### PR TITLE
Council-permissioned communities and ceremony management

### DIFF
--- a/balances/src/mock.rs
+++ b/balances/src/mock.rs
@@ -38,7 +38,7 @@ frame_support::construct_runtime!(
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},
 		EncointerScheduler: encointer_scheduler::{Pallet, Call, Storage, Config<T>, Event},
-		EncointerCommunities: encointer_communities::{Pallet, Call, Storage, Config<T>, Event<T>},
+		EncointerCommunities: encointer_communities::{Pallet, Call, Storage, Event<T>},
 		EncointerBalances: dut::{Pallet, Call, Storage, Event<T>},
 	}
 );

--- a/bazaar/src/mock.rs
+++ b/bazaar/src/mock.rs
@@ -34,7 +34,7 @@ frame_support::construct_runtime!(
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},
 		EncointerScheduler: encointer_scheduler::{Pallet, Call, Storage, Config<T>, Event},
-		EncointerCommunities: encointer_communities::{Pallet, Call, Storage, Config<T>, Event<T>},
+		EncointerCommunities: encointer_communities::{Pallet, Call, Storage, Event<T>},
 		EncointerBalances: encointer_balances::{Pallet, Call, Storage, Event<T>},
 		EncointerBazaar: dut::{Pallet, Call, Storage, Event<T>},
 	}

--- a/ceremonies/src/lib.rs
+++ b/ceremonies/src/lib.rs
@@ -90,28 +90,6 @@ pub mod pallet {
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
 		#[pallet::weight(10_000)]
-		pub fn grant_reputation(
-			origin: OriginFor<T>,
-			cid: CommunityIdentifier,
-			reputable: T::AccountId,
-		) -> DispatchResultWithPostInfo {
-			let sender = ensure_signed(origin)?;
-
-			let master = <encointer_scheduler::Pallet<T>>::ceremony_master()
-				.ok_or(Error::<T>::AuthorizationRequired)?;
-			ensure!(sender == master, Error::<T>::AuthorizationRequired);
-
-			let cindex = <encointer_scheduler::Pallet<T>>::current_ceremony_index();
-			<ParticipantReputation<T>>::insert(
-				&(cid, cindex - 1),
-				reputable,
-				Reputation::VerifiedUnlinked,
-			); //safe; cindex comes from within, will not overflow at +1/d
-			info!(target: LOG, "granting reputation to {:?}", sender);
-			Ok(().into())
-		}
-
-		#[pallet::weight(10_000)]
 		pub fn register_participant(
 			origin: OriginFor<T>,
 			cid: CommunityIdentifier,

--- a/ceremonies/src/mock.rs
+++ b/ceremonies/src/mock.rs
@@ -43,7 +43,7 @@ frame_support::construct_runtime!(
 		Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},
 		EncointerScheduler: encointer_scheduler::{Pallet, Call, Storage, Config<T>, Event},
 		EncointerCeremonies: dut::{Pallet, Call, Storage, Config<T>, Event<T>},
-		EncointerCommunities: encointer_communities::{Pallet, Call, Storage, Config<T>, Event<T>},
+		EncointerCommunities: encointer_communities::{Pallet, Call, Storage, Event<T>},
 		EncointerBalances: encointer_balances::{Pallet, Call, Storage, Event<T>},
 	}
 );
@@ -77,11 +77,7 @@ impl_encointer_balances!(TestRuntime);
 // genesis values
 pub fn new_test_ext() -> sp_io::TestExternalities {
 	let mut t = frame_system::GenesisConfig::default().build_storage::<TestRuntime>().unwrap();
-	encointer_communities::GenesisConfig::<TestRuntime> {
-		community_master: Some(AccountKeyring::Alice.to_account_id()),
-	}
-	.assimilate_storage(&mut t)
-	.unwrap();
+
 	encointer_scheduler::GenesisConfig::<TestRuntime> {
 		current_phase: CeremonyPhaseType::REGISTERING,
 		current_ceremony_index: 1,

--- a/ceremonies/src/mock.rs
+++ b/ceremonies/src/mock.rs
@@ -85,7 +85,6 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 	encointer_scheduler::GenesisConfig::<TestRuntime> {
 		current_phase: CeremonyPhaseType::REGISTERING,
 		current_ceremony_index: 1,
-		ceremony_master: Some(AccountKeyring::Alice.to_account_id()),
 		phase_durations: vec![
 			(CeremonyPhaseType::REGISTERING, ONE_DAY),
 			(CeremonyPhaseType::ASSIGNING, ONE_DAY),

--- a/ceremonies/src/tests.rs
+++ b/ceremonies/src/tests.rs
@@ -864,21 +864,6 @@ fn bootstrapping_works() {
 }
 
 #[test]
-fn grant_reputation_works() {
-	new_test_ext().execute_with(|| {
-		let cid = perform_bootstrapping_ceremony(None, 1);
-		let master = AccountId::from(AccountKeyring::Alice);
-		// a non-bootstrapper
-		let zoran = sr25519::Pair::from_entropy(&[9u8; 32], None).0;
-		assert_ok!(EncointerCeremonies::grant_reputation(
-			Origin::signed(master.clone()),
-			cid,
-			account_id(&zoran)
-		));
-	});
-}
-
-#[test]
 fn register_with_reputation_works() {
 	new_test_ext().execute_with(|| {
 		let cid = perform_bootstrapping_ceremony(None, 1);

--- a/communities/src/lib.rs
+++ b/communities/src/lib.rs
@@ -343,35 +343,6 @@ pub mod pallet {
 	#[pallet::getter(fn nominal_income)]
 	pub type NominalIncome<T: Config> =
 		StorageMap<_, Blake2_128Concat, CommunityIdentifier, NominalIncomeType, ValueQuery>;
-
-	#[pallet::storage]
-	#[pallet::getter(fn community_master)]
-	pub(super) type CommunityMaster<T: Config> = StorageValue<_, T::AccountId, OptionQuery>;
-
-	#[pallet::genesis_config]
-	pub struct GenesisConfig<T: Config> {
-		pub community_master: Option<T::AccountId>,
-	}
-
-	#[cfg(feature = "std")]
-	impl<T: Config> Default for GenesisConfig<T> {
-		fn default() -> Self {
-			Self { community_master: None }
-		}
-	}
-
-	#[pallet::genesis_build]
-	impl<T: Config> GenesisBuild<T> for GenesisConfig<T> {
-		fn build(&self) {
-			if let Some(ref community_master) = self.community_master {
-				// First I thought, it might be sensible to put an expect here. However, one can always
-				// edit the genesis config afterwards, so we can't really prevent here anything.
-				//
-				// substrate does the same in the sudo pallet.
-				<CommunityMaster<T>>::put(community_master);
-			}
-		}
-	}
 }
 
 impl<T: Config> Pallet<T> {

--- a/communities/src/lib.rs
+++ b/communities/src/lib.rs
@@ -62,7 +62,7 @@ pub mod pallet {
 		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
 
 		/// Required origin for adding or updating a community (though can always be Root).
-		type CouncilOrigin: EnsureOrigin<Self::Origin>;
+		type CommunityMaster: EnsureOrigin<Self::Origin>;
 
 		#[pallet::constant]
 		type MinSolarTripTimeS: Get<u32>; // [s] minimum adversary trip time between two locations measured in local (solar) time.
@@ -74,7 +74,7 @@ pub mod pallet {
 	impl<T: Config> Pallet<T> {
 		/// Add a new community.
 		///
-		/// May only be called from `T::CouncilOrigin`.
+		/// May only be called from `T::CommunityMaster`.
 		#[pallet::weight(10_000)]
 		pub fn new_community(
 			origin: OriginFor<T>,
@@ -84,7 +84,7 @@ pub mod pallet {
 			demurrage: Option<Demurrage>,
 			nominal_income: Option<NominalIncomeType>,
 		) -> DispatchResultWithPostInfo {
-			T::CouncilOrigin::ensure_origin(origin)?;
+			T::CommunityMaster::ensure_origin(origin)?;
 			Self::validate_bootstrappers(&bootstrappers)?;
 			community_metadata
 				.validate()
@@ -196,14 +196,14 @@ pub mod pallet {
 
 		/// Update the metadata of the community with `cid`.
 		///
-		/// May only be called from `T::CouncilOrigin`.
+		/// May only be called from `T::CommunityMaster`.
 		#[pallet::weight(10_000)]
 		pub fn update_community_metadata(
 			origin: OriginFor<T>,
 			cid: CommunityIdentifier,
 			community_metadata: CommunityMetadataType,
 		) -> DispatchResultWithPostInfo {
-			T::CouncilOrigin::ensure_origin(origin)?;
+			T::CommunityMaster::ensure_origin(origin)?;
 
 			Self::ensure_cid_exists(&cid)?;
 			community_metadata
@@ -226,7 +226,7 @@ pub mod pallet {
 			cid: CommunityIdentifier,
 			demurrage: BalanceType,
 		) -> DispatchResultWithPostInfo {
-			T::CouncilOrigin::ensure_origin(origin)?;
+			T::CommunityMaster::ensure_origin(origin)?;
 
 			Self::ensure_cid_exists(&cid)?;
 			validate_demurrage(&demurrage).map_err(|_| <Error<T>>::InvalidDemurrage)?;
@@ -244,7 +244,7 @@ pub mod pallet {
 			cid: CommunityIdentifier,
 			nominal_income: NominalIncomeType,
 		) -> DispatchResultWithPostInfo {
-			T::CouncilOrigin::ensure_origin(origin)?;
+			T::CommunityMaster::ensure_origin(origin)?;
 
 			Self::ensure_cid_exists(&cid)?;
 			validate_nominal_income(&nominal_income)

--- a/communities/src/lib.rs
+++ b/communities/src/lib.rs
@@ -36,7 +36,7 @@ use encointer_primitives::{
 	scheduler::CeremonyPhaseType,
 };
 use frame_support::{ensure, traits::Get};
-use frame_system::{ensure_root, ensure_signed};
+use frame_system::ensure_signed;
 use log::{info, warn};
 use sp_runtime::{DispatchResult, SaturatedConversion};
 use sp_std::{prelude::*, result::Result};
@@ -226,7 +226,8 @@ pub mod pallet {
 			cid: CommunityIdentifier,
 			demurrage: BalanceType,
 		) -> DispatchResultWithPostInfo {
-			ensure_root(origin)?;
+			T::CouncilOrigin::ensure_origin(origin)?;
+
 			Self::ensure_cid_exists(&cid)?;
 			validate_demurrage(&demurrage).map_err(|_| <Error<T>>::InvalidDemurrage)?;
 			Self::ensure_cid_exists(&cid)?;
@@ -243,7 +244,8 @@ pub mod pallet {
 			cid: CommunityIdentifier,
 			nominal_income: NominalIncomeType,
 		) -> DispatchResultWithPostInfo {
-			ensure_root(origin)?;
+			T::CouncilOrigin::ensure_origin(origin)?;
+
 			Self::ensure_cid_exists(&cid)?;
 			validate_nominal_income(&nominal_income)
 				.map_err(|_| <Error<T>>::InvalidNominalIncome)?;

--- a/communities/src/mock.rs
+++ b/communities/src/mock.rs
@@ -40,7 +40,7 @@ frame_support::construct_runtime!(
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},
 		EncointerScheduler: encointer_scheduler::{Pallet, Call, Storage, Config<T>, Event},
-		EncointerCommunities: dut::{Pallet, Call, Storage, Config<T>, Event<T>},
+		EncointerCommunities: dut::{Pallet, Call, Storage, Event<T>},
 	}
 );
 
@@ -59,11 +59,6 @@ impl_encointer_scheduler!(TestRuntime);
 // genesis values
 pub fn new_test_ext() -> sp_io::TestExternalities {
 	let mut t = frame_system::GenesisConfig::default().build_storage::<TestRuntime>().unwrap();
-	dut::GenesisConfig::<TestRuntime> {
-		community_master: Some(AccountKeyring::Alice.to_account_id()),
-	}
-	.assimilate_storage(&mut t)
-	.unwrap();
 
 	encointer_scheduler::GenesisConfig::<TestRuntime> {
 		current_phase: CeremonyPhaseType::REGISTERING,

--- a/communities/src/mock.rs
+++ b/communities/src/mock.rs
@@ -46,6 +46,7 @@ frame_support::construct_runtime!(
 
 impl dut::Config for TestRuntime {
 	type Event = Event;
+	type CouncilOrigin = EnsureAlice;
 	type MinSolarTripTimeS = MinSolarTripTimeS;
 	type MaxSpeedMps = MaxSpeedMps;
 }

--- a/communities/src/mock.rs
+++ b/communities/src/mock.rs
@@ -68,7 +68,6 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 	encointer_scheduler::GenesisConfig::<TestRuntime> {
 		current_phase: CeremonyPhaseType::REGISTERING,
 		current_ceremony_index: 1,
-		ceremony_master: Some(AccountKeyring::Alice.to_account_id()),
 		phase_durations: vec![
 			(CeremonyPhaseType::REGISTERING, ONE_DAY),
 			(CeremonyPhaseType::ASSIGNING, ONE_DAY),

--- a/communities/src/mock.rs
+++ b/communities/src/mock.rs
@@ -46,7 +46,7 @@ frame_support::construct_runtime!(
 
 impl dut::Config for TestRuntime {
 	type Event = Event;
-	type CouncilOrigin = EnsureAlice;
+	type CommunityMaster = EnsureAlice;
 	type MinSolarTripTimeS = MinSolarTripTimeS;
 	type MaxSpeedMps = MaxSpeedMps;
 }

--- a/communities/src/tests.rs
+++ b/communities/src/tests.rs
@@ -19,6 +19,7 @@ use approx::assert_abs_diff_eq;
 use frame_support::assert_ok;
 use mock::{dut, new_test_ext, EncointerCommunities, Origin, TestRuntime};
 use sp_core::sr25519;
+use sp_runtime::DispatchError;
 
 use test_utils::{
 	helpers::{account_id, bootstrappers},
@@ -152,6 +153,26 @@ fn new_community_works() {
 		assert_eq!(EncointerCommunities::bootstrappers(&cid), bs);
 		assert_eq!(EncointerCommunities::bootstrappers(&cid), bs);
 		assert_eq!(EncointerCommunities::community_metadata(&cid), community_meta);
+	});
+}
+
+#[test]
+fn new_community_errs_with_invalid_origin() {
+	new_test_ext().execute_with(|| {
+		let bob = AccountId::from(AccountKeyring::Bob);
+		assert_eq!(
+			EncointerCommunities::new_community(
+				Origin::signed(bob),
+				Location::default(),
+				vec![],
+				CommunityMetadataType::default(),
+				None,
+				None,
+			)
+			.unwrap_err()
+			.error,
+			DispatchError::BadOrigin
+		);
 	});
 }
 

--- a/communities/src/tests.rs
+++ b/communities/src/tests.rs
@@ -16,13 +16,13 @@
 
 use super::*;
 use approx::assert_abs_diff_eq;
-use frame_support::{assert_ok, pallet_prelude::DispatchResultWithPostInfo};
+use frame_support::assert_ok;
 use mock::{dut, new_test_ext, EncointerCommunities, Origin, TestRuntime};
 use sp_core::sr25519;
 use sp_runtime::DispatchError;
 
 use test_utils::{
-	helpers::{account_id, bootstrappers},
+	helpers::{account_id, assert_dispatch_err, bootstrappers},
 	*,
 };
 
@@ -30,10 +30,6 @@ type T = Degree;
 
 fn string_to_geohash(s: &str) -> GeoHash {
 	GeoHash::try_from(s).unwrap()
-}
-
-fn assert_dispatch_err(actual: DispatchResultWithPostInfo, expected: DispatchError) {
-	assert_eq!(actual.unwrap_err().error, expected)
 }
 
 /// register a simple test community with a specified location and defined bootstrappers

--- a/communities/src/tests.rs
+++ b/communities/src/tests.rs
@@ -237,6 +237,38 @@ fn two_communities_in_same_bucket_works() {
 }
 
 #[test]
+fn updating_community_metadata_works() {
+	new_test_ext().execute_with(|| {
+		let cid = register_test_community(None, 0.0, 0.0);
+		let new_metadata = CommunityMetadataType { name: "New".into(), ..Default::default() };
+
+		assert_ok!(EncointerCommunities::update_community_metadata(
+			Origin::signed(AccountKeyring::Alice.into()),
+			cid,
+			new_metadata.clone(),
+		));
+		assert_eq!(CommunityMetadata::<TestRuntime>::try_get(&cid).unwrap(), new_metadata);
+	});
+}
+
+#[test]
+fn updating_community_errs_with_invalid_origin() {
+	new_test_ext().execute_with(|| {
+		let cid = register_test_community(None, 0.0, 0.0);
+		let new_metadata = CommunityMetadataType { name: "New".into(), ..Default::default() };
+
+		assert_dispatch_err(
+			EncointerCommunities::update_community_metadata(
+				Origin::signed(AccountKeyring::Bob.into()),
+				cid,
+				new_metadata.clone(),
+			),
+			DispatchError::BadOrigin,
+		);
+	});
+}
+
+#[test]
 fn updating_nominal_income_works() {
 	new_test_ext().execute_with(|| {
 		let cid = register_test_community(None, 0.0, 0.0);

--- a/communities/src/tests.rs
+++ b/communities/src/tests.rs
@@ -240,7 +240,7 @@ fn updating_nominal_income_works() {
 		let cid = register_test_community(None, 0.0, 0.0);
 		assert!(NominalIncome::<TestRuntime>::try_get(cid).is_err());
 		assert_ok!(EncointerCommunities::update_nominal_income(
-			Origin::root(),
+			Origin::signed(AccountKeyring::Alice.into()),
 			cid,
 			BalanceType::from_num(1.1),
 		));
@@ -257,7 +257,7 @@ fn updating_demurrage_works() {
 		let cid = register_test_community(None, 0.0, 0.0);
 		assert!(DemurragePerBlock::<TestRuntime>::try_get(cid).is_err());
 		assert_ok!(EncointerCommunities::update_demurrage(
-			Origin::root(),
+			Origin::signed(AccountKeyring::Alice.into()),
 			cid,
 			Demurrage::from_num(0.0001),
 		));

--- a/communities/src/tests.rs
+++ b/communities/src/tests.rs
@@ -373,6 +373,21 @@ fn add_location_works() {
 }
 
 #[test]
+fn add_new_location_errs_with_invalid_origin() {
+	new_test_ext().execute_with(|| {
+		let cid = register_test_community(None, 0.0, 0.0);
+		assert_dispatch_err(
+			EncointerCommunities::add_location(
+				Origin::signed(AccountKeyring::Bob.into()),
+				cid,
+				Location::default(),
+			),
+			DispatchError::BadOrigin,
+		);
+	});
+}
+
+#[test]
 fn remove_community_works() {
 	new_test_ext().execute_with(|| {
 		let cid = register_test_community(None, 0.0, 0.0);
@@ -472,6 +487,21 @@ fn remove_location_works() {
 		assert_eq!(
 			EncointerCommunities::cids_by_geohash(&geo_hash),
 			Vec::<CommunityIdentifier>::new()
+		);
+	});
+}
+
+#[test]
+fn remove_location_errs_with_invalid_origin() {
+	new_test_ext().execute_with(|| {
+		let cid = register_test_community(None, 0.0, 0.0);
+		assert_dispatch_err(
+			EncointerCommunities::remove_location(
+				Origin::signed(AccountKeyring::Bob.into()),
+				cid,
+				Location::default(),
+			),
+			DispatchError::BadOrigin,
 		);
 	});
 }

--- a/personhood-oracle/src/mock.rs
+++ b/personhood-oracle/src/mock.rs
@@ -37,7 +37,7 @@ frame_support::construct_runtime!(
 		Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},
 		EncointerScheduler: encointer_scheduler::{Pallet, Call, Storage, Config<T>, Event},
 		EncointerCeremonies: encointer_ceremonies::{Pallet, Call, Storage, Config<T>, Event<T>},
-		EncointerCommunities: encointer_communities::{Pallet, Call, Storage, Config<T>, Event<T>},
+		EncointerCommunities: encointer_communities::{Pallet, Call, Storage, Event<T>},
 		EncointerBalances: encointer_balances::{Pallet, Call, Storage, Event<T>},
 		EncointerPersonhoodOracle: dut::{Pallet, Call, Event},
 	}
@@ -65,11 +65,7 @@ impl_encointer_ceremonies!(TestRuntime);
 // genesis values
 pub fn new_test_ext() -> sp_io::TestExternalities {
 	let mut t = frame_system::GenesisConfig::default().build_storage::<TestRuntime>().unwrap();
-	encointer_communities::GenesisConfig::<TestRuntime> {
-		community_master: Some(AccountKeyring::Alice.to_account_id()),
-	}
-	.assimilate_storage(&mut t)
-	.unwrap();
+
 	encointer_scheduler::GenesisConfig::<TestRuntime> {
 		current_phase: CeremonyPhaseType::REGISTERING,
 		current_ceremony_index: 1,

--- a/personhood-oracle/src/mock.rs
+++ b/personhood-oracle/src/mock.rs
@@ -73,7 +73,6 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 	encointer_scheduler::GenesisConfig::<TestRuntime> {
 		current_phase: CeremonyPhaseType::REGISTERING,
 		current_ceremony_index: 1,
-		ceremony_master: Some(AccountKeyring::Alice.to_account_id()),
 		phase_durations: vec![
 			(CeremonyPhaseType::REGISTERING, ONE_DAY),
 			(CeremonyPhaseType::ASSIGNING, ONE_DAY),

--- a/scheduler/src/lib.rs
+++ b/scheduler/src/lib.rs
@@ -53,7 +53,7 @@ pub mod pallet {
 		type Event: From<Event> + IsType<<Self as frame_system::Config>::Event>;
 
 		/// Required origin to interfere with the scheduling (though can always be Root)
-		type CeremonyMasterOrigin: EnsureOrigin<Self::Origin>;
+		type CeremonyMaster: EnsureOrigin<Self::Origin>;
 
 		type OnCeremonyPhaseChange: OnCeremonyPhaseChange;
 		#[pallet::constant]
@@ -144,10 +144,10 @@ pub mod pallet {
 	impl<T: Config> Pallet<T> {
 		/// Manually transition to next phase without affecting the ceremony rhythm
 		///
-		/// May only be called from `T::CeremonyMasterOrigin`.
+		/// May only be called from `T::CeremonyMaster`.
 		#[pallet::weight((1000, DispatchClass::Operational, Pays::No))]
 		pub fn next_phase(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
-			T::CeremonyMasterOrigin::ensure_origin(origin)?;
+			T::CeremonyMaster::ensure_origin(origin)?;
 
 			Self::progress_phase()?;
 			Ok(().into())
@@ -155,10 +155,10 @@ pub mod pallet {
 
 		/// Push next phase change by one entire day
 		///
-		/// May only be called from `T::CeremonyMasterOrigin`.
+		/// May only be called from `T::CeremonyMaster`.
 		#[pallet::weight((1000, DispatchClass::Operational, Pays::No))]
 		pub fn push_by_one_day(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
-			T::CeremonyMasterOrigin::ensure_origin(origin)?;
+			T::CeremonyMaster::ensure_origin(origin)?;
 
 			let tnext = Self::next_phase_timestamp().saturating_add(T::MomentsPerDay::get());
 			<NextPhaseTimestamp<T>>::put(tnext);

--- a/scheduler/src/mock.rs
+++ b/scheduler/src/mock.rs
@@ -42,6 +42,7 @@ frame_support::construct_runtime!(
 
 impl dut::Config for TestRuntime {
 	type Event = Event;
+	type CeremonyMasterOrigin = EnsureAlice;
 	type OnCeremonyPhaseChange = (); //OnCeremonyPhaseChange;
 	type MomentsPerDay = MomentsPerDay;
 }
@@ -56,7 +57,6 @@ pub fn new_test_ext(phase_duration: u64) -> sp_io::TestExternalities {
 	dut::GenesisConfig::<TestRuntime> {
 		current_phase: CeremonyPhaseType::REGISTERING,
 		current_ceremony_index: 1,
-		ceremony_master: Some(master()),
 		phase_durations: vec![
 			(CeremonyPhaseType::REGISTERING, phase_duration),
 			(CeremonyPhaseType::ASSIGNING, phase_duration),

--- a/scheduler/src/mock.rs
+++ b/scheduler/src/mock.rs
@@ -42,7 +42,7 @@ frame_support::construct_runtime!(
 
 impl dut::Config for TestRuntime {
 	type Event = Event;
-	type CeremonyMasterOrigin = EnsureAlice;
+	type CeremonyMaster = EnsureAlice;
 	type OnCeremonyPhaseChange = (); //OnCeremonyPhaseChange;
 	type MomentsPerDay = MomentsPerDay;
 }

--- a/scheduler/src/tests.rs
+++ b/scheduler/src/tests.rs
@@ -22,8 +22,9 @@ use frame_support::{
 	assert_ok,
 	traits::{OnFinalize, OnInitialize},
 };
+use sp_runtime::DispatchError;
 use std::ops::Rem;
-use test_utils::*;
+use test_utils::{helpers::assert_dispatch_err, *};
 
 const TEN_MIN: u64 = 600_000;
 const ONE_DAY: u64 = 86_400_000;
@@ -64,15 +65,20 @@ fn ceremony_phase_statemachine_works() {
 #[test]
 fn next_phase_errs_on_bad_origin() {
 	new_test_ext(ONE_DAY).execute_with(|| {
-		assert_eq!(EncointerScheduler::current_phase(), CeremonyPhaseType::REGISTERING);
-		assert_eq!(EncointerScheduler::current_ceremony_index(), 1);
-		assert_ok!(EncointerScheduler::next_phase(Origin::signed(master())));
-		assert_eq!(EncointerScheduler::current_phase(), CeremonyPhaseType::ASSIGNING);
-		assert_ok!(EncointerScheduler::next_phase(Origin::signed(master())));
-		assert_eq!(EncointerScheduler::current_phase(), CeremonyPhaseType::ATTESTING);
-		assert_ok!(EncointerScheduler::next_phase(Origin::signed(master())));
-		assert_eq!(EncointerScheduler::current_phase(), CeremonyPhaseType::REGISTERING);
-		assert_eq!(EncointerScheduler::current_ceremony_index(), 2);
+		assert_dispatch_err(
+			EncointerScheduler::next_phase(Origin::signed(AccountKeyring::Bob.into())),
+			DispatchError::BadOrigin,
+		);
+	});
+}
+
+#[test]
+fn push_by_one_day_errs_on_bad_origin() {
+	new_test_ext(ONE_DAY).execute_with(|| {
+		assert_dispatch_err(
+			EncointerScheduler::push_by_one_day(Origin::signed(AccountKeyring::Bob.into())),
+			DispatchError::BadOrigin,
+		);
 	});
 }
 

--- a/scheduler/src/tests.rs
+++ b/scheduler/src/tests.rs
@@ -63,7 +63,7 @@ fn ceremony_phase_statemachine_works() {
 }
 
 #[test]
-fn next_phase_errs_on_bad_origin() {
+fn next_phase_errs_with_bad_origin() {
 	new_test_ext(ONE_DAY).execute_with(|| {
 		assert_dispatch_err(
 			EncointerScheduler::next_phase(Origin::signed(AccountKeyring::Bob.into())),
@@ -73,7 +73,7 @@ fn next_phase_errs_on_bad_origin() {
 }
 
 #[test]
-fn push_by_one_day_errs_on_bad_origin() {
+fn push_by_one_day_errs_with_bad_origin() {
 	new_test_ext(ONE_DAY).execute_with(|| {
 		assert_dispatch_err(
 			EncointerScheduler::push_by_one_day(Origin::signed(AccountKeyring::Bob.into())),

--- a/scheduler/src/tests.rs
+++ b/scheduler/src/tests.rs
@@ -62,6 +62,21 @@ fn ceremony_phase_statemachine_works() {
 }
 
 #[test]
+fn next_phase_errs_on_bad_origin() {
+	new_test_ext(ONE_DAY).execute_with(|| {
+		assert_eq!(EncointerScheduler::current_phase(), CeremonyPhaseType::REGISTERING);
+		assert_eq!(EncointerScheduler::current_ceremony_index(), 1);
+		assert_ok!(EncointerScheduler::next_phase(Origin::signed(master())));
+		assert_eq!(EncointerScheduler::current_phase(), CeremonyPhaseType::ASSIGNING);
+		assert_ok!(EncointerScheduler::next_phase(Origin::signed(master())));
+		assert_eq!(EncointerScheduler::current_phase(), CeremonyPhaseType::ATTESTING);
+		assert_ok!(EncointerScheduler::next_phase(Origin::signed(master())));
+		assert_eq!(EncointerScheduler::current_phase(), CeremonyPhaseType::REGISTERING);
+		assert_eq!(EncointerScheduler::current_ceremony_index(), 2);
+	});
+}
+
+#[test]
 fn timestamp_callback_works() {
 	new_test_ext(ONE_DAY).execute_with(|| {
 		//large offset since 1970 to when first block is generated

--- a/test-utils/src/helpers.rs
+++ b/test-utils/src/helpers.rs
@@ -16,9 +16,10 @@
 
 use crate::AccountId;
 use encointer_primitives::communities::{CommunityIdentifier, Degree, Location};
-use frame_support::traits::OriginTrait;
+use frame_support::{pallet_prelude::DispatchResultWithPostInfo, traits::OriginTrait};
 use sp_core::{sr25519, Pair};
 use sp_keyring::AccountKeyring;
+use sp_runtime::DispatchError;
 
 /// shorthand to convert Pair to AccountId
 pub fn account_id(pair: &sr25519::Pair) -> AccountId {
@@ -80,4 +81,8 @@ pub fn assert_last_event<T: frame_system::Config>(
 	// compare to the last event record
 	let frame_system::EventRecord { event, .. } = &events[events.len() - 1];
 	assert_eq!(event, &system_event);
+}
+
+pub fn assert_dispatch_err(actual: DispatchResultWithPostInfo, expected: DispatchError) {
+	assert_eq!(actual.unwrap_err().error, expected)
 }

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -190,6 +190,7 @@ macro_rules! impl_encointer_communities {
 	($t:ident) => {
 		impl encointer_communities::Config for $t {
 			type Event = Event;
+			type CouncilOrigin = EnsureAlice;
 			type MinSolarTripTimeS = MinSolarTripTimeS;
 			type MaxSpeedMps = MaxSpeedMps;
 		}

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -237,7 +237,7 @@ macro_rules! impl_encointer_scheduler {
 	($t:ident, $ceremonies:ident) => {
 		impl encointer_scheduler::Config for $t {
 			type Event = Event;
-			type CeremonyMasterOrigin = EnsureAlice;
+			type CeremonyMaster = EnsureAlice;
 			type OnCeremonyPhaseChange = $ceremonies; //OnCeremonyPhaseChange;
 			type MomentsPerDay = MomentsPerDay;
 		}
@@ -245,7 +245,7 @@ macro_rules! impl_encointer_scheduler {
 	($t:ident) => {
 		impl encointer_scheduler::Config for $t {
 			type Event = Event;
-			type CeremonyMasterOrigin = EnsureAlice;
+			type CeremonyMaster = EnsureAlice;
 			type OnCeremonyPhaseChange = (); //OnCeremonyPhaseChange;
 			type MomentsPerDay = MomentsPerDay;
 		}

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -244,6 +244,7 @@ macro_rules! impl_encointer_scheduler {
 	($t:ident) => {
 		impl encointer_scheduler::Config for $t {
 			type Event = Event;
+			type CeremonyMasterOrigin = EnsureAlice;
 			type OnCeremonyPhaseChange = (); //OnCeremonyPhaseChange;
 			type MomentsPerDay = MomentsPerDay;
 		}

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -190,7 +190,7 @@ macro_rules! impl_encointer_communities {
 	($t:ident) => {
 		impl encointer_communities::Config for $t {
 			type Event = Event;
-			type CouncilOrigin = EnsureAlice;
+			type CommunityMaster = EnsureAlice;
 			type MinSolarTripTimeS = MinSolarTripTimeS;
 			type MaxSpeedMps = MaxSpeedMps;
 		}

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -262,5 +262,5 @@ ord_parameter_types! {
 	pub const Alice: AccountId32 = AccountId32::new([212, 53, 147, 199, 21, 253, 211, 28, 97, 20, 26, 189, 4, 169, 159, 214, 130, 44, 133, 88, 133, 76, 205, 227, 154, 86, 132, 231, 165, 109, 162, 125]);
 }
 
-/// Test origin for the communities pallet's `EnsureOrigin` associated type.
+/// Test origin for the pallet's `EnsureOrigin` associated type.
 pub type EnsureAlice = EnsureSignedBy<Alice, AccountId32>;

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -237,6 +237,7 @@ macro_rules! impl_encointer_scheduler {
 	($t:ident, $ceremonies:ident) => {
 		impl encointer_scheduler::Config for $t {
 			type Event = Event;
+			type CeremonyMasterOrigin = EnsureAlice;
 			type OnCeremonyPhaseChange = $ceremonies; //OnCeremonyPhaseChange;
 			type MomentsPerDay = MomentsPerDay;
 		}

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -19,8 +19,10 @@
 //extern crate node_primitives;
 
 use encointer_primitives::balances::{BalanceType, Demurrage};
-use frame_support::{parameter_types, traits::Get};
+use frame_support::{ord_parameter_types, parameter_types, traits::Get};
+use frame_system::EnsureSignedBy;
 use polkadot_parachain::primitives::Sibling;
+use sp_core::crypto::AccountId32;
 use sp_runtime::{generic, traits::IdentifyAccount, MultiSignature, Perbill};
 use std::cell::RefCell;
 use xcm::v1::NetworkId;
@@ -252,3 +254,10 @@ parameter_types! {
 }
 
 pub type LocationConverter = SiblingParachainConvertsVia<Sibling, AccountId>;
+
+ord_parameter_types! {
+	pub const Alice: AccountId32 = AccountId32::new([212, 53, 147, 199, 21, 253, 211, 28, 97, 20, 26, 189, 4, 169, 159, 214, 130, 44, 133, 88, 133, 76, 205, 227, 154, 86, 132, 231, 165, 109, 162, 125]);
+}
+
+/// Test origin for the communities pallet's `EnsureOrigin` associated type.
+pub type EnsureAlice = EnsureSignedBy<Alice, AccountId32>;


### PR DESCRIPTION
* Closes #77 

Changes:
* [communities]:
   * Replace `community_master` genesis field with `CommunityMaster` associated type
   * Some extrinsics require now `CommunityMaster` origin, which were unpermissioned before
* [scheduler]
   * Replace `ceremony_master` genesis field with `CeremonyMaster` associated type
* [ceremonies]
   * Remove `ceremonies::grant_reputation` extrinsic

**Note:** has not been tested with the node, but it would require some version bumping there, which would also require a further version bump in the api-client. (yes, again). So I suggest we merge that untested.