### PR TITLE
rename rpcs

### DIFF
--- a/bazaar/rpc/src/lib.rs
+++ b/bazaar/rpc/src/lib.rs
@@ -33,19 +33,19 @@ pub trait BazaarApi<BlockHash, AccountId>
 where
 	AccountId: 'static + Encode + Decode + Send + Sync,
 {
-	#[rpc(name = "encointer_bazaar_getBusinesses")]
+	#[rpc(name = "encointer_bazaarGetBusinesses")]
 	fn get_businesses(
 		&self,
 		cid: CommunityIdentifier,
 		at: Option<BlockHash>,
 	) -> Result<Vec<BusinessData>>;
-	#[rpc(name = "encointer_bazaar_getOfferings")]
+	#[rpc(name = "encointer_bazaarGetOfferings")]
 	fn get_offerings(
 		&self,
 		cid: CommunityIdentifier,
 		at: Option<BlockHash>,
 	) -> Result<Vec<OfferingData>>;
-	#[rpc(name = "encointer_bazaar_getOfferingsForBusiness")]
+	#[rpc(name = "encointer_bazaarGetOfferingsForBusiness")]
 	fn get_offerings_for_business(
 		&self,
 		bid: BusinessIdentifier<AccountId>,

--- a/bazaar/rpc/src/lib.rs
+++ b/bazaar/rpc/src/lib.rs
@@ -33,19 +33,19 @@ pub trait BazaarApi<BlockHash, AccountId>
 where
 	AccountId: 'static + Encode + Decode + Send + Sync,
 {
-	#[rpc(name = "bazaar_getBusinesses")]
+	#[rpc(name = "encointer_bazaar_getBusinesses")]
 	fn get_businesses(
 		&self,
 		cid: CommunityIdentifier,
 		at: Option<BlockHash>,
 	) -> Result<Vec<BusinessData>>;
-	#[rpc(name = "bazaar_getOfferings")]
+	#[rpc(name = "encointer_bazaar_getOfferings")]
 	fn get_offerings(
 		&self,
 		cid: CommunityIdentifier,
 		at: Option<BlockHash>,
 	) -> Result<Vec<OfferingData>>;
-	#[rpc(name = "bazaar_getOfferingsForBusiness")]
+	#[rpc(name = "encointer_bazaar_getOfferingsForBusiness")]
 	fn get_offerings_for_business(
 		&self,
 		bid: BusinessIdentifier<AccountId>,

--- a/ceremonies/rpc/src/lib.rs
+++ b/ceremonies/rpc/src/lib.rs
@@ -46,7 +46,7 @@ where
 		at: Option<BlockHash>,
 	) -> Result<Vec<(CeremonyIndexType, CommunityReputation)>>;
 
-	#[rpc(name = "ceremonies_getAggregatedAccountData")]
+	#[rpc(name = "encointer_getAggregatedAccountData")]
 	fn get_aggregated_account_data(
 		&self,
 		cid: CommunityIdentifier,

--- a/ceremonies/rpc/src/lib.rs
+++ b/ceremonies/rpc/src/lib.rs
@@ -39,7 +39,7 @@ where
 	AccountId: 'static + Encode + Decode + Send + Sync,
 	Moment: 'static + Encode + Decode + Send + Sync,
 {
-	#[rpc(name = "ceremonies_getReputations")]
+	#[rpc(name = "encointer_getReputations")]
 	fn get_reputations(
 		&self,
 		account: AccountId,

--- a/communities/rpc/src/lib.rs
+++ b/communities/rpc/src/lib.rs
@@ -41,17 +41,17 @@ where
 	AccountId: 'static + Encode + Decode + Send + Sync,
 	BlockNumber: 'static + Encode + Decode + Send + Sync,
 {
-	#[rpc(name = "communities_getAll")]
+	#[rpc(name = "encointer_getAllCommunities")]
 	fn communities_get_all(&self, at: Option<BlockHash>) -> Result<Vec<CidName>>;
 
-	#[rpc(name = "communities_getLocations")]
+	#[rpc(name = "encointer_getLocations")]
 	fn communities_get_locations(
 		&self,
 		cid: CommunityIdentifier,
 		at: Option<BlockHash>,
 	) -> Result<Vec<Location>>;
 
-	#[rpc(name = "communities_getAllBalances")]
+	#[rpc(name = "encointer_getAllBalances")]
 	fn communities_get_all_balances(
 		&self,
 		account: AccountId,


### PR DESCRIPTION
Introduce `encointer_` prefix for RPC method names
Part of #163 