### PR TITLE
[ceremonies] bootstrappers can also endorse as reputables

### DIFF
--- a/ceremonies/src/lib.rs
+++ b/ceremonies/src/lib.rs
@@ -332,26 +332,7 @@ pub mod pallet {
 				Error::<T>::AlreadyEndorsed
 			);
 
-			if <encointer_communities::Pallet<T>>::bootstrappers(&cid).contains(&sender) {
-				ensure!(
-					<BurnedBootstrapperNewbieTickets<T>>::get(&cid, &sender) <
-						Self::endorsement_tickets_per_bootstrapper(),
-					Error::<T>::NoMoreNewbieTickets
-				);
-				<BurnedBootstrapperNewbieTickets<T>>::mutate(&cid, sender.clone(), |b| *b += 1);
-			// safe; limited by AMOUNT_NEWBIE_TICKETS
-			} else if Self::has_reputation(&sender, &cid) {
-				ensure!(
-					<BurnedReputableNewbieTickets<T>>::get(&(cid, cindex), &sender) <
-						Self::endorsement_tickets_per_reputable(),
-					Error::<T>::NoMoreNewbieTickets
-				);
-				<BurnedReputableNewbieTickets<T>>::mutate(&(cid, cindex), sender.clone(), |b| {
-					*b += 1
-				}); // safe; limited by AMOUNT_NEWBIE_TICKETS
-			} else {
-				return Err(Error::<T>::AuthorizationRequired.into())
-			}
+			Self::burn_newbie_tickets(cid, cindex, &sender)?;
 
 			<Endorsees<T>>::insert((cid, cindex), newbie.clone(), ());
 			let new_endorsee_count = Self::endorsee_count((cid, cindex))
@@ -1276,6 +1257,36 @@ impl<T: Config> Pallet<T> {
 			<ReputableIndex<T>>::contains_key((cid, cindex), &sender) ||
 			<EndorseeIndex<T>>::contains_key((cid, cindex), &sender) ||
 			<NewbieIndex<T>>::contains_key((cid, cindex), &sender)
+	}
+
+	/// Will burn the `sender`'s newbie tickets if he has some.
+	///
+	/// First we try to use the the reputable tickets because they refill with new reputation, and
+	/// then we try to use the bootstrapper tickets.
+	fn burn_newbie_tickets(
+		cid: CommunityIdentifier,
+		cindex: CeremonyIndexType,
+		sender: &T::AccountId,
+	) -> Result<(), Error<T>> {
+		if Self::has_reputation(&sender, &cid) &&
+			<BurnedReputableNewbieTickets<T>>::get(&(cid, cindex), &sender) <
+				Self::endorsement_tickets_per_reputable()
+		{
+			// safe; limited by AMOUNT_NEWBIE_TICKETS
+			<BurnedReputableNewbieTickets<T>>::mutate(&(cid, cindex), sender.clone(), |b| *b += 1);
+			return Ok(())
+		}
+
+		if <encointer_communities::Pallet<T>>::bootstrappers(&cid).contains(&sender) &&
+			<BurnedBootstrapperNewbieTickets<T>>::get(&cid, &sender) <
+				Self::endorsement_tickets_per_bootstrapper()
+		{
+			// safe; limited by AMOUNT_NEWBIE_TICKETS
+			<BurnedBootstrapperNewbieTickets<T>>::mutate(&cid, sender.clone(), |b| *b += 1);
+			return Ok(())
+		}
+
+		Err(Error::<T>::NoMoreNewbieTickets)
 	}
 
 	#[allow(deprecated)]

--- a/ceremonies/src/lib.rs
+++ b/ceremonies/src/lib.rs
@@ -1273,7 +1273,7 @@ impl<T: Config> Pallet<T> {
 				Self::endorsement_tickets_per_reputable()
 		{
 			// safe; limited by AMOUNT_NEWBIE_TICKETS
-			<BurnedReputableNewbieTickets<T>>::mutate(&(cid, cindex), sender.clone(), |b| *b += 1);
+			<BurnedReputableNewbieTickets<T>>::mutate(&(cid, cindex), sender, |b| *b += 1);
 			return Ok(())
 		}
 
@@ -1282,7 +1282,7 @@ impl<T: Config> Pallet<T> {
 				Self::endorsement_tickets_per_bootstrapper()
 		{
 			// safe; limited by AMOUNT_NEWBIE_TICKETS
-			<BurnedBootstrapperNewbieTickets<T>>::mutate(&cid, sender.clone(), |b| *b += 1);
+			<BurnedBootstrapperNewbieTickets<T>>::mutate(&cid, sender, |b| *b += 1);
 			return Ok(())
 		}
 

--- a/ceremonies/src/lib.rs
+++ b/ceremonies/src/lib.rs
@@ -666,8 +666,6 @@ pub mod pallet {
 		MeetupTimeCalculationError,
 		/// no valid claims were supplied
 		NoValidClaims,
-		/// sender doesn't have the necessary authority to perform action
-		AuthorizationRequired,
 		/// the action can only be performed during REGISTERING phase
 		RegisteringPhaseRequired,
 		/// the action can only be performed during ATTESTING phase

--- a/ceremonies/src/lib.rs
+++ b/ceremonies/src/lib.rs
@@ -1268,8 +1268,8 @@ impl<T: Config> Pallet<T> {
 		cindex: CeremonyIndexType,
 		sender: &T::AccountId,
 	) -> Result<(), Error<T>> {
-		if Self::has_reputation(&sender, &cid) &&
-			<BurnedReputableNewbieTickets<T>>::get(&(cid, cindex), &sender) <
+		if Self::has_reputation(sender, &cid) &&
+			<BurnedReputableNewbieTickets<T>>::get(&(cid, cindex), sender) <
 				Self::endorsement_tickets_per_reputable()
 		{
 			// safe; limited by AMOUNT_NEWBIE_TICKETS
@@ -1277,8 +1277,8 @@ impl<T: Config> Pallet<T> {
 			return Ok(())
 		}
 
-		if <encointer_communities::Pallet<T>>::bootstrappers(&cid).contains(&sender) &&
-			<BurnedBootstrapperNewbieTickets<T>>::get(&cid, &sender) <
+		if <encointer_communities::Pallet<T>>::bootstrappers(&cid).contains(sender) &&
+			<BurnedBootstrapperNewbieTickets<T>>::get(&cid, sender) <
 				Self::endorsement_tickets_per_bootstrapper()
 		{
 			// safe; limited by AMOUNT_NEWBIE_TICKETS

--- a/ceremonies/src/tests.rs
+++ b/ceremonies/src/tests.rs
@@ -1452,7 +1452,7 @@ fn endorse_newbie_fails_if_already_endorsed_in_previous_ceremony() {
 }
 
 #[test]
-fn endorse_newbie_fails_without_reputation() {
+fn endorse_newbie_fails_if_sender_has_no_reputation_and_is_not_bootstrapper() {
 	new_test_ext().execute_with(|| {
 		let cid = perform_bootstrapping_ceremony(None, 1);
 

--- a/ceremonies/src/tests.rs
+++ b/ceremonies/src/tests.rs
@@ -1452,7 +1452,7 @@ fn endorse_newbie_fails_if_already_endorsed_in_previous_ceremony() {
 }
 
 #[test]
-fn endorse_newbie_fails_if_not_authorized() {
+fn endorse_newbie_fails_without_reputation() {
 	new_test_ext().execute_with(|| {
 		let cid = perform_bootstrapping_ceremony(None, 1);
 
@@ -1460,7 +1460,7 @@ fn endorse_newbie_fails_if_not_authorized() {
 		let zoran = sr25519::Pair::from_entropy(&[9u8; 32], None).0;
 		assert_err!(
 			EncointerCeremonies::endorse_newcomer(Origin::signed(account_id(&zoran)), cid, yran),
-			Error::<TestRuntime>::AuthorizationRequired
+			Error::<TestRuntime>::NoMoreNewbieTickets
 		);
 	});
 }


### PR DESCRIPTION
* Closes #287 

As commented in #287 I think it makes more sense to first burn the reputable newbie tickets and then the bootstrapper newbie tickets.