### PR TITLE
[balances/#56] benchmark balances pallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3168,6 +3168,7 @@ version = "0.8.1"
 dependencies = [
  "approx",
  "encointer-primitives",
+ "frame-benchmarking",
  "frame-support",
  "frame-system",
  "log",

--- a/balances/Cargo.toml
+++ b/balances/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["encointer.org <alain@encointer.org> and Parity Technologies <admin@p
 edition = "2021"
 
 [dependencies]
+approx = "0.5.0"
 codec = { package = "parity-scale-codec", version = "2.3.1", default-features = false, features = ["derive"] }
 log = { version = "0.4.14", default-features = false }
 scale-info = { version = "1.0", default-features = false }
@@ -13,6 +14,7 @@ scale-info = { version = "1.0", default-features = false }
 encointer-primitives = { path = "../primitives", default-features = false }
 
 # substrate deps
+frame-benchmarking = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", default-features = false, optional = true, branch = "master" }
 frame-support = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", default-features = false, branch = "master" }
 frame-system = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", default-features = false, branch = "master" }
 sp-std = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", default-features = false, branch = "master" }
@@ -35,3 +37,5 @@ std = [
 	"sp-runtime/std",
 	"encointer-primitives/std",
 ]
+
+runtime-benchmarks = ["frame-benchmarking"]

--- a/balances/Cargo.toml
+++ b/balances/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["encointer.org <alain@encointer.org> and Parity Technologies <admin@p
 edition = "2021"
 
 [dependencies]
-approx = "0.5.0"
+approx = { version = "0.5.0", optional = true }
 codec = { package = "parity-scale-codec", version = "2.3.1", default-features = false, features = ["derive"] }
 log = { version = "0.4.14", default-features = false }
 scale-info = { version = "1.0", default-features = false }
@@ -38,4 +38,4 @@ std = [
 	"encointer-primitives/std",
 ]
 
-runtime-benchmarks = ["frame-benchmarking"]
+runtime-benchmarks = ["frame-benchmarking", "approx"]

--- a/balances/src/benchmarking.rs
+++ b/balances/src/benchmarking.rs
@@ -1,16 +1,11 @@
 use crate::*;
 use approx::assert_abs_diff_eq;
 use encointer_primitives::{
-	balances::{BalanceType, Demurrage},
+	balances::{BalanceType},
 	fixed::traits::LossyInto,
 };
 use frame_benchmarking::{account, benchmarks, impl_benchmark_test_suite};
-use frame_support::parameter_types;
 use frame_system::RawOrigin;
-
-parameter_types! {
-	pub const DefaultDemurrage: Demurrage = Demurrage::from_bits(0x0000000000000000000001E3F0A8A973_i128);
-}
 
 benchmarks! {
 	transfer {

--- a/balances/src/benchmarking.rs
+++ b/balances/src/benchmarking.rs
@@ -1,0 +1,32 @@
+use crate::*;
+use approx::assert_abs_diff_eq;
+use encointer_primitives::{
+	balances::{BalanceType, Demurrage},
+	fixed::traits::LossyInto,
+};
+use frame_benchmarking::{account, benchmarks, impl_benchmark_test_suite};
+use frame_support::parameter_types;
+use frame_system::RawOrigin;
+
+parameter_types! {
+	pub const DefaultDemurrage: Demurrage = Demurrage::from_bits(0x0000000000000000000001E3F0A8A973_i128);
+}
+
+benchmarks! {
+	transfer {
+		let cid = CommunityIdentifier::default();
+		let alice: T::AccountId = account("alice", 1, 1);
+		let bob: T::AccountId = account("bob", 2, 2);
+		let bob_lookup: <T::Lookup as StaticLookup>::Source = T::Lookup::unlookup(bob.clone());
+
+		Pallet::<T>::issue(cid, &alice, BalanceType::from_num(12i32)).ok();
+	}: _(RawOrigin::Signed(alice.clone()), bob_lookup, cid, BalanceType::from_num(10i32))
+	verify{
+		let balance_alice: f64 = Pallet::<T>::balance(cid, &alice).lossy_into();
+		assert_abs_diff_eq!(balance_alice, 2f64, epsilon= 0.0001);
+		let balance_bob: f64 = Pallet::<T>::balance(cid, &bob).lossy_into();
+		assert_abs_diff_eq!(balance_bob, 10f64, epsilon= 0.0001);
+	}
+}
+
+impl_benchmark_test_suite!(Pallet, crate::mock::new_test_ext(), crate::mock::TestRuntime);

--- a/balances/src/benchmarking.rs
+++ b/balances/src/benchmarking.rs
@@ -1,9 +1,6 @@
 use crate::*;
 use approx::assert_abs_diff_eq;
-use encointer_primitives::{
-	balances::{BalanceType},
-	fixed::traits::LossyInto,
-};
+use encointer_primitives::{balances::BalanceType, fixed::traits::LossyInto};
 use frame_benchmarking::{account, benchmarks, impl_benchmark_test_suite};
 use frame_system::RawOrigin;
 

--- a/balances/src/lib.rs
+++ b/balances/src/lib.rs
@@ -254,3 +254,6 @@ mod mock;
 
 #[cfg(test)]
 mod tests;
+
+#[cfg(feature = "runtime-benchmarks")]
+mod benchmarking;


### PR DESCRIPTION
benchmarks can be tested without building the node by running

```cargo test --features runtime-benchmarks --manifest-path balances/Cargo.toml -- benchmarking```

from the `pallets` repo root.