### PR TITLE
fix node build error because of missing vec

### DIFF
--- a/balances/src/lib.rs
+++ b/balances/src/lib.rs
@@ -25,8 +25,7 @@ use frame_support::{dispatch::DispatchResult, ensure, traits::Get};
 use frame_system::{self as frame_system, ensure_signed};
 use log::debug;
 use sp_runtime::traits::StaticLookup;
-use sp_std::convert::TryInto;
-use sp_std::{prelude::Vec, vec};
+use sp_std::{convert::TryInto, prelude::Vec, vec};
 
 // Logger target
 const LOG: &str = "encointer";

--- a/balances/src/lib.rs
+++ b/balances/src/lib.rs
@@ -26,6 +26,7 @@ use frame_system::{self as frame_system, ensure_signed};
 use log::debug;
 use sp_runtime::traits::StaticLookup;
 use sp_std::convert::TryInto;
+use sp_std::{prelude::Vec, vec};
 
 // Logger target
 const LOG: &str = "encointer";


### PR DESCRIPTION
this was necessary as the node build complained about missing `vec`

how could we ensure this wouldn't pass CI next time @clangenb ?
Also, pallets CI doesn't build no-default-features (even if it would, it wouldn't have detected this!)