### PR TITLE
EncoinerBalance creates accounts if they did not exists before

### DIFF
--- a/balances/src/lib.rs
+++ b/balances/src/lib.rs
@@ -73,7 +73,7 @@ pub mod pallet {
 		#[pallet::constant]
 		type DefaultDemurrage: Get<Demurrage>;
 
-		/// Existential deposit needed to have an account the respective community currency
+		/// Existential deposit needed to have an account in the respective community currency
 		///
 		/// This does currently not prevent dust-accounts, but it prevents account creation
 		/// by transferring tiny amounts of funds.
@@ -164,7 +164,7 @@ pub mod pallet {
 		TotalIssuanceOverflow,
 		/// Account to alter does not exist in community
 		NoAccount,
-		/// Balance to low to create an account
+		/// Balance too low to create an account
 		ExistentialDeposit,
 	}
 

--- a/balances/src/lib.rs
+++ b/balances/src/lib.rs
@@ -286,7 +286,7 @@ impl<T: Config> Pallet<T> {
 		if !Balance::<T>::contains_key(cid, &dest) {
 			ensure!(amount > T::ExistentialDeposit::get(), Error::<T>::ExistentialDeposit);
 			Self::new_account(&dest)?;
-			Self::deposit_event(Event::Endowed { cid, who: source.clone(), balance: amount });
+			Self::deposit_event(Event::Endowed { cid, who: dest.clone(), balance: amount });
 		}
 
 		let mut entry_to = Self::balance_entry_updated(cid, &dest);

--- a/balances/src/lib.rs
+++ b/balances/src/lib.rs
@@ -148,6 +148,8 @@ pub mod pallet {
 	#[pallet::event]
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
 	pub enum Event<T: Config> {
+		/// Endowed a new account with a respective currency `[community_id, who, balance]`
+		Endowed { cid: CommunityIdentifier, who: T::AccountId, balance: BalanceType },
 		/// Token transfer success `[community_id, from, to, amount]`
 		Transferred(CommunityIdentifier, T::AccountId, T::AccountId, BalanceType),
 		/// fee conversion factor updated successfully
@@ -284,6 +286,7 @@ impl<T: Config> Pallet<T> {
 		if !Balance::<T>::contains_key(cid, &dest) {
 			ensure!(amount > T::ExistentialDeposit::get(), Error::<T>::ExistentialDeposit);
 			Self::new_account(&dest)?;
+			Self::deposit_event(Event::Endowed { cid, who: source.clone(), balance: amount });
 		}
 
 		let mut entry_to = Self::balance_entry_updated(cid, &dest);

--- a/balances/src/mock.rs
+++ b/balances/src/mock.rs
@@ -17,7 +17,7 @@
 //! Mock runtime for the encointer_balances module
 
 use crate as dut;
-use encointer_primitives::balances::Demurrage;
+use encointer_primitives::balances::{BalanceType, Demurrage};
 use frame_support::pallet_prelude::GenesisBuild;
 use test_utils::*;
 
@@ -26,6 +26,8 @@ type Block = frame_system::mocking::MockBlock<TestRuntime>;
 
 frame_support::parameter_types! {
 	pub const DefaultDemurrage: Demurrage = Demurrage::from_bits(0x0000000000000000000001E3F0A8A973_i128);
+	/// 0.000005
+	pub const ExistentialDeposit: BalanceType = BalanceType::from_bits(0x0000000000000000000053e2d6238da4_i128);
 }
 
 frame_support::construct_runtime!(
@@ -44,6 +46,7 @@ frame_support::construct_runtime!(
 impl dut::Config for TestRuntime {
 	type Event = Event;
 	type DefaultDemurrage = DefaultDemurrage;
+	type ExistentialDeposit = ExistentialDeposit;
 	type WeightInfo = ();
 	type CeremonyMaster = EnsureAlice;
 }

--- a/balances/src/tests.rs
+++ b/balances/src/tests.rs
@@ -156,6 +156,27 @@ fn transfer_should_create_new_account() {
 }
 
 #[test]
+fn transfer_does_not_create_new_account_if_below_ed() {
+	new_test_ext().execute_with(|| {
+		System::set_block_number(System::block_number() + 1);
+		System::on_initialize(System::block_number());
+
+		let alice = AccountKeyring::Alice.to_account_id();
+
+		// does not exist on chain
+		let zoltan: AccountId32 = sr25519::Pair::from_entropy(&[9u8; 32], None).0.public().into();
+		let cid = CommunityIdentifier::default();
+		let amount = BalanceType::from_num(0.0000000001);
+
+		assert_ok!(EncointerBalances::issue(cid, &alice, BalanceType::from_num(50u128)));
+		assert_noop!(
+			EncointerBalances::transfer(Some(alice.clone()).into(), zoltan.clone(), cid, amount),
+			Error::<TestRuntime>::ExistentialDeposit,
+		);
+	});
+}
+
+#[test]
 fn demurrage_should_work() {
 	new_test_ext().execute_with(|| {
 		let alice = AccountKeyring::Alice.to_account_id();

--- a/balances/src/tests.rs
+++ b/balances/src/tests.rs
@@ -177,6 +177,26 @@ fn transfer_does_not_create_new_account_if_below_ed() {
 }
 
 #[test]
+fn if_account_does_not_exist_in_community_transfer_errs_with_no_account_error() {
+	new_test_ext().execute_with(|| {
+		System::set_block_number(System::block_number() + 1);
+		System::on_initialize(System::block_number());
+
+		let alice = AccountKeyring::Alice.to_account_id();
+
+		// does not exist on chain
+		let zoltan: AccountId32 = sr25519::Pair::from_entropy(&[9u8; 32], None).0.public().into();
+		let cid = CommunityIdentifier::default();
+		let amount = BalanceType::from_num(0.0000000001);
+
+		assert_noop!(
+			EncointerBalances::transfer(Some(alice.clone()).into(), zoltan.clone(), cid, amount),
+			Error::<TestRuntime>::NoAccount,
+		);
+	});
+}
+
+#[test]
 fn demurrage_should_work() {
 	new_test_ext().execute_with(|| {
 		let alice = AccountKeyring::Alice.to_account_id();

--- a/test-utils/src/helpers.rs
+++ b/test-utils/src/helpers.rs
@@ -73,6 +73,15 @@ where
 	CommunityIdentifier::new(location, bs).unwrap()
 }
 
+pub fn events<T: frame_system::Config>() -> Vec<T::Event> {
+	let events = frame_system::Pallet::<T>::events()
+		.into_iter()
+		.map(|evt| evt.event)
+		.collect::<Vec<_>>();
+	frame_system::Pallet::<T>::reset_events();
+	events
+}
+
 pub fn last_event<T: frame_system::Config>() -> Option<T::Event> {
 	let events = frame_system::Pallet::<T>::events();
 	if events.len() < 1 {

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -171,6 +171,8 @@ macro_rules! impl_balances {
 
 parameter_types! {
 	pub const DefaultDemurrage: Demurrage = Demurrage::from_bits(0x0000000000000000000001E3F0A8A973_i128);
+	/// 0.000005
+	pub const EncointerBalancesExistentialDeposit: BalanceType = BalanceType::from_bits(0x0000000000000000000053e2d6238da4_i128);
 }
 
 #[macro_export]
@@ -179,6 +181,7 @@ macro_rules! impl_encointer_balances {
 		impl encointer_balances::Config for $t {
 			type Event = Event;
 			type DefaultDemurrage = DefaultDemurrage;
+			type ExistentialDeposit = EncointerBalancesExistentialDeposit;
 			type WeightInfo = ();
 			type CeremonyMaster = EnsureAlice;
 		}


### PR DESCRIPTION
Tested with the encointer-node that we can create accounts with an encointer-balance transfer, and that the created account can send extrinsics without having native balance 🥳 