### PR TITLE
fix division by zero panic if phase duration is zero

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3398,7 +3398,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-scheduler"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "encointer-primitives",
  "frame-benchmarking",

--- a/scheduler/Cargo.toml
+++ b/scheduler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-encointer-scheduler"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["encointer.org <alain@encointer.org>"]
 edition = "2018"
 


### PR DESCRIPTION
when upgrading to full runtime from launch, we experienced a panic because phase durations were initialized to zero