### PR TITLE
[ceremonies] fix purging of a community and community ceremonies

### DIFF
--- a/ceremonies/src/lib.rs
+++ b/ceremonies/src/lib.rs
@@ -1447,11 +1447,8 @@ impl<T: Config> Pallet<T> {
 		let current = <encointer_scheduler::Pallet<T>>::current_ceremony_index();
 		let reputation_lifetime = Self::reputation_lifetime();
 
-		for cindex in max(current.saturating_sub(reputation_lifetime), 0)..current {
-			if cindex > reputation_lifetime {
-				let purge_index = current.saturating_sub(reputation_lifetime).saturating_sub(1);
-				Self::purge_registry(purge_index);
-			}
+		for cindex in current.saturating_sub(reputation_lifetime)..=current {
+			Self::purge_community_ceremony_internal((cid, cindex));
 		}
 		<encointer_communities::Pallet<T>>::remove_community(cid);
 	}

--- a/ceremonies/src/lib.rs
+++ b/ceremonies/src/lib.rs
@@ -1248,33 +1248,33 @@ impl<T: Config> Pallet<T> {
 
 		<BootstrapperRegistry<T>>::remove_prefix(cc, None);
 		<BootstrapperIndex<T>>::remove_prefix(cc, None);
-		<BootstrapperCount<T>>::insert(cc, 0);
+		<BootstrapperCount<T>>::remove(cc);
 
 		<ReputableRegistry<T>>::remove_prefix(cc, None);
 		<ReputableIndex<T>>::remove_prefix(cc, None);
-		<ReputableCount<T>>::insert(cc, 0);
+		<ReputableCount<T>>::remove(cc);
 
 		<EndorseeRegistry<T>>::remove_prefix(cc, None);
 		<EndorseeIndex<T>>::remove_prefix(cc, None);
-		<EndorseeCount<T>>::insert(cc, 0);
+		<EndorseeCount<T>>::remove(cc);
 
 		<NewbieRegistry<T>>::remove_prefix(cc, None);
 		<NewbieIndex<T>>::remove_prefix(cc, None);
-		<NewbieCount<T>>::insert(cc, 0);
+		<NewbieCount<T>>::remove(cc);
 
-		<AssignmentCounts<T>>::insert(cc, AssignmentCount::default());
+		<AssignmentCounts<T>>::remove(cc);
 
 		Assignments::<T>::remove(cc);
 
 		<ParticipantReputation<T>>::remove_prefix(cc, None);
 
 		<Endorsees<T>>::remove_prefix(cc, None);
-		<EndorseesCount<T>>::insert(cc, 0);
-		<MeetupCount<T>>::insert(cc, 0);
+		<EndorseesCount<T>>::remove(cc);
+		<MeetupCount<T>>::remove(cc);
 
 		<AttestationRegistry<T>>::remove_prefix(cc, None);
 		<AttestationIndex<T>>::remove_prefix(cc, None);
-		<AttestationCount<T>>::insert(cc, 0);
+		<AttestationCount<T>>::remove(cc);
 
 		<MeetupParticipantCountVote<T>>::remove_prefix(cc, None);
 		<IssuedRewards<T>>::remove_prefix(cc, None);
@@ -1450,6 +1450,9 @@ impl<T: Config> Pallet<T> {
 		for cindex in current.saturating_sub(reputation_lifetime)..=current {
 			Self::purge_community_ceremony_internal((cid, cindex));
 		}
+
+		<InactivityCounters<T>>::remove(cid);
+
 		<encointer_communities::Pallet<T>>::remove_community(cid);
 	}
 

--- a/ceremonies/src/tests.rs
+++ b/ceremonies/src/tests.rs
@@ -1665,7 +1665,7 @@ fn grow_population_and_removing_community_works() {
 		assert_eq!(proof_count, 13);
 		assert_eq!(EncointerCeremonies::meetup_count((cid, cindex)), 2);
 
-		// no we remove the community
+		// now we remove the community
 		EncointerCeremonies::purge_community(cid);
 
 		let reputation_lifetime = EncointerCeremonies::reputation_lifetime();

--- a/ceremonies/src/tests.rs
+++ b/ceremonies/src/tests.rs
@@ -1563,7 +1563,7 @@ fn after_inactive_cycle_forbid_non_bootstrapper_registration() {
 }
 
 #[test]
-fn grow_population_works() {
+fn grow_population_and_removing_community_works() {
 	new_test_ext().execute_with(|| {
 		let cid = perform_bootstrapping_ceremony(None, 3);
 		let mut participants = bootstrappers();
@@ -1664,6 +1664,62 @@ fn grow_population_works() {
 		// Assigning
 		assert_eq!(proof_count, 13);
 		assert_eq!(EncointerCeremonies::meetup_count((cid, cindex)), 2);
+
+		// no we remove the community
+		EncointerCeremonies::purge_community(cid);
+
+		let reputation_lifetime = EncointerCeremonies::reputation_lifetime();
+		let current_cindex =
+			EncointerScheduler::current_ceremony_index().saturating_sub(reputation_lifetime);
+
+		// only sanity check. Community removal is better tested in the communities pallet.
+		assert_eq!(EncointerCommunities::community_identifiers().contains(&cid), false);
+
+		for cindex in current_cindex.saturating_sub(reputation_lifetime)..=current_cindex {
+			assert_eq!(
+				BootstrapperRegistry::<TestRuntime>::iter_prefix((cid, cindex)).next(),
+				None
+			);
+			assert_eq!(BootstrapperIndex::<TestRuntime>::iter_prefix((cid, cindex)).next(), None);
+			assert_eq!(BootstrapperCount::<TestRuntime>::contains_key((cid, cindex)), false);
+
+			assert_eq!(ReputableRegistry::<TestRuntime>::iter_prefix((cid, cindex)).next(), None);
+			assert_eq!(ReputableIndex::<TestRuntime>::iter_prefix((cid, cindex)).next(), None);
+			assert_eq!(ReputableCount::<TestRuntime>::contains_key((cid, cindex)), false);
+
+			assert_eq!(EndorseeRegistry::<TestRuntime>::iter_prefix((cid, cindex)).next(), None);
+			assert_eq!(EndorseeIndex::<TestRuntime>::iter_prefix((cid, cindex)).next(), None);
+			assert_eq!(EndorseeCount::<TestRuntime>::contains_key((cid, cindex)), false);
+
+			assert_eq!(NewbieRegistry::<TestRuntime>::iter_prefix((cid, cindex)).next(), None);
+			assert_eq!(NewbieIndex::<TestRuntime>::iter_prefix((cid, cindex)).next(), None);
+			assert_eq!(NewbieCount::<TestRuntime>::contains_key((cid, cindex)), false);
+
+			assert_eq!(AssignmentCounts::<TestRuntime>::contains_key((cid, cindex)), false);
+			assert_eq!(Assignments::<TestRuntime>::contains_key((cid, cindex)), false);
+
+			assert_eq!(
+				ParticipantReputation::<TestRuntime>::iter_prefix((cid, cindex)).next(),
+				None
+			);
+
+			assert_eq!(Endorsees::<TestRuntime>::iter_prefix((cid, cindex)).next(), None);
+			assert_eq!(EndorseesCount::<TestRuntime>::contains_key((cid, cindex)), false);
+			assert_eq!(MeetupCount::<TestRuntime>::contains_key((cid, cindex)), false);
+
+			assert_eq!(AttestationRegistry::<TestRuntime>::iter_prefix((cid, cindex)).next(), None);
+			assert_eq!(AttestationIndex::<TestRuntime>::iter_prefix((cid, cindex)).next(), None);
+			assert_eq!(AttestationCount::<TestRuntime>::contains_key((cid, cindex)), false);
+
+			assert_eq!(
+				MeetupParticipantCountVote::<TestRuntime>::iter_prefix((cid, cindex)).next(),
+				None
+			);
+
+			assert_eq!(IssuedRewards::<TestRuntime>::iter_prefix((cid, cindex)).next(), None);
+
+			assert_eq!(InactivityCounters::<TestRuntime>::contains_key(cid), false);
+		}
 	});
 }
 


### PR DESCRIPTION
The purging was untested, and was not done cleanly. This PR fixes the purging of community/-ceremonies and adds a test.

Fixes:
* We essentially had a storage leak: There were residues in the map when we purged the community ceremony before because the default value was set in the clean-up instead of removing the key. This was correct at some point as far as a remember, but it was bricked after substrate introduced the `OptionQuery` and `ValueQuery` parameters. As we did not test this, we did not notice the change in behaviour.

This PR fixes the above and tests purging the community ceremony.