### PR TITLE
Fixes for node-integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3247,6 +3247,7 @@ dependencies = [
  "sp-application-crypto",
  "sp-core",
  "sp-io",
+ "sp-keystore",
  "sp-runtime",
  "sp-std",
  "test-utils",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3244,7 +3244,7 @@ dependencies = [
  "parity-scale-codec",
  "rstest",
  "scale-info",
- "sp-core",
+ "sp-application-crypto",
  "sp-io",
  "sp-runtime",
  "sp-std",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3245,6 +3245,7 @@ dependencies = [
  "rstest",
  "scale-info",
  "sp-application-crypto",
+ "sp-core",
  "sp-io",
  "sp-runtime",
  "sp-std",

--- a/bazaar/src/benchmarking.rs
+++ b/bazaar/src/benchmarking.rs
@@ -4,13 +4,14 @@ use encointer_primitives::communities::{
 };
 use frame_benchmarking::{account, benchmarks, impl_benchmark_test_suite};
 use frame_system::RawOrigin;
+use sp_std::borrow::ToOwned;
 
-fn test_url() -> String {
-	"https://test.com".to_string()
+fn test_url() -> PalletString {
+	"https://test.com".to_owned().into()
 }
 
-fn example_url() -> String {
-	"https://example.com".to_string()
+fn example_url() -> PalletString {
+	"https://example.com".to_owned().into()
 }
 
 fn create_community<T: Config>() -> CommunityIdentifier {

--- a/ceremonies/Cargo.toml
+++ b/ceremonies/Cargo.toml
@@ -17,19 +17,21 @@ encointer-communities = { package = "pallet-encointer-communities", path = "../c
 encointer-scheduler = { package = "pallet-encointer-scheduler", path = "../scheduler", default-features = false }
 
 # substrate deps
-frame-benchmarking = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", default-features = false, optional = true, branch = "master" }
 frame-system = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", default-features = false, branch = "master" }
 frame-support = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", default-features = false, branch = "master" }
 pallet-timestamp = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", default-features = false, branch = "master" }
 sp-runtime = { version = "6.0.0", git = "https://github.com/paritytech/substrate.git", default-features = false, branch = "master" }
 sp-std = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", default-features = false, branch = "master" }
-sp-core = { version = "6.0.0", git = "https://github.com/paritytech/substrate.git", branch = "master", default-features = false, optional = true}
+
+# benchmarking
+frame-benchmarking = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", default-features = false, optional = true, branch = "master" }
+sp-application-crypto = { version = "6.0.0", git = "https://github.com/paritytech/substrate.git", branch = "master", default-features = false, optional = true, features = ["full_crypto"] }
+
 
 [dev-dependencies]
 approx = "0.5.1"
 itertools = "0.10.3"
 rstest = "0.12.0"
-sp-core = { version = "6.0.0", git = "https://github.com/paritytech/substrate.git", branch = "master" }
 sp-io = { version = "6.0.0", git = "https://github.com/paritytech/substrate.git", branch = "master" }
 test-utils = { path = "../test-utils" }
 
@@ -50,4 +52,4 @@ std = [
 	"encointer-scheduler/std",
 ]
 
-runtime-benchmarks = ["frame-benchmarking", "sp-core"]
+runtime-benchmarks = ["frame-benchmarking", "encointer-primitives/full_crypto", "sp-application-crypto"]

--- a/ceremonies/Cargo.toml
+++ b/ceremonies/Cargo.toml
@@ -25,7 +25,8 @@ sp-std = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate
 
 # benchmarking
 frame-benchmarking = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", default-features = false, optional = true, branch = "master" }
-sp-application-crypto = { version = "6.0.0", git = "https://github.com/paritytech/substrate.git", branch = "master", default-features = false, optional = true, features = ["full_crypto"] }
+sp-application-crypto = { version = "6.0.0", git = "https://github.com/paritytech/substrate.git", branch = "master", default-features = false, optional = true }
+sp-core = { version = "6.0.0", git = "https://github.com/paritytech/substrate.git", branch = "master", default-features = false, optional = true }
 
 
 [dev-dependencies]
@@ -50,6 +51,8 @@ std = [
 	"encointer-communities/std",
 	"encointer-primitives/std",
 	"encointer-scheduler/std",
+	"frame-benchmarking/std",
+	"sp-core/std",
 ]
 
-runtime-benchmarks = ["frame-benchmarking", "encointer-primitives/full_crypto", "sp-application-crypto"]
+runtime-benchmarks = ["frame-benchmarking", "sp-application-crypto", "sp-core"]

--- a/ceremonies/Cargo.toml
+++ b/ceremonies/Cargo.toml
@@ -34,6 +34,7 @@ approx = "0.5.1"
 itertools = "0.10.3"
 rstest = "0.12.0"
 sp-io = { version = "6.0.0", git = "https://github.com/paritytech/substrate.git", branch = "master" }
+sp-keystore = { version = "0.12.0", git = "https://github.com/paritytech/substrate.git", branch = "master" }
 test-utils = { path = "../test-utils" }
 
 [features]

--- a/ceremonies/src/benchmarking.rs
+++ b/ceremonies/src/benchmarking.rs
@@ -317,7 +317,7 @@ benchmarks! {
 		let cid = create_community::<T>();
 		let alice: T::AccountId = account("alice", 1, 1);
 
-		// issue some income such that nebies are allowed to register
+		// issue some income such that newbies are allowed to register
 		assert_ok!(encointer_balances::Pallet::<T>::issue(
 			cid,
 			&alice,
@@ -325,30 +325,19 @@ benchmarks! {
 		));
 
 		let newbie = pair(&[10u8; 32]);
-		assert_ok!(Pallet::<T>::register_participant(RawOrigin::Signed(account_id::<T>(&newbie.clone())).into(), cid, None));
+		assert_ok!(Pallet::<T>::register_participant(
+			RawOrigin::Signed(account_id::<T>(&newbie)).into(),
+			cid, None
+		));
+
 		let cindex = encointer_scheduler::Pallet::<T>::current_ceremony_index();
 
-	// endorse_newcomer {
-	// 	let cid = create_community::<T>();
-	// 	let alice: T::AccountId = account("alice", 1, 1);
-	//
-	// 	// issue some income such that nebies are allowed to register
-	// 	assert_ok!(encointer_balances::Pallet::<T>::issue(
-	// 		cid,
-	// 		&alice,
-	// 		NominalIncome::from_num(1)
-	// 	));
-	//
-	// 	let newbie = pair(&[10u8; 32]);
-	// 	assert_ok!(Pallet::<T>::register_participant(RawOrigin::Signed(account_id::<T>(&newbie.clone())).into(), cid, None));
-	// 	let cindex = encointer_scheduler::Pallet::<T>::current_ceremony_index();
-	//
-	// 	assert_eq!(<EndorseesCount<T>>::get((cid, cindex)), 0);
-	// }: _(RawOrigin::Signed(alice), cid, account_id::<T>(&newbie))
-	// verify {
-	// 	assert_eq!(<EndorseesCount<T>>::get((cid, cindex)), 1);
-	// }
-	//
+		assert_eq!(<EndorseesCount<T>>::get((cid, cindex)), 0);
+	}: _(RawOrigin::Signed(alice), cid, account_id::<T>(&newbie))
+	verify {
+		assert_eq!(<EndorseesCount<T>>::get((cid, cindex)), 1);
+	}
+
 	// claim_rewards {
 	// 	frame_system::Pallet::<T>::set_block_number(frame_system::Pallet::<T>::block_number() + 1u32.into()); // this is needed to assert events
 	// 	let cid = create_community::<T>();

--- a/ceremonies/src/benchmarking.rs
+++ b/ceremonies/src/benchmarking.rs
@@ -287,23 +287,28 @@ benchmarks! {
 		let cid = create_community::<T>();
 
 		let attestor = pair(&[10u8; 32]);
-		assert_ok!(Pallet::<T>::register_participant(RawOrigin::Signed(account_id::<T>(&attestor.clone())).into(), cid, Some(fake_last_attendance_and_get_proof::<T>(&attestor.clone(), cid))));
+		let attestor_account = account_id::<T>(&attestor);
+
+		assert_ok!(Pallet::<T>::register_participant(
+			RawOrigin::Signed(attestor_account.clone()).into(),
+			cid,
+			Some(fake_last_attendance_and_get_proof::<T>(&attestor, cid)))
+		);
 
 		let attestees =  register_users::<T>(cid, 2, 7);
 
 		run_to_next_phase::<T>();
 		run_to_next_phase::<T>();
 
-
 		let cindex = encointer_scheduler::Pallet::<T>::current_ceremony_index();
 		let loc = Location { lat: Degree::from_num(1i32), lon: Degree::from_num(1i32) };
 		let time = correct_meetup_time::<T>(cindex, loc);
 		let mindex = 1;
 
-
-		let claims = get_all_claims::<T>(&attestees, cid, cindex, mindex, loc,time, 10);
+		let claims = get_all_claims::<T>(attestees, cid, cindex, mindex, loc,time, 10);
 		assert_eq!(AttestationCount::<T>::get((cid, cindex)), 0);
-	}: _(RawOrigin::Signed(account_id::<T>(&attestor)), claims)
+
+	}: _(RawOrigin::Signed(attestor_account), claims)
 	verify {
 		assert_eq!(AttestationCount::<T>::get((cid, cindex)), 1);
 	}

--- a/ceremonies/src/benchmarking.rs
+++ b/ceremonies/src/benchmarking.rs
@@ -26,8 +26,12 @@ mod app_sr25519 {
 
 type TestPublic = app_sr25519::Public;
 
-fn pair(seed: &[u8; 32]) -> TestPublic {
-	TestPublic::generate_pair(Some(seed.to_vec()))
+/// Generates a pair in the test externalities' `KeyStoreExt`.
+///
+///
+fn pair() -> TestPublic {
+	// passing a seed gives an error for some reason
+	TestPublic::generate_pair(None)
 }
 
 fn sign(signer: &TestPublic, data: &Vec<u8>) -> sr25519::Signature {
@@ -406,4 +410,16 @@ benchmarks! {
 
 }
 
-impl_benchmark_test_suite!(Pallet, crate::mock::new_test_ext(), crate::mock::TestRuntime);
+impl_benchmark_test_suite!(Pallet, crate::benchmarking::new_test_ext(), crate::mock::TestRuntime);
+
+#[cfg(test)]
+fn new_test_ext() -> sp_io::TestExternalities {
+	use sp_keystore::{testing::KeyStore, KeystoreExt, SyncCryptoStorePtr};
+	use sp_std::sync::Arc;
+
+	let mut ext = crate::mock::new_test_ext();
+
+	ext.register_extension(KeystoreExt(Arc::new(KeyStore::new()) as SyncCryptoStorePtr));
+
+	ext
+}

--- a/ceremonies/src/benchmarking.rs
+++ b/ceremonies/src/benchmarking.rs
@@ -8,7 +8,7 @@ use frame_support::{
 	traits::{OnFinalize, OnInitialize},
 };
 use frame_system::RawOrigin;
-use sp_core::{sr25519, Pair};
+use sp_application_crypto::{sp_core, sr25519, Pair};
 use sp_runtime::traits::UniqueSaturatedInto;
 
 pub const GENESIS_TIME: u64 = 1_585_058_843_000;

--- a/ceremonies/src/benchmarking.rs
+++ b/ceremonies/src/benchmarking.rs
@@ -342,36 +342,36 @@ benchmarks! {
 		assert_eq!(<EndorseesCount<T>>::get((cid, cindex)), 1);
 	}
 
-	// claim_rewards {
-	// 	frame_system::Pallet::<T>::set_block_number(frame_system::Pallet::<T>::block_number() + 1u32.into()); // this is needed to assert events
-	// 	let cid = create_community::<T>();
-	// 	let users = register_users::<T>(cid, 2, 8);
-	//
-	// 	run_to_next_phase::<T>();
-	// 	run_to_next_phase::<T>();
-	//
-	// 	let cindex = encointer_scheduler::Pallet::<T>::current_ceremony_index();
-	// 	let loc = Location { lat: Degree::from_num(1i32), lon: Degree::from_num(1i32) };
-	// 	let time = correct_meetup_time::<T>(cindex, loc);
-	// 	let mindex = 1;
-	//
-	// 	// attest_claims
-	// 	for i in 0..10 {
-	// 		let attestor = users[i as usize].clone();
-	// 		let mut attestees = users.clone();
-	// 		attestees.remove(i as usize);
-	// 		let claims = get_all_claims::<T>(attestees, cid, cindex, mindex, loc, time, 10);
-	// 		assert_ok!(Pallet::<T>::attest_claims(RawOrigin::Signed(account_id::<T>(&attestor)).into(), claims));
-	// 	}
-	//
-	// 	run_to_next_phase::<T>();
-	// 	assert!(!IssuedRewards::<T>::contains_key((cid, cindex), mindex));
-	//
-	// }: _(RawOrigin::Signed(account_id::<T>(&users[0])), cid)
-	// verify {
-	// 	assert_eq!(last_event::<T>(), Some(Event::RewardsIssued(cid, 1, 10).into()));
-	// 	assert!(IssuedRewards::<T>::contains_key((cid, cindex), mindex));
-	// }
+	claim_rewards {
+		frame_system::Pallet::<T>::set_block_number(frame_system::Pallet::<T>::block_number() + 1u32.into()); // this is needed to assert events
+		let cid = create_community::<T>();
+		let users = register_users::<T>(cid, 2, 8);
+
+		run_to_next_phase::<T>();
+		run_to_next_phase::<T>();
+
+		let cindex = encointer_scheduler::Pallet::<T>::current_ceremony_index();
+		let loc = Location { lat: Degree::from_num(1i32), lon: Degree::from_num(1i32) };
+		let time = correct_meetup_time::<T>(cindex, loc);
+		let mindex = 1;
+
+		// attest_claims
+		for i in 0..10 {
+			let attestor = users[i as usize].clone();
+			let mut attestees = users.clone();
+			attestees.remove(i as usize);
+			let claims = get_all_claims::<T>(attestees, cid, cindex, mindex, loc, time, 10);
+			assert_ok!(Pallet::<T>::attest_claims(RawOrigin::Signed(account_id::<T>(&attestor)).into(), claims));
+		}
+
+		run_to_next_phase::<T>();
+		assert!(!IssuedRewards::<T>::contains_key((cid, cindex), mindex));
+
+	}: _(RawOrigin::Signed(account_id::<T>(&users[0])), cid)
+	verify {
+		assert_eq!(last_event::<T>(), Some(Event::RewardsIssued(cid, 1, 10).into()));
+		assert!(IssuedRewards::<T>::contains_key((cid, cindex), mindex));
+	}
 
 	set_inactivity_timeout {
 	}: _(RawOrigin::Root, 13)

--- a/ceremonies/src/benchmarking.rs
+++ b/ceremonies/src/benchmarking.rs
@@ -14,7 +14,7 @@ use sp_runtime::{traits::UniqueSaturatedInto, RuntimeAppPublic};
 
 pub const GENESIS_TIME: u64 = 1_585_058_843_000;
 pub const ONE_DAY: u64 = 86_400_000;
-pub const BLOCKTIME: u64 = 3_600_000;
+pub const BLOCKTIME: u64 = 6000;
 
 pub const TEST_KEY_TYPE_ID: KeyTypeId = KeyTypeId(*b"test");
 

--- a/ceremonies/src/benchmarking.rs
+++ b/ceremonies/src/benchmarking.rs
@@ -342,71 +342,71 @@ benchmarks! {
 		assert_eq!(<EndorseesCount<T>>::get((cid, cindex)), 1);
 	}
 
-	claim_rewards {
-		frame_system::Pallet::<T>::set_block_number(frame_system::Pallet::<T>::block_number() + 1u32.into()); // this is needed to assert events
-		let cid = create_community::<T>();
-		let users = register_users::<T>(cid, 2, 8);
+	// claim_rewards {
+	// 	frame_system::Pallet::<T>::set_block_number(frame_system::Pallet::<T>::block_number() + 1u32.into()); // this is needed to assert events
+	// 	let cid = create_community::<T>();
+	// 	let users = register_users::<T>(cid, 2, 8);
+	//
+	// 	run_to_next_phase::<T>();
+	// 	run_to_next_phase::<T>();
+	//
+	// 	let cindex = encointer_scheduler::Pallet::<T>::current_ceremony_index();
+	// 	let loc = Location { lat: Degree::from_num(1i32), lon: Degree::from_num(1i32) };
+	// 	let time = correct_meetup_time::<T>(cindex, loc);
+	// 	let mindex = 1;
+	//
+	// 	// attest_claims
+	// 	for i in 0..10 {
+	// 		let attestor = users[i as usize].clone();
+	// 		let mut attestees = users.clone();
+	// 		attestees.remove(i as usize);
+	// 		let claims = get_all_claims::<T>(attestees, cid, cindex, mindex, loc, time, 10);
+	// 		assert_ok!(Pallet::<T>::attest_claims(RawOrigin::Signed(account_id::<T>(&attestor)).into(), claims));
+	// 	}
+	//
+	// 	run_to_next_phase::<T>();
+	// 	assert!(!IssuedRewards::<T>::contains_key((cid, cindex), mindex));
+	//
+	// }: _(RawOrigin::Signed(account_id::<T>(&users[0])), cid)
+	// verify {
+	// 	assert_eq!(last_event::<T>(), Some(Event::RewardsIssued(cid, 1, 10).into()));
+	// 	assert!(IssuedRewards::<T>::contains_key((cid, cindex), mindex));
+	// }
 
-		run_to_next_phase::<T>();
-		run_to_next_phase::<T>();
-
-		let cindex = encointer_scheduler::Pallet::<T>::current_ceremony_index();
-		let loc = Location { lat: Degree::from_num(1i32), lon: Degree::from_num(1i32) };
-		let time = correct_meetup_time::<T>(cindex, loc);
-		let mindex = 1;
-
-		// attest_claims
-		for i in 0..10 {
-			let attestor = users[i as usize].clone();
-			let mut attestees = users.clone();
-			attestees.remove(i as usize);
-			let claims = get_all_claims::<T>(attestees, cid, cindex, mindex, loc, time, 10);
-			assert_ok!(Pallet::<T>::attest_claims(RawOrigin::Signed(account_id::<T>(&attestor)).into(), claims));
-		}
-
-		run_to_next_phase::<T>();
-		assert!(!IssuedRewards::<T>::contains_key((cid, cindex), mindex));
-
-	}: _(RawOrigin::Signed(account_id::<T>(&users[0])), cid)
+	set_inactivity_timeout {
+	}: _(RawOrigin::Root, 13)
 	verify {
-		assert_eq!(last_event::<T>(), Some(Event::RewardsIssued(cid, 1, 10).into()));
-		assert!(IssuedRewards::<T>::contains_key((cid, cindex), mindex));
+		assert_eq!(InactivityTimeout::<T>::get(), 13)
 	}
 
-	// set_inactivity_timeout {
-	// }: _(RawOrigin::Root, 13)
-	// verify {
-	// 	assert_eq!(InactivityTimeout::<T>::get(), 13)
-	// }
-	//
-	// set_meetup_time_offset {
-	// }: _(RawOrigin::Root, 12i32)
-	// verify {
-	// 	assert_eq!(MeetupTimeOffset::<T>::get(), 12i32)
-	// }
-	//
-	// set_reputation_lifetime {
-	// }: _(RawOrigin::Root, 11)
-	// verify {
-	// 	assert_eq!(ReputationLifetime::<T>::get(), 11)
-	// }
-	//
-	// set_endorsement_tickets_per_bootstrapper {
-	// }: _(RawOrigin::Root, 10)
-	// verify {
-	// 	assert_eq!(EndorsementTicketsPerBootstrapper::<T>::get(), 10)
-	// }
-	//
-	// purge_community_ceremony {
-	// 	let cid = create_community::<T>();
-	// 	let cindex = encointer_scheduler::Pallet::<T>::current_ceremony_index();
-	// 	let user = generate_pair();
-	// 	assert_ok!(Pallet::<T>::register_participant(RawOrigin::Signed(account_id::<T>(&user.clone())).into(), cid, Some(fake_last_attendance_and_get_proof::<T>(&user.clone(), cid))));
-	// 	assert_eq!(ReputableCount::<T>::get((cid, cindex)), 1);
-	// }: _(RawOrigin::Root, (cid, cindex))
-	// verify {
-	// 	assert_eq!(ReputableCount::<T>::get((cid, cindex)), 0);
-	// }
+	set_meetup_time_offset {
+	}: _(RawOrigin::Root, 12i32)
+	verify {
+		assert_eq!(MeetupTimeOffset::<T>::get(), 12i32)
+	}
+
+	set_reputation_lifetime {
+	}: _(RawOrigin::Root, 11)
+	verify {
+		assert_eq!(ReputationLifetime::<T>::get(), 11)
+	}
+
+	set_endorsement_tickets_per_bootstrapper {
+	}: _(RawOrigin::Root, 10)
+	verify {
+		assert_eq!(EndorsementTicketsPerBootstrapper::<T>::get(), 10)
+	}
+
+	purge_community_ceremony {
+		let cid = create_community::<T>();
+		let cindex = encointer_scheduler::Pallet::<T>::current_ceremony_index();
+		let user = generate_pair();
+		assert_ok!(Pallet::<T>::register_participant(RawOrigin::Signed(account_id::<T>(&user.clone())).into(), cid, Some(fake_last_attendance_and_get_proof::<T>(&user.clone(), cid))));
+		assert_eq!(ReputableCount::<T>::get((cid, cindex)), 1);
+	}: _(RawOrigin::Root, (cid, cindex))
+	verify {
+		assert_eq!(ReputableCount::<T>::get((cid, cindex)), 0);
+	}
 
 }
 

--- a/ceremonies/src/benchmarking.rs
+++ b/ceremonies/src/benchmarking.rs
@@ -29,14 +29,17 @@ fn sign(signer: &TestPublic, data: &Vec<u8>) -> sr25519::Signature {
 	signer.sign(data).unwrap().into()
 }
 
-fn create_community<T: Config>() -> CommunityIdentifier {
+fn bootstrappers<T: frame_system::Config>() -> Vec<T::AccountId> {
 	let alice: T::AccountId = account("alice", 1, 1);
 	let bob: T::AccountId = account("bob", 2, 2);
 	let charlie: T::AccountId = account("charlie", 3, 3);
 
-	let location = Location { lat: Degree::from_num(1i32), lon: Degree::from_num(1i32) };
+	vec![alice.clone(), bob.clone(), charlie.clone()]
+}
 
-	let bs = vec![alice.clone(), bob.clone(), charlie.clone()];
+fn create_community<T: Config>() -> CommunityIdentifier {
+	let location = Location { lat: Degree::from_num(1i32), lon: Degree::from_num(1i32) };
+	let bs = bootstrappers::<T>();
 
 	encointer_communities::Pallet::<T>::new_community(
 		RawOrigin::Root.into(),
@@ -103,7 +106,6 @@ where
 	claims
 }
 
-/// Progress blocks until the phase changes
 fn next_phase<T: Config>() {
 	encointer_scheduler::Pallet::<T>::next_phase(RawOrigin::Root.into()).unwrap();
 }

--- a/ceremonies/src/benchmarking.rs
+++ b/ceremonies/src/benchmarking.rs
@@ -15,6 +15,10 @@ pub const GENESIS_TIME: u64 = 1_585_058_843_000;
 pub const ONE_DAY: u64 = 86_400_000;
 pub const BLOCKTIME: u64 = 3_600_000;
 
+fn pair(seed: &[u8; 32]) -> sr25519::Pair {
+	sr25519::Pair::from_seed(seed)
+}
+
 fn create_community<T: Config>() -> CommunityIdentifier {
 	let alice: T::AccountId = account("alice", 1, 1);
 	let bob: T::AccountId = account("bob", 2, 2);
@@ -213,7 +217,7 @@ where
 	let num_users_total = num_newbies + num_reputables;
 	// create users and fake reputation
 	for i in 0..num_users_total {
-		let p = sr25519::Pair::from_entropy(&[i as u8; 32], None).0;
+		let p = pair(&[i as u8; 32]);
 		users.push(p.clone());
 		if i < num_reputables {
 			proofs.push(fake_last_attendance_and_get_proof::<T>(&p, cid));
@@ -249,7 +253,7 @@ benchmarks! {
 	register_participant {
 		let cid = create_community::<T>();
 
-		let zoran = sr25519::Pair::from_entropy(&[9u8; 32], None).0;
+		let zoran = pair(&[9u8; 32]);
 		let proof = fake_last_attendance_and_get_proof::<T>(&zoran, cid);
 		let cindex = encointer_scheduler::Pallet::<T>::current_ceremony_index();
 
@@ -266,7 +270,7 @@ benchmarks! {
 	attest_claims {
 		let cid = create_community::<T>();
 
-		let attestor = sr25519::Pair::from_entropy(&[10u8; 32], None).0;
+		let attestor = pair(&[10u8; 32]);
 		assert_ok!(Pallet::<T>::register_participant(RawOrigin::Signed(account_id::<T>(&attestor.clone())).into(), cid, Some(fake_last_attendance_and_get_proof::<T>(&attestor.clone(), cid))));
 
 		let attestees =  register_users::<T>(cid, 2, 7);
@@ -299,7 +303,7 @@ benchmarks! {
 			NominalIncome::from_num(1)
 		));
 
-		let newbie = sr25519::Pair::from_entropy(&[10u8; 32], None).0;
+		let newbie = pair(&[10u8; 32]);
 		assert_ok!(Pallet::<T>::register_participant(RawOrigin::Signed(account_id::<T>(&newbie.clone())).into(), cid, None));
 		let cindex = encointer_scheduler::Pallet::<T>::current_ceremony_index();
 
@@ -369,7 +373,7 @@ benchmarks! {
 	purge_community_ceremony {
 		let cid = create_community::<T>();
 		let cindex = encointer_scheduler::Pallet::<T>::current_ceremony_index();
-		let user = sr25519::Pair::from_entropy(&[10u8; 32], None).0;
+		let user = pair(&[10u8; 32]);
 		assert_ok!(Pallet::<T>::register_participant(RawOrigin::Signed(account_id::<T>(&user.clone())).into(), cid, Some(fake_last_attendance_and_get_proof::<T>(&user.clone(), cid))));
 		assert_eq!(ReputableCount::<T>::get((cid, cindex)), 1);
 	}: _(RawOrigin::Root, (cid, cindex))

--- a/ceremonies/src/benchmarking.rs
+++ b/ceremonies/src/benchmarking.rs
@@ -110,6 +110,10 @@ where
 	claims
 }
 
+/// Goes to next ceremony phase.
+///
+/// We purposely don't use `run_to_next_phase` because in the actual node aura complained
+/// when the timestamps were manipulated.
 fn next_phase<T: Config>() {
 	encointer_scheduler::Pallet::<T>::next_phase(RawOrigin::Root.into()).unwrap();
 }

--- a/ceremonies/src/benchmarking.rs
+++ b/ceremonies/src/benchmarking.rs
@@ -8,15 +8,30 @@ use frame_support::{
 	traits::{OnFinalize, OnInitialize},
 };
 use frame_system::RawOrigin;
-use sp_application_crypto::{sp_core, sr25519, Pair};
-use sp_runtime::traits::UniqueSaturatedInto;
+use sp_application_crypto::KeyTypeId;
+use sp_core::{crypto::ByteArray, sr25519};
+use sp_runtime::{traits::UniqueSaturatedInto, RuntimeAppPublic};
 
 pub const GENESIS_TIME: u64 = 1_585_058_843_000;
 pub const ONE_DAY: u64 = 86_400_000;
 pub const BLOCKTIME: u64 = 3_600_000;
 
-fn pair(seed: &[u8; 32]) -> sr25519::Pair {
-	sr25519::Pair::from_seed(seed)
+pub const TEST_KEY_TYPE_ID: KeyTypeId = KeyTypeId(*b"test");
+
+mod app_sr25519 {
+	use super::TEST_KEY_TYPE_ID;
+	use sp_application_crypto::{app_crypto, sr25519};
+	app_crypto!(sr25519, TEST_KEY_TYPE_ID);
+}
+
+type TestPublic = app_sr25519::Public;
+
+fn pair(seed: &[u8; 32]) -> TestPublic {
+	TestPublic::generate_pair(Some(seed.to_vec()))
+}
+
+fn sign(signer: &TestPublic, data: &Vec<u8>) -> sr25519::Signature {
+	signer.sign(data).unwrap().into()
 }
 
 fn create_community<T: Config>() -> CommunityIdentifier {
@@ -64,22 +79,15 @@ where
 	T::Moment::from(time as u64)
 }
 
-pub fn account_id<T: Config>(pair: &sr25519::Pair) -> T::AccountId
-where
-	<T as frame_system::Config>::AccountId: From<sp_core::sr25519::Public>,
-{
-	pair.public().into()
-}
-
 fn create_proof_of_attendance<T: Config>(
 	prover: T::AccountId,
 	cid: CommunityIdentifier,
 	cindex: CeremonyIndexType,
-	attendee: &sr25519::Pair,
+	attendee: &TestPublic,
 ) -> ProofOfAttendance<T::Signature, T::AccountId>
 where
-	<T as frame_system::Config>::AccountId: From<sp_core::sr25519::Public>,
-	<T as Config>::Signature: From<sp_core::sr25519::Signature>,
+	<T as frame_system::Config>::AccountId: ByteArray,
+	<T as Config>::Signature: From<sr25519::Signature>,
 {
 	let msg = (prover.clone(), cindex);
 	ProofOfAttendance {
@@ -87,12 +95,12 @@ where
 		community_identifier: cid,
 		ceremony_index: cindex,
 		attendee_public: account_id::<T>(&attendee),
-		attendee_signature: T::Signature::from(attendee.sign(&msg.encode())),
+		attendee_signature: T::Signature::from(sign(attendee, &msg.encode())),
 	}
 }
 
 fn get_all_claims<T: Config>(
-	attestees: &Vec<sr25519::Pair>,
+	attestees: Vec<TestPublic>,
 	cid: CommunityIdentifier,
 	cindex: CeremonyIndexType,
 	mindex: MeetupIndexType,
@@ -101,23 +109,24 @@ fn get_all_claims<T: Config>(
 	n_participants: u32,
 ) -> Vec<ClaimOfAttendance<T::Signature, T::AccountId, T::Moment>>
 where
-	<T as frame_system::Config>::AccountId: From<sp_core::sr25519::Public>,
-	<T as Config>::Signature: From<sp_core::sr25519::Signature>,
+	<T as frame_system::Config>::AccountId: ByteArray,
+	<T as Config>::Signature: From<sr25519::Signature>,
 {
 	let mut claims: Vec<ClaimOfAttendance<T::Signature, T::AccountId, T::Moment>> = vec![];
-	for a in attestees {
-		claims.push(
-			ClaimOfAttendance::<T::Signature, T::AccountId, T::Moment>::new_unsigned(
-				a.public().into(),
-				cindex,
-				cid,
-				mindex,
-				location,
-				timestamp,
-				n_participants,
-			)
-			.sign(a),
+	for a in attestees.into_iter() {
+		let mut claim = ClaimOfAttendance::<T::Signature, T::AccountId, T::Moment>::new_unsigned(
+			account_id::<T>(&a),
+			cindex,
+			cid,
+			mindex,
+			location,
+			timestamp,
+			n_participants,
 		);
+
+		claim.claimant_signature = Some(sign(&a, &claim.payload_encoded()).into());
+
+		claims.push(claim);
 	}
 	claims
 }
@@ -164,33 +173,38 @@ pub fn set_timestamp<T: Config>(t: T::Moment) {
 	let _ = pallet_timestamp::Pallet::<T>::set(RawOrigin::None.into(), t);
 }
 
+pub fn account_id<T: Config>(account: &TestPublic) -> T::AccountId
+where
+	<T as frame_system::Config>::AccountId: ByteArray,
+{
+	T::AccountId::from_slice(account.as_slice()).unwrap()
+}
+
 fn fake_last_attendance_and_get_proof<T: Config>(
-	prover: &sr25519::Pair,
+	prover: &TestPublic,
 	cid: CommunityIdentifier,
 ) -> ProofOfAttendance<T::Signature, T::AccountId>
 where
-	<T as frame_system::Config>::AccountId: From<sp_core::sr25519::Public>,
-	<T as Config>::Signature: From<sp_core::sr25519::Signature>,
+	<T as frame_system::Config>::AccountId: ByteArray,
+	<T as Config>::Signature: From<sr25519::Signature>,
 {
 	let cindex = encointer_scheduler::Pallet::<T>::current_ceremony_index();
-	let prover_account_id = account_id::<T>(&prover);
+	let prover_account: T::AccountId = account_id::<T>(prover);
+
 	assert_ok!(encointer_balances::Pallet::<T>::issue(
 		cid,
-		&prover_account_id,
+		&prover_account,
 		NominalIncome::from_num(1)
 	));
-	Pallet::<T>::fake_reputation(
-		(cid, cindex - 1),
-		&account_id::<T>(&prover),
-		Reputation::VerifiedUnlinked,
-	);
+	Pallet::<T>::fake_reputation((cid, cindex - 1), &prover_account, Reputation::VerifiedUnlinked);
 	assert_eq!(
-		Pallet::<T>::participant_reputation((cid, cindex - 1), &prover_account_id),
+		Pallet::<T>::participant_reputation((cid, cindex - 1), &prover_account),
 		Reputation::VerifiedUnlinked
 	);
+
 	let cindex = encointer_scheduler::Pallet::<T>::current_ceremony_index();
 	IssuedRewards::<T>::insert((cid, cindex - 1), 0, ());
-	let proof = create_proof_of_attendance::<T>(prover_account_id, cid, cindex - 1, &prover);
+	let proof = create_proof_of_attendance::<T>(prover_account, cid, cindex - 1, prover);
 	proof
 }
 
@@ -207,12 +221,12 @@ fn register_users<T: Config>(
 	cid: CommunityIdentifier,
 	num_newbies: u32,
 	num_reputables: u32,
-) -> Vec<sr25519::Pair>
+) -> Vec<TestPublic>
 where
-	<T as frame_system::Config>::AccountId: From<sp_core::sr25519::Public>,
-	<T as Config>::Signature: From<sp_core::sr25519::Signature>,
+	<T as frame_system::Config>::AccountId: ByteArray,
+	<T as Config>::Signature: From<sr25519::Signature>,
 {
-	let mut users: Vec<sr25519::Pair> = vec![];
+	let mut users: Vec<TestPublic> = vec![];
 	let mut proofs: Vec<ProofOfAttendance<T::Signature, T::AccountId>> = vec![];
 
 	let num_users_total = num_newbies + num_reputables;
@@ -244,8 +258,8 @@ where
 benchmarks! {
 	where_clause {
 		where
-		<T as frame_system::Config>::AccountId: From<sp_core::sr25519::Public>,
-		<T as Config>::Signature: From<sp_core::sr25519::Signature>,
+		<T as frame_system::Config>::AccountId: ByteArray,
+		<T as Config>::Signature: From<sr25519::Signature>,
 		<T as pallet_timestamp::Config>::Moment: From<u64>,
 		<T as frame_system::Config>::BlockNumber: From<u32>,
 		<T as frame_system::Config>::Event: From<pallet::Event<T>>
@@ -255,15 +269,16 @@ benchmarks! {
 		let cid = create_community::<T>();
 
 		let zoran = pair(&[9u8; 32]);
+		let zoran_account= account_id::<T>(&zoran);
 		let proof = fake_last_attendance_and_get_proof::<T>(&zoran, cid);
 		let cindex = encointer_scheduler::Pallet::<T>::current_ceremony_index();
 
 		assert_eq!(ReputableCount::<T>::get((cid, cindex)), 0);
-	}: _(RawOrigin::Signed(account_id::<T>(&zoran)), cid, Some(proof))
+	}: _(RawOrigin::Signed(zoran_account.clone()), cid, Some(proof))
 	verify {
 		assert_eq!(ReputableCount::<T>::get((cid, cindex)), 1);
 		assert_eq!(
-			Pallet::<T>::participant_reputation((cid, cindex - 1), account_id::<T>(&zoran)),
+			Pallet::<T>::participant_reputation((cid, cindex - 1), zoran_account),
 			Reputation::VerifiedLinked
 		);
 	}
@@ -308,79 +323,94 @@ benchmarks! {
 		assert_ok!(Pallet::<T>::register_participant(RawOrigin::Signed(account_id::<T>(&newbie.clone())).into(), cid, None));
 		let cindex = encointer_scheduler::Pallet::<T>::current_ceremony_index();
 
-		assert_eq!(<EndorseesCount<T>>::get((cid, cindex)), 0);
-	}: _(RawOrigin::Signed(alice), cid, account_id::<T>(&newbie))
-	verify {
-		assert_eq!(<EndorseesCount<T>>::get((cid, cindex)), 1);
-	}
-
-	claim_rewards {
-		frame_system::Pallet::<T>::set_block_number(frame_system::Pallet::<T>::block_number() + 1u32.into()); // this is needed to assert events
-		let cid = create_community::<T>();
-
-
-		let users = register_users::<T>(cid, 2, 8);
-
-		run_to_next_phase::<T>();
-		run_to_next_phase::<T>();
-
-
-		let cindex = encointer_scheduler::Pallet::<T>::current_ceremony_index();
-		let loc = Location { lat: Degree::from_num(1i32), lon: Degree::from_num(1i32) };
-		let time = correct_meetup_time::<T>(cindex, loc);
-		let mindex = 1;
-
-		// attest_claims
-		for i in 0..10 {
-			let attestor = users[i as usize].clone();
-			let mut attestees = users.clone();
-			attestees.remove(i as usize);
-			let claims = get_all_claims::<T>(&attestees, cid, cindex, mindex, loc, time, 10);
-			assert_ok!(Pallet::<T>::attest_claims(RawOrigin::Signed(account_id::<T>(&attestor)).into(), claims));
-		}
-
-		run_to_next_phase::<T>();
-		assert!(!IssuedRewards::<T>::contains_key((cid, cindex), mindex));
-	}: _(RawOrigin::Signed(account_id::<T>(&users[0])), cid)
-	verify {
-		assert_eq!(last_event::<T>(), Some(Event::RewardsIssued(cid, 1, 10).into()));
-		assert!(IssuedRewards::<T>::contains_key((cid, cindex), mindex));
-	}
-
-	set_inactivity_timeout {
-	}: _(RawOrigin::Root, 13)
-	verify {
-		assert_eq!(InactivityTimeout::<T>::get(), 13)
-	}
-
-	set_meetup_time_offset {
-	}: _(RawOrigin::Root, 12i32)
-	verify {
-		assert_eq!(MeetupTimeOffset::<T>::get(), 12i32)
-	}
-
-	set_reputation_lifetime {
-	}: _(RawOrigin::Root, 11)
-	verify {
-		assert_eq!(ReputationLifetime::<T>::get(), 11)
-	}
-
-	set_endorsement_tickets_per_bootstrapper {
-	}: _(RawOrigin::Root, 10)
-	verify {
-		assert_eq!(EndorsementTicketsPerBootstrapper::<T>::get(), 10)
-	}
-
-	purge_community_ceremony {
-		let cid = create_community::<T>();
-		let cindex = encointer_scheduler::Pallet::<T>::current_ceremony_index();
-		let user = pair(&[10u8; 32]);
-		assert_ok!(Pallet::<T>::register_participant(RawOrigin::Signed(account_id::<T>(&user.clone())).into(), cid, Some(fake_last_attendance_and_get_proof::<T>(&user.clone(), cid))));
-		assert_eq!(ReputableCount::<T>::get((cid, cindex)), 1);
-	}: _(RawOrigin::Root, (cid, cindex))
-	verify {
-		assert_eq!(ReputableCount::<T>::get((cid, cindex)), 0);
-	}
+	// endorse_newcomer {
+	// 	let cid = create_community::<T>();
+	// 	let alice: T::AccountId = account("alice", 1, 1);
+	//
+	// 	// issue some income such that nebies are allowed to register
+	// 	assert_ok!(encointer_balances::Pallet::<T>::issue(
+	// 		cid,
+	// 		&alice,
+	// 		NominalIncome::from_num(1)
+	// 	));
+	//
+	// 	let newbie = pair(&[10u8; 32]);
+	// 	assert_ok!(Pallet::<T>::register_participant(RawOrigin::Signed(account_id::<T>(&newbie.clone())).into(), cid, None));
+	// 	let cindex = encointer_scheduler::Pallet::<T>::current_ceremony_index();
+	//
+	// 	assert_eq!(<EndorseesCount<T>>::get((cid, cindex)), 0);
+	// }: _(RawOrigin::Signed(alice), cid, account_id::<T>(&newbie))
+	// verify {
+	// 	assert_eq!(<EndorseesCount<T>>::get((cid, cindex)), 1);
+	// }
+	//
+	// claim_rewards {
+	// 	frame_system::Pallet::<T>::set_block_number(frame_system::Pallet::<T>::block_number() + 1u32.into()); // this is needed to assert events
+	// 	let cid = create_community::<T>();
+	//
+	//
+	// 	let users = register_users::<T>(cid, 2, 8);
+	//
+	// 	run_to_next_phase::<T>();
+	// 	run_to_next_phase::<T>();
+	//
+	//
+	// 	let cindex = encointer_scheduler::Pallet::<T>::current_ceremony_index();
+	// 	let loc = Location { lat: Degree::from_num(1i32), lon: Degree::from_num(1i32) };
+	// 	let time = correct_meetup_time::<T>(cindex, loc);
+	// 	let mindex = 1;
+	//
+	// 	// attest_claims
+	// 	for i in 0..10 {
+	// 		let attestor = users[i as usize].clone();
+	// 		let mut attestees = users.clone();
+	// 		attestees.remove(i as usize);
+	// 		let claims = get_all_claims::<T>(&attestees, cid, cindex, mindex, loc, time, 10);
+	// 		assert_ok!(Pallet::<T>::attest_claims(RawOrigin::Signed(&attestor).into(), claims));
+	// 	}
+	//
+	// 	run_to_next_phase::<T>();
+	// 	assert!(!IssuedRewards::<T>::contains_key((cid, cindex), mindex));
+	// }: _(RawOrigin::Signed(account_id::<T>(&users[0])), cid)
+	// verify {
+	// 	assert_eq!(last_event::<T>(), Some(Event::RewardsIssued(cid, 1, 10).into()));
+	// 	assert!(IssuedRewards::<T>::contains_key((cid, cindex), mindex));
+	// }
+	//
+	// set_inactivity_timeout {
+	// }: _(RawOrigin::Root, 13)
+	// verify {
+	// 	assert_eq!(InactivityTimeout::<T>::get(), 13)
+	// }
+	//
+	// set_meetup_time_offset {
+	// }: _(RawOrigin::Root, 12i32)
+	// verify {
+	// 	assert_eq!(MeetupTimeOffset::<T>::get(), 12i32)
+	// }
+	//
+	// set_reputation_lifetime {
+	// }: _(RawOrigin::Root, 11)
+	// verify {
+	// 	assert_eq!(ReputationLifetime::<T>::get(), 11)
+	// }
+	//
+	// set_endorsement_tickets_per_bootstrapper {
+	// }: _(RawOrigin::Root, 10)
+	// verify {
+	// 	assert_eq!(EndorsementTicketsPerBootstrapper::<T>::get(), 10)
+	// }
+	//
+	// purge_community_ceremony {
+	// 	let cid = create_community::<T>();
+	// 	let cindex = encointer_scheduler::Pallet::<T>::current_ceremony_index();
+	// 	let user = pair(&[10u8; 32]);
+	// 	assert_ok!(Pallet::<T>::register_participant(RawOrigin::Signed(account_id::<T>(&user.clone())).into(), cid, Some(fake_last_attendance_and_get_proof::<T>(&user.clone(), cid))));
+	// 	assert_eq!(ReputableCount::<T>::get((cid, cindex)), 1);
+	// }: _(RawOrigin::Root, (cid, cindex))
+	// verify {
+	// 	assert_eq!(ReputableCount::<T>::get((cid, cindex)), 0);
+	// }
 
 }
 

--- a/ceremonies/src/benchmarking.rs
+++ b/ceremonies/src/benchmarking.rs
@@ -109,10 +109,7 @@ where
 }
 
 /// Run until a particular block.
-fn run_to_block<T: Config>(n: T::BlockNumber)
-where
-	<T as pallet_timestamp::Config>::Moment: From<u64>,
-{
+fn run_to_block<T: Config>(n: T::BlockNumber) {
 	while frame_system::Pallet::<T>::block_number() < n {
 		if frame_system::Pallet::<T>::block_number() > 1u32.into() {
 			frame_system::Pallet::<T>::on_finalize(frame_system::Pallet::<T>::block_number());
@@ -123,7 +120,7 @@ where
 
 		let new_timestamp: u64 = GENESIS_TIME + block_time * n_moment;
 
-		set_timestamp::<T>(new_timestamp.into());
+		set_timestamp::<T>(new_timestamp.saturated_into());
 
 		pallet_timestamp::Pallet::<T>::on_finalize(frame_system::Pallet::<T>::block_number());
 		frame_system::Pallet::<T>::set_block_number(
@@ -135,11 +132,7 @@ where
 }
 
 /// Progress blocks until the phase changes
-fn run_to_next_phase<T: Config>()
-where
-	// <T as frame_system::Config>::BlockNumber: From<u64>,
-	<T as pallet_timestamp::Config>::Moment: From<u64>,
-{
+fn run_to_next_phase<T: Config>() {
 	let phase = encointer_scheduler::Pallet::<T>::current_phase();
 	let mut blocknr = frame_system::Pallet::<T>::block_number();
 	while phase == encointer_scheduler::Pallet::<T>::current_phase() {
@@ -248,8 +241,6 @@ benchmarks! {
 		where
 		<T as frame_system::Config>::AccountId: ByteArray,
 		<T as Config>::Signature: From<sr25519::Signature>,
-		<T as pallet_timestamp::Config>::Moment: From<u64>,
-		<T as frame_system::Config>::BlockNumber: From<u32>,
 		<T as frame_system::Config>::Event: From<pallet::Event<T>>
 	}
 

--- a/ceremonies/src/benchmarking.rs
+++ b/ceremonies/src/benchmarking.rs
@@ -3,21 +3,22 @@ use encointer_primitives::communities::{CommunityIdentifier, CommunityMetadata, 
 use frame_benchmarking::{account, benchmarks, impl_benchmark_test_suite};
 use frame_support::assert_ok;
 use frame_system::RawOrigin;
-use sp_application_crypto::KeyTypeId;
 use sp_core::{crypto::ByteArray, sr25519};
 use sp_runtime::RuntimeAppPublic;
 
-pub const TEST_KEY_TYPE_ID: KeyTypeId = KeyTypeId(*b"test");
-
+/// Our own little test-crypto module because we can't use the `sp-core::sr25519` signing methods
+/// in the runtime.
 mod app_sr25519 {
-	use super::TEST_KEY_TYPE_ID;
+	use sp_application_crypto::KeyTypeId;
+	pub const TEST_KEY_TYPE_ID: KeyTypeId = KeyTypeId(*b"test");
+
 	use sp_application_crypto::{app_crypto, sr25519};
 	app_crypto!(sr25519, TEST_KEY_TYPE_ID);
 }
 
 type TestPublic = app_sr25519::Public;
 
-/// Generates a pair in the test externalities' `KeyStoreExt`.
+/// Generates a pair in the externalities' `KeyStoreExt`.
 ///
 /// Returns the public key of the generated pair.
 fn generate_pair() -> TestPublic {

--- a/ceremonies/src/benchmarking.rs
+++ b/ceremonies/src/benchmarking.rs
@@ -338,39 +338,37 @@ benchmarks! {
 		assert_eq!(<EndorseesCount<T>>::get((cid, cindex)), 1);
 	}
 
-	// claim_rewards {
-	// 	frame_system::Pallet::<T>::set_block_number(frame_system::Pallet::<T>::block_number() + 1u32.into()); // this is needed to assert events
-	// 	let cid = create_community::<T>();
-	//
-	//
-	// 	let users = register_users::<T>(cid, 2, 8);
-	//
-	// 	run_to_next_phase::<T>();
-	// 	run_to_next_phase::<T>();
-	//
-	//
-	// 	let cindex = encointer_scheduler::Pallet::<T>::current_ceremony_index();
-	// 	let loc = Location { lat: Degree::from_num(1i32), lon: Degree::from_num(1i32) };
-	// 	let time = correct_meetup_time::<T>(cindex, loc);
-	// 	let mindex = 1;
-	//
-	// 	// attest_claims
-	// 	for i in 0..10 {
-	// 		let attestor = users[i as usize].clone();
-	// 		let mut attestees = users.clone();
-	// 		attestees.remove(i as usize);
-	// 		let claims = get_all_claims::<T>(&attestees, cid, cindex, mindex, loc, time, 10);
-	// 		assert_ok!(Pallet::<T>::attest_claims(RawOrigin::Signed(&attestor).into(), claims));
-	// 	}
-	//
-	// 	run_to_next_phase::<T>();
-	// 	assert!(!IssuedRewards::<T>::contains_key((cid, cindex), mindex));
-	// }: _(RawOrigin::Signed(account_id::<T>(&users[0])), cid)
-	// verify {
-	// 	assert_eq!(last_event::<T>(), Some(Event::RewardsIssued(cid, 1, 10).into()));
-	// 	assert!(IssuedRewards::<T>::contains_key((cid, cindex), mindex));
-	// }
-	//
+	claim_rewards {
+		frame_system::Pallet::<T>::set_block_number(frame_system::Pallet::<T>::block_number() + 1u32.into()); // this is needed to assert events
+		let cid = create_community::<T>();
+		let users = register_users::<T>(cid, 2, 8);
+
+		run_to_next_phase::<T>();
+		run_to_next_phase::<T>();
+
+		let cindex = encointer_scheduler::Pallet::<T>::current_ceremony_index();
+		let loc = Location { lat: Degree::from_num(1i32), lon: Degree::from_num(1i32) };
+		let time = correct_meetup_time::<T>(cindex, loc);
+		let mindex = 1;
+
+		// attest_claims
+		for i in 0..10 {
+			let attestor = users[i as usize].clone();
+			let mut attestees = users.clone();
+			attestees.remove(i as usize);
+			let claims = get_all_claims::<T>(attestees, cid, cindex, mindex, loc, time, 10);
+			assert_ok!(Pallet::<T>::attest_claims(RawOrigin::Signed(account_id::<T>(&attestor)).into(), claims));
+		}
+
+		run_to_next_phase::<T>();
+		assert!(!IssuedRewards::<T>::contains_key((cid, cindex), mindex));
+
+	}: _(RawOrigin::Signed(account_id::<T>(&users[0])), cid)
+	verify {
+		assert_eq!(last_event::<T>(), Some(Event::RewardsIssued(cid, 1, 10).into()));
+		assert!(IssuedRewards::<T>::contains_key((cid, cindex), mindex));
+	}
+
 	// set_inactivity_timeout {
 	// }: _(RawOrigin::Root, 13)
 	// verify {

--- a/ceremonies/src/benchmarking.rs
+++ b/ceremonies/src/benchmarking.rs
@@ -28,8 +28,8 @@ type TestPublic = app_sr25519::Public;
 
 /// Generates a pair in the test externalities' `KeyStoreExt`.
 ///
-///
-fn pair() -> TestPublic {
+/// Returns the public key of the generated pair.
+fn generate_pair() -> TestPublic {
 	// passing a seed gives an error for some reason
 	TestPublic::generate_pair(None)
 }
@@ -236,7 +236,7 @@ where
 	let num_users_total = num_newbies + num_reputables;
 	// create users and fake reputation
 	for i in 0..num_users_total {
-		let p = pair(&[i as u8; 32]);
+		let p = generate_pair();
 		users.push(p.clone());
 		if i < num_reputables {
 			proofs.push(fake_last_attendance_and_get_proof::<T>(&p, cid));
@@ -272,7 +272,7 @@ benchmarks! {
 	register_participant {
 		let cid = create_community::<T>();
 
-		let zoran = pair(&[9u8; 32]);
+		let zoran = generate_pair();
 		let zoran_account= account_id::<T>(&zoran);
 		let proof = fake_last_attendance_and_get_proof::<T>(&zoran, cid);
 		let cindex = encointer_scheduler::Pallet::<T>::current_ceremony_index();
@@ -290,7 +290,7 @@ benchmarks! {
 	attest_claims {
 		let cid = create_community::<T>();
 
-		let attestor = pair(&[10u8; 32]);
+		let attestor = generate_pair();
 		let attestor_account = account_id::<T>(&attestor);
 
 		assert_ok!(Pallet::<T>::register_participant(
@@ -328,7 +328,7 @@ benchmarks! {
 			NominalIncome::from_num(1)
 		));
 
-		let newbie = pair(&[10u8; 32]);
+		let newbie = generate_pair();
 		assert_ok!(Pallet::<T>::register_participant(
 			RawOrigin::Signed(account_id::<T>(&newbie)).into(),
 			cid, None
@@ -400,7 +400,7 @@ benchmarks! {
 	// purge_community_ceremony {
 	// 	let cid = create_community::<T>();
 	// 	let cindex = encointer_scheduler::Pallet::<T>::current_ceremony_index();
-	// 	let user = pair(&[10u8; 32]);
+	// 	let user = generate_pair();
 	// 	assert_ok!(Pallet::<T>::register_participant(RawOrigin::Signed(account_id::<T>(&user.clone())).into(), cid, Some(fake_last_attendance_and_get_proof::<T>(&user.clone(), cid))));
 	// 	assert_eq!(ReputableCount::<T>::get((cid, cindex)), 1);
 	// }: _(RawOrigin::Root, (cid, cindex))

--- a/ceremonies/src/benchmarking.rs
+++ b/ceremonies/src/benchmarking.rs
@@ -37,8 +37,12 @@ fn bootstrappers<T: frame_system::Config>() -> Vec<T::AccountId> {
 	vec![alice.clone(), bob.clone(), charlie.clone()]
 }
 
+fn test_location() -> Location {
+	Location { lat: Degree::from_num(1i32), lon: Degree::from_num(1i32) }
+}
+
 fn create_community<T: Config>() -> CommunityIdentifier {
-	let location = Location { lat: Degree::from_num(1i32), lon: Degree::from_num(1i32) };
+	let location = test_location();
 	let bs = bootstrappers::<T>();
 
 	encointer_communities::Pallet::<T>::new_community(
@@ -236,7 +240,7 @@ benchmarks! {
 		next_phase::<T>();
 
 		let cindex = encointer_scheduler::Pallet::<T>::current_ceremony_index();
-		let loc = Location { lat: Degree::from_num(1i32), lon: Degree::from_num(1i32) };
+		let loc = test_location();
 		let time = crate::Pallet::<T>::get_meetup_time(loc).expect("Could not get meetup time");
 		let mindex = 1;
 
@@ -282,7 +286,7 @@ benchmarks! {
 		next_phase::<T>();
 
 		let cindex = encointer_scheduler::Pallet::<T>::current_ceremony_index();
-		let loc = Location { lat: Degree::from_num(1i32), lon: Degree::from_num(1i32) };
+		let loc = test_location();
 		let time = crate::Pallet::<T>::get_meetup_time(loc).expect("Could not get meetup time");
 		let mindex = 1;
 

--- a/ceremonies/src/lib.rs
+++ b/ceremonies/src/lib.rs
@@ -1448,7 +1448,7 @@ impl<T: Config> Pallet<T> {
 	}
 
 	// this function only works during ATTESTING, so we're keeping it for private use
-	fn get_meetup_time(location: Location) -> Option<T::Moment> {
+	pub(crate) fn get_meetup_time(location: Location) -> Option<T::Moment> {
 		if !(<encointer_scheduler::Pallet<T>>::current_phase() == CeremonyPhaseType::ATTESTING) {
 			return None
 		}

--- a/communities/src/benchmarking.rs
+++ b/communities/src/benchmarking.rs
@@ -6,6 +6,7 @@ use encointer_primitives::{
 use frame_benchmarking::{account, benchmarks, impl_benchmark_test_suite};
 use frame_support::{assert_ok, parameter_types};
 use frame_system::RawOrigin;
+use sp_std::borrow::ToOwned;
 
 const NUM_LOCATIONS: u32 = 200;
 
@@ -111,12 +112,14 @@ benchmarks! {
 	update_community_metadata {
 		let (cid, bootstrappers, community_metadata, demurrage, nominal_income) = setup_test_community::<T>();
 		let mut new_community_metadata = CommunityMetadata::default();
-		new_community_metadata.name = "99charsaaaaaaaaaaaaa".into();
+		let new_community_name: PalletString = "99charsaaaaaaaaaaaaa".to_owned().into();
+
+		new_community_metadata.name = new_community_name.clone();
 	} : {
 		assert_ok!(Communities::<T>::update_community_metadata(RawOrigin::Root.into(), cid, new_community_metadata));
 	}
 	verify {
-		assert_eq!(Pallet::<T>::community_metadata(&cid).name, "99charsaaaaaaaaaaaaa");
+		assert_eq!(Pallet::<T>::community_metadata(&cid).name, new_community_name);
 	}
 
 	update_demurrage {

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -37,6 +37,9 @@ serde_derive = [
     "ep-core/serde_derive",
     "serde",
 ]
+full_crypto = [
+    "sp-core/full_crypto"
+]
 std = [
     "bs58/std",
     "codec/std",

--- a/primitives/src/ceremonies.rs
+++ b/primitives/src/ceremonies.rs
@@ -37,9 +37,6 @@ pub type MeetupTimeOffsetType = i32;
 #[cfg(not(feature = "std"))]
 use sp_std::vec::Vec;
 
-#[cfg(feature = "std")]
-use sp_core::Pair;
-
 #[derive(Encode, Decode, Copy, Clone, PartialEq, Eq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(feature = "serde_derive", derive(Serialize, Deserialize))]
 pub enum Reputation {
@@ -161,10 +158,10 @@ impl<Signature, AccountId: Clone + Encode, Moment: Encode + Copy>
 			.encode()
 	}
 
-	#[cfg(feature = "std")]
+	#[cfg(any(feature = "std", feature = "full_crypto"))]
 	pub fn sign<P>(self, pair: &P) -> Self
 	where
-		P: Pair,
+		P: sp_core::Pair,
 		Signature: From<P::Signature>,
 	{
 		let mut claim_mut = self;

--- a/primitives/src/ceremonies.rs
+++ b/primitives/src/ceremonies.rs
@@ -279,6 +279,7 @@ pub struct AssignmentParams {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use sp_core::Pair;
 	use test_utils::{AccountId, AccountKeyring, Moment, Signature};
 
 	#[test]

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -54,7 +54,7 @@ pub mod storage;
 pub const NONE: u64 = 0;
 pub const GENESIS_TIME: u64 = 1_585_058_843_000;
 pub const ONE_DAY: u64 = 86_400_000;
-pub const BLOCKTIME: u64 = 3_600_000; //1h per block
+pub const BLOCKTIME: u64 = 6_000; // 6s per block
 pub const TIME_TOLERANCE: u64 = 600000; // [ms]
 pub const LOCATION_TOLERANCE: u32 = 1000; // [m]
 pub const ZERO: BalanceType = BalanceType::from_bits(0x0);
@@ -122,7 +122,7 @@ macro_rules! impl_frame_system {
 
 pub type Moment = u64;
 parameter_types! {
-	pub const MinimumPeriod: Moment = 1;
+	pub const MinimumPeriod: Moment = BLOCKTIME / 2;
 }
 
 #[macro_export]


### PR DESCRIPTION
This predominantly contains changes in the ceremonies-benchmark, which had multiple issues:

* `no_std` incompatibility due to crypto usage. This was circumvented by not using the `sp_core::crypto::sr25519` module. Instead, we created our own crypto application keys with `sp-application-crypto`. This approach is taken from [frame-benchmarking](https://github.com/paritytech/substrate/blob/master/frame/benchmarking/src/baseline.rs).
* the node disliked that we played with block numbers, timestamps and `on_finalize` hooks. Updating the phase was simply replaced by a `scheduler::next_phase` call.
* fixed some unrealistic trait bounds and cleaned up the benchmarking in general.

General Changes:
 * Fix some no_std stuff.

Tested:
* benchmarks run for all pallets