### PR TITLE
types and doc cleanup

### DIFF
--- a/ceremonies/src/lib.rs
+++ b/ceremonies/src/lib.rs
@@ -763,7 +763,7 @@ pub mod pallet {
 		CommunityIdentifier,
 		Blake2_128Concat,
 		T::AccountId,
-		u8,
+		EndorsementTicketsType,
 		ValueQuery,
 	>;
 
@@ -775,7 +775,7 @@ pub mod pallet {
 		CommunityCeremony,
 		Blake2_128Concat,
 		T::AccountId,
-		u8,
+		EndorsementTicketsType,
 		ValueQuery,
 	>;
 
@@ -936,7 +936,7 @@ pub mod pallet {
 	#[pallet::storage]
 	#[pallet::getter(fn endorsees_count)]
 	pub(super) type EndorseesCount<T: Config> =
-		StorageMap<_, Blake2_128Concat, CommunityCeremony, u64, ValueQuery>;
+		StorageMap<_, Blake2_128Concat, CommunityCeremony, ParticipantIndexType, ValueQuery>;
 
 	#[pallet::storage]
 	#[pallet::getter(fn meetup_count)]

--- a/ceremonies/src/lib.rs
+++ b/ceremonies/src/lib.rs
@@ -638,7 +638,7 @@ pub mod pallet {
 		/// A participant has registered N attestations for fellow meetup participants
 		AttestationsRegistered(CommunityIdentifier, MeetupIndexType, u32, T::AccountId),
 		/// rewards have been claimed and issued successfully for N participants for their meetup at the previous ceremony
-		RewardsIssued(CommunityIdentifier, MeetupIndexType, u8),
+		RewardsIssued(CommunityIdentifier, MeetupIndexType, MeetupParticipantIndexType),
 		/// inactivity timeout has changed. affects how many ceremony cycles a community can be idle before getting purged
 		InactivityTimeoutUpdated(InactivityTimeoutType),
 		/// The number of endorsement tickets which bootstrappers can give out has changed
@@ -1763,7 +1763,7 @@ impl<T: Config> Pallet<T> {
 		Self::deposit_event(Event::RewardsIssued(
 			cid,
 			meetup_idx,
-			participants_indices.len() as u8,
+			participants_indices.len() as MeetupParticipantIndexType,
 		));
 		Ok(())
 	}

--- a/ceremonies/src/lib.rs
+++ b/ceremonies/src/lib.rs
@@ -709,7 +709,7 @@ pub mod pallet {
 		TooManyAttestations,
 		/// can't have more claims than other meetup participants
 		TooManyClaims,
-		/// bootstrapper has run out of newbie tickets
+		/// sender has run out of newbie tickets
 		NoMoreNewbieTickets,
 		/// newbie is already endorsed
 		AlreadyEndorsed,

--- a/primitives/src/ceremonies.rs
+++ b/primitives/src/ceremonies.rs
@@ -28,6 +28,7 @@ pub use crate::scheduler::CeremonyIndexType;
 
 pub type ParticipantIndexType = u64;
 pub type MeetupIndexType = u64;
+pub type MeetupParticipantIndexType = u8;
 pub type AttestationIndexType = u64;
 pub type CommunityCeremony = (CommunityIdentifier, CeremonyIndexType);
 pub type InactivityTimeoutType = u32;


### PR DESCRIPTION
a few little things that bugged me when reviewing the new endorsement code

I don't think it is good practise to use base types in pallet storage if used in more than one place