### PR TITLE
`ceremonies_getReputation` returns now `CeremonyIndex` too

### DIFF
--- a/ceremonies/rpc/runtime-api/src/lib.rs
+++ b/ceremonies/rpc/runtime-api/src/lib.rs
@@ -21,13 +21,13 @@
 #[cfg(not(feature = "std"))]
 use sp_std::vec::Vec;
 
-use encointer_primitives::ceremonies::{CommunityCeremony, Reputation};
+use encointer_primitives::ceremonies::{CeremonyIndexType, CommunityReputation};
 use sp_api::{Decode, Encode};
 
 sp_api::decl_runtime_apis! {
 	pub trait CeremoniesApi<AccountId>
 	where AccountId: Encode + Decode
 	{
-		fn get_reputations() -> Vec<(CommunityCeremony, AccountId, Reputation)>;
+		fn get_reputations(account: &AccountId) -> Vec<(CeremonyIndexType, CommunityReputation)>;
 	}
 }

--- a/ceremonies/src/lib.rs
+++ b/ceremonies/src/lib.rs
@@ -813,8 +813,13 @@ pub mod pallet {
 }
 
 impl<T: Config> Pallet<T> {
-	pub fn get_reputations() -> Vec<(CommunityCeremony, T::AccountId, Reputation)> {
-		return ParticipantReputation::<T>::iter().collect()
+	pub fn get_reputations(
+		account: &T::AccountId,
+	) -> Vec<(CeremonyIndexType, CommunityReputation)> {
+		return ParticipantReputation::<T>::iter()
+			.filter(|t| &t.1 == account)
+			.map(|t| (t.0 .1, CommunityReputation::new(t.0 .0, t.2)))
+			.collect()
 	}
 
 	fn register(

--- a/primitives/src/ceremonies.rs
+++ b/primitives/src/ceremonies.rs
@@ -14,18 +14,16 @@
 // You should have received a copy of the GNU General Public License
 // along with Encointer.  If not, see <http://www.gnu.org/licenses/>.
 
+#[cfg(feature = "serde_derive")]
+use serde::{Deserialize, Serialize};
+
+use crate::communities::{CommunityIdentifier, Location};
 use codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 use sp_core::{RuntimeDebug, H256};
 use sp_runtime::traits::{BlakeTwo256, Hash, IdentifyAccount, Verify};
 
-#[cfg(feature = "serde_derive")]
-use serde::{Deserialize, Serialize};
-
-use crate::{
-	communities::{CommunityIdentifier, Location},
-	scheduler::CeremonyIndexType,
-};
+pub use crate::scheduler::CeremonyIndexType;
 
 pub type ParticipantIndexType = u64;
 pub type MeetupIndexType = u64;
@@ -186,6 +184,22 @@ impl<Signature, AccountId, Moment> ClaimOfAttendance<Signature, AccountId, Momen
 			.as_ref()
 			.map(|sig| sig.verify(&self.payload_encoded()[..], &self.claimant_public))
 			.unwrap_or(false)
+	}
+}
+
+/// Reputation that is linked to a specific community
+#[derive(
+	Encode, Decode, Copy, Clone, PartialEq, Eq, Default, RuntimeDebug, TypeInfo, MaxEncodedLen,
+)]
+#[cfg_attr(feature = "serde_derive", derive(Serialize, Deserialize))]
+pub struct CommunityReputation {
+	pub community_identifier: CommunityIdentifier,
+	pub reputation: Reputation,
+}
+
+impl CommunityReputation {
+	pub fn new(community_identifier: CommunityIdentifier, reputation: Reputation) -> Self {
+		Self { community_identifier, reputation }
 	}
 }
 

--- a/primitives/src/ceremonies.rs
+++ b/primitives/src/ceremonies.rs
@@ -215,29 +215,6 @@ impl<Signature, AccountId: Clone + Encode> ProofOfAttendance<Signature, AccountI
 	}
 }
 
-#[cfg(test)]
-mod tests {
-	use super::*;
-	use test_utils::{AccountId, AccountKeyring, Moment, Signature};
-
-	#[test]
-	fn claim_verification_works() {
-		let alice = AccountKeyring::Alice.pair();
-		let claim = ClaimOfAttendance::<Signature, AccountId, Moment>::new_unsigned(
-			alice.public().into(),
-			1,
-			Default::default(),
-			1,
-			Default::default(),
-			Default::default(),
-			3,
-		)
-		.sign(&alice);
-
-		assert!(claim.verify_signature())
-	}
-}
-
 #[derive(
 	Encode, Decode, Default, Copy, Clone, PartialEq, Eq, RuntimeDebug, TypeInfo, MaxEncodedLen,
 )]
@@ -276,4 +253,27 @@ pub struct AssignmentParams {
 	/// Second random group element in the interval (0, m). For locations the closest prime to m,
 	/// with s2 < m.
 	pub s2: u64,
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use test_utils::{AccountId, AccountKeyring, Moment, Signature};
+
+	#[test]
+	fn claim_verification_works() {
+		let alice = AccountKeyring::Alice.pair();
+		let claim = ClaimOfAttendance::<Signature, AccountId, Moment>::new_unsigned(
+			alice.public().into(),
+			1,
+			Default::default(),
+			1,
+			Default::default(),
+			Default::default(),
+			3,
+		)
+		.sign(&alice);
+
+		assert!(claim.verify_signature())
+	}
 }


### PR DESCRIPTION
The RPC did not return meaningful values before. We could not infer the ceremony index the reputations were valid.
 
Now the return value has been changed to: `Vec<(CeremonyIndex, CommunityReputation)>`, where `CommunityReputation = { community_identifier, reputation }`.
