### PR TITLE
Fix encointer balances transfer decoding in runtime

### DIFF
--- a/balances/src/benchmarking.rs
+++ b/balances/src/benchmarking.rs
@@ -9,10 +9,9 @@ benchmarks! {
 		let cid = CommunityIdentifier::default();
 		let alice: T::AccountId = account("alice", 1, 1);
 		let bob: T::AccountId = account("bob", 2, 2);
-		let bob_lookup: <T::Lookup as StaticLookup>::Source = T::Lookup::unlookup(bob.clone());
 
 		Pallet::<T>::issue(cid, &alice, BalanceType::from_num(12i32)).ok();
-	}: _(RawOrigin::Signed(alice.clone()), bob_lookup, cid, BalanceType::from_num(10i32))
+	}: _(RawOrigin::Signed(alice.clone()), bob.clone(), cid, BalanceType::from_num(10i32))
 	verify{
 		let balance_alice: f64 = Pallet::<T>::balance(cid, &alice).lossy_into();
 		assert_abs_diff_eq!(balance_alice, 2f64, epsilon= 0.0001);

--- a/balances/src/lib.rs
+++ b/balances/src/lib.rs
@@ -30,7 +30,6 @@ use frame_support::{
 };
 use frame_system::{self as frame_system, ensure_signed};
 use log::{debug, info};
-use sp_runtime::traits::StaticLookup;
 use sp_std::convert::TryInto;
 
 // Logger target
@@ -84,15 +83,14 @@ pub mod pallet {
 		#[pallet::weight((<T as Config>::WeightInfo::transfer(), DispatchClass::Normal, Pays::Yes))]
 		pub fn transfer(
 			origin: OriginFor<T>,
-			dest: <T::Lookup as StaticLookup>::Source,
+			dest: T::AccountId,
 			community_id: CommunityIdentifier,
 			amount: BalanceType,
 		) -> DispatchResultWithPostInfo {
 			let from = ensure_signed(origin)?;
-			let to = T::Lookup::lookup(dest)?;
-			Self::transfer_(community_id, &from, &to, amount)?;
+			Self::transfer_(community_id, &from, &dest, amount)?;
 
-			Self::deposit_event(Event::Transferred(community_id, from, to, amount));
+			Self::deposit_event(Event::Transferred(community_id, from, dest, amount));
 			Ok(().into())
 		}
 


### PR DESCRIPTION
When sending `encointer_balances.transfer` from the rust client, the runtime could not decode the tx.

I have no idea, why we used `StaticLookup` in the first place. The normal `balances` pallet does also use standart account id.