### PR TITLE
fix purging of inactive communities

### DIFF
--- a/ceremonies/src/lib.rs
+++ b/ceremonies/src/lib.rs
@@ -689,6 +689,9 @@ pub mod pallet {
 			account: T::AccountId,
 			reason: ExclusionReason,
 		},
+
+		/// The inactivity counter of a community has been increased
+		InactivityCounterUpdated(CommunityIdentifier, u32),
 	}
 
 	#[pallet::error]
@@ -1422,7 +1425,7 @@ impl<T: Config> Pallet<T> {
 		})
 	}
 
-	fn get_inactive_communities(
+	fn update_inactivity_counters(
 		cindex: u32,
 		inactivity_timeout: u32,
 		cids: Vec<CommunityIdentifier>,
@@ -1431,12 +1434,15 @@ impl<T: Config> Pallet<T> {
 		for cid in cids {
 			if <IssuedRewards<T>>::iter_prefix_values((cid, cindex)).next().is_some() {
 				<InactivityCounters<T>>::insert(cid, 0);
+				Self::deposit_event(Event::InactivityCounterUpdated(cid, 0));
 			} else {
 				let current = Self::inactivity_counters(cid).unwrap_or(0);
 				if current >= inactivity_timeout {
 					inactives.push(cid.clone());
 				} else {
-					<InactivityCounters<T>>::insert(cid, current + 1);
+					let new_counter = current + 1;
+					<InactivityCounters<T>>::insert(cid, new_counter);
+					Self::deposit_event(Event::InactivityCounterUpdated(cid, new_counter));
 				}
 			}
 		}
@@ -1839,11 +1845,15 @@ impl<T: Config> OnCeremonyPhaseChange for Pallet<T> {
 				let cindex = <encointer_scheduler::Pallet<T>>::current_ceremony_index();
 				// Clean up with a time delay, such that participants can claim their UBI in the following cycle.
 				if cindex > Self::reputation_lifetime() {
-					Self::purge_registry(cindex - Self::reputation_lifetime() - 1);
+					Self::purge_registry(
+						cindex.saturating_sub(Self::reputation_lifetime()).saturating_sub(1),
+					);
 				}
-				let inactives = Self::get_inactive_communities(
-					<encointer_scheduler::Pallet<T>>::current_ceremony_index() - 1,
-					Self::inactivity_timeout(),
+				let inactives = Self::update_inactivity_counters(
+					// check inactivity with delay, such that rewards can be claimed before the inactivity check happens
+					<encointer_scheduler::Pallet<T>>::current_ceremony_index().saturating_sub(2),
+					// compensate for the delay
+					Self::inactivity_timeout().saturating_add(1),
 					<encointer_communities::Pallet<T>>::community_identifiers(),
 				);
 				for inactive in inactives {

--- a/ceremonies/src/mock.rs
+++ b/ceremonies/src/mock.rs
@@ -97,7 +97,7 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 		ceremony_reward: BalanceType::from_num(1),
 		location_tolerance: LOCATION_TOLERANCE, // [m]
 		time_tolerance: TIME_TOLERANCE,         // [ms]
-		inactivity_timeout: 12,
+		inactivity_timeout: 3,
 		endorsement_tickets_per_bootstrapper: 50,
 		reputation_lifetime: 6,
 		meetup_time_offset: 0,

--- a/ceremonies/src/tests.rs
+++ b/ceremonies/src/tests.rs
@@ -1513,6 +1513,13 @@ fn ceremony_index_and_purging_registry_works() {
 		assert_eq!(EncointerCeremonies::bootstrapper_registry((cid, cindex), &1).unwrap(), alice);
 
 		for _ in 0..reputation_lifetime {
+			// issue some rewards such that the inactivity counter is not increased
+			IssuedRewards::<TestRuntime>::insert(
+				(cid, EncointerScheduler::current_ceremony_index()),
+				0,
+				(),
+			);
+
 			run_to_next_phase();
 			run_to_next_phase();
 			run_to_next_phase();
@@ -1715,7 +1722,7 @@ fn get_assignment_params_works() {
 }
 
 #[test]
-fn get_inactive_communities_works() {
+fn update_inactivity_counters_works() {
 	new_test_ext().execute_with(|| {
 		let cid0 = CommunityIdentifier::default();
 		let cid1 = CommunityIdentifier::new(
@@ -1731,27 +1738,124 @@ fn get_inactive_communities_works() {
 
 		let timeout = 1;
 		assert_eq!(
-			EncointerCeremonies::get_inactive_communities(cindex, timeout, vec![cid0, cid1]),
+			EncointerCeremonies::update_inactivity_counters(cindex, timeout, vec![cid0, cid1]),
 			vec![]
 		);
 
 		cindex += 1;
 		IssuedRewards::<TestRuntime>::insert((cid0, cindex), 0, ());
 		assert_eq!(
-			EncointerCeremonies::get_inactive_communities(cindex, timeout, vec![cid0, cid1]),
+			EncointerCeremonies::update_inactivity_counters(cindex, timeout, vec![cid0, cid1]),
 			vec![]
 		);
 
 		cindex += 1;
 		assert_eq!(
-			EncointerCeremonies::get_inactive_communities(cindex, timeout, vec![cid0, cid1]),
+			EncointerCeremonies::update_inactivity_counters(cindex, timeout, vec![cid0, cid1]),
 			vec![cid1]
 		);
 
 		cindex += 1;
 		assert_eq!(
-			EncointerCeremonies::get_inactive_communities(cindex, timeout, vec![cid0, cid1]),
+			EncointerCeremonies::update_inactivity_counters(cindex, timeout, vec![cid0, cid1]),
 			vec![cid0, cid1]
+		);
+	});
+}
+
+#[test]
+fn purge_inactive_communities_works() {
+	new_test_ext().execute_with(|| {
+		System::set_block_number(System::block_number() + 1); // this is needed to assert events
+		let cid = perform_bootstrapping_ceremony(None, 1);
+
+		assert!(
+			<encointer_communities::Pallet<TestRuntime>>::community_identifiers().contains(&cid)
+		);
+
+		// inactivity counter is 1, beacuse of a full ceremony cycle in the bootstrapping ceremony
+		// without any rewards being claimed
+		assert_eq!(EncointerCeremonies::inactivity_counters(cid).unwrap(), 1);
+
+		// issued rewards will cause inactivity counter to go to 0 after two cycles
+		IssuedRewards::<TestRuntime>::insert(
+			(cid, EncointerScheduler::current_ceremony_index()),
+			0,
+			(),
+		);
+
+		run_to_next_phase();
+		run_to_next_phase();
+		run_to_next_phase();
+
+		assert_eq!(
+			event_at_index::<TestRuntime>(get_num_events::<TestRuntime>() - 2),
+			Some(Event::InactivityCounterUpdated(cid, 2).into())
+		);
+
+		assert!(
+			<encointer_communities::Pallet<TestRuntime>>::community_identifiers().contains(&cid)
+		);
+		assert_eq!(EncointerCeremonies::inactivity_counters(cid).unwrap(), 2);
+
+		run_to_next_phase();
+		run_to_next_phase();
+		run_to_next_phase();
+
+		assert_eq!(
+			event_at_index::<TestRuntime>(get_num_events::<TestRuntime>() - 2),
+			Some(Event::InactivityCounterUpdated(cid, 0).into())
+		);
+
+		assert!(
+			<encointer_communities::Pallet<TestRuntime>>::community_identifiers().contains(&cid)
+		);
+		assert_eq!(EncointerCeremonies::inactivity_counters(cid).unwrap(), 0);
+
+		run_to_next_phase();
+		run_to_next_phase();
+		run_to_next_phase();
+
+		assert!(
+			<encointer_communities::Pallet<TestRuntime>>::community_identifiers().contains(&cid)
+		);
+		assert_eq!(EncointerCeremonies::inactivity_counters(cid).unwrap(), 1);
+
+		run_to_next_phase();
+		run_to_next_phase();
+		run_to_next_phase();
+
+		assert!(
+			<encointer_communities::Pallet<TestRuntime>>::community_identifiers().contains(&cid)
+		);
+		assert_eq!(EncointerCeremonies::inactivity_counters(cid).unwrap(), 2);
+
+		run_to_next_phase();
+		run_to_next_phase();
+		run_to_next_phase();
+
+		assert!(
+			<encointer_communities::Pallet<TestRuntime>>::community_identifiers().contains(&cid)
+		);
+		assert_eq!(EncointerCeremonies::inactivity_counters(cid).unwrap(), 3);
+
+		run_to_next_phase();
+		run_to_next_phase();
+		run_to_next_phase();
+
+		assert!(
+			<encointer_communities::Pallet<TestRuntime>>::community_identifiers().contains(&cid)
+		);
+		// now the inactivity counter is 4 = inactivity_timeout + 1, so the community will be purged after the next cycle
+		assert_eq!(EncointerCeremonies::inactivity_counters(cid).unwrap(), 4);
+
+		run_to_next_phase();
+		run_to_next_phase();
+		run_to_next_phase();
+
+		// here community gets purged
+		assert!(
+			!<encointer_communities::Pallet<TestRuntime>>::community_identifiers().contains(&cid)
 		);
 	});
 }

--- a/ceremonies/src/tests.rs
+++ b/ceremonies/src/tests.rs
@@ -1777,17 +1777,8 @@ fn purge_inactive_communities_works() {
 		// without any rewards being claimed
 		assert_eq!(EncointerCeremonies::inactivity_counters(cid).unwrap(), 1);
 
-		// issued rewards will cause inactivity counter to go to 0 after two cycles
-		IssuedRewards::<TestRuntime>::insert(
-			(cid, EncointerScheduler::current_ceremony_index()),
-			0,
-			(),
-		);
-
 		run_to_next_phase();
-		run_to_next_phase();
-		run_to_next_phase();
-
+		// Assigning
 		assert_eq!(
 			event_at_index::<TestRuntime>(get_num_events::<TestRuntime>() - 2),
 			Some(Event::InactivityCounterUpdated(cid, 2).into())
@@ -1798,6 +1789,12 @@ fn purge_inactive_communities_works() {
 		);
 		assert_eq!(EncointerCeremonies::inactivity_counters(cid).unwrap(), 2);
 
+		// issued rewards will cause inactivity counter to go to 0 in the next cycle
+		IssuedRewards::<TestRuntime>::insert(
+			(cid, EncointerScheduler::current_ceremony_index()),
+			0,
+			(),
+		);
 		run_to_next_phase();
 		run_to_next_phase();
 		run_to_next_phase();
@@ -1811,7 +1808,6 @@ fn purge_inactive_communities_works() {
 			<encointer_communities::Pallet<TestRuntime>>::community_identifiers().contains(&cid)
 		);
 		assert_eq!(EncointerCeremonies::inactivity_counters(cid).unwrap(), 0);
-
 		run_to_next_phase();
 		run_to_next_phase();
 		run_to_next_phase();
@@ -1837,17 +1833,8 @@ fn purge_inactive_communities_works() {
 		assert!(
 			<encointer_communities::Pallet<TestRuntime>>::community_identifiers().contains(&cid)
 		);
+		// now the inactivity counter is 3 == inactivity_timeout, so in the next cycle the community will be purged
 		assert_eq!(EncointerCeremonies::inactivity_counters(cid).unwrap(), 3);
-
-		run_to_next_phase();
-		run_to_next_phase();
-		run_to_next_phase();
-
-		assert!(
-			<encointer_communities::Pallet<TestRuntime>>::community_identifiers().contains(&cid)
-		);
-		// now the inactivity counter is 4 = inactivity_timeout + 1, so the community will be purged after the next cycle
-		assert_eq!(EncointerCeremonies::inactivity_counters(cid).unwrap(), 4);
 
 		run_to_next_phase();
 		run_to_next_phase();


### PR DESCRIPTION
* Closes https://github.com/encointer/encointer-parachain/issues/138

The issue was simple: The check if cc was issued in cindex-1 was performed at the very beginning of the registration phase. The problem is that the claiming of cc for cindex-1 only happens in this registration phase after the check.

Fixed by checking for cindex-2.
Added tests and events.
Also renamed `get_inactive_communities_works` -> `update_inactivity_counters_works` beacuse `get` suggests side-effect-freeness which is not the case here