### PR TITLE
Make demurrage computation sound

### DIFF
--- a/balances/src/lib.rs
+++ b/balances/src/lib.rs
@@ -19,7 +19,7 @@
 pub use crate::weights::WeightInfo;
 use core::marker::PhantomData;
 use encointer_primitives::{
-	balances::{BalanceEntry, BalanceType, Demurrage, DemurrageError, FeeConversionFactorType},
+	balances::{BalanceEntry, BalanceType, Demurrage, FeeConversionFactorType},
 	communities::CommunityIdentifier,
 };
 use frame_support::{
@@ -251,18 +251,7 @@ impl<T: Config> Pallet<T> {
 	) -> BalanceEntry<T::BlockNumber> {
 		let current_block = frame_system::Pallet::<T>::block_number();
 
-		match entry.apply_demurrage(demurrage, current_block) {
-			Ok(updated_entry) => updated_entry,
-			Err(e) => {
-				// This should never happen in production! We handle every potential error case
-				// explicitly to be sure  that we detect changes in the `DemurrageError` enum.
-
-				match e {
-					DemurrageError::DemurrageMustBePositive =>
-						unreachable!("Demurrage is always positive; qed"),
-				}
-			},
-		}
+		entry.apply_demurrage(demurrage, current_block)
 	}
 
 	/// Create a new account on-chain if it does not exist.

--- a/balances/src/lib.rs
+++ b/balances/src/lib.rs
@@ -258,11 +258,6 @@ impl<T: Config> Pallet<T> {
 				// explicitly to be sure  that we detect changes in the `DemurrageError` enum.
 
 				match e {
-					DemurrageError::LastBlockBiggerThanCurrent =>
-						unreachable!("block number monotonically increases; qed"),
-					DemurrageError::ElapsedBlocksMoreThan32Bits => unreachable!(
-						"This can only be reached around the year 2720 with 6 seconds block time; qed"
-					),
 					DemurrageError::DemurrageMustBePositive =>
 						unreachable!("Demurrage is always positive; qed"),
 				}

--- a/balances/src/lib.rs
+++ b/balances/src/lib.rs
@@ -254,10 +254,15 @@ impl<T: Config> Pallet<T> {
 		match entry.apply_demurrage(demurrage, current_block) {
 			Ok(updated_entry) => updated_entry,
 			Err(e) => {
-				// This should never happen in production!
+				// This should never happen in production! The `apply_demurrage` method is designed
+				// to only return an error when some blockchain invariants no longer hold like:
+				// * last_update < current_block
+				// * demurrage < 0
+				// * blocknumber > 2^32
+				//
+				// Still if such an invariant is violated, what should we do here? Shall we use an
+				// expect after all?
 				debug!("Error when applying demurrage: {:?}", e);
-
-				// Todo: is this the safe fallback, or shall we introduce expects?
 				Default::default()
 			},
 		}

--- a/balances/src/lib.rs
+++ b/balances/src/lib.rs
@@ -247,7 +247,7 @@ impl<T: Config> Pallet<T> {
 	///     * exp(-1* demurrage_rate_per_block * number_of_blocks_since_last_written)
 	pub(crate) fn apply_demurrage(
 		entry: BalanceEntry<T::BlockNumber>,
-		demurrage: BalanceType,
+		demurrage: Demurrage,
 	) -> BalanceEntry<T::BlockNumber> {
 		let current_block = frame_system::Pallet::<T>::block_number();
 

--- a/balances/src/lib.rs
+++ b/balances/src/lib.rs
@@ -20,7 +20,7 @@ pub use crate::weights::WeightInfo;
 use core::marker::PhantomData;
 use encointer_primitives::{
 	balances::{BalanceEntry, BalanceType, Demurrage, FeeConversionFactorType},
-	communities::CommunityIdentifier,
+	communities::{validate_demurrage, CommunityIdentifier, RangeError},
 };
 use frame_support::{
 	dispatch::DispatchResult,
@@ -367,8 +367,13 @@ impl<T: Config> Pallet<T> {
 		<DemurragePerBlock<T>>::try_get(cid).unwrap_or_else(|_| T::DefaultDemurrage::get())
 	}
 
-	pub fn set_demurrage(cid: &CommunityIdentifier, demurrage: Demurrage) {
+	pub fn set_demurrage(
+		cid: &CommunityIdentifier,
+		demurrage: Demurrage,
+	) -> Result<(), RangeError> {
+		validate_demurrage(&demurrage)?;
 		<DemurragePerBlock<T>>::insert(cid, &demurrage);
+		Ok(())
 	}
 
 	pub fn purge_balances(cid: CommunityIdentifier) {

--- a/balances/src/lib.rs
+++ b/balances/src/lib.rs
@@ -21,7 +21,6 @@ use core::marker::PhantomData;
 use encointer_primitives::{
 	balances::{BalanceEntry, BalanceType, Demurrage, FeeConversionFactorType},
 	communities::CommunityIdentifier,
-	fixed::transcendental::exp,
 };
 use frame_support::{
 	dispatch::DispatchResult,
@@ -251,21 +250,16 @@ impl<T: Config> Pallet<T> {
 		demurrage: BalanceType,
 	) -> BalanceEntry<T::BlockNumber> {
 		let current_block = frame_system::Pallet::<T>::block_number();
-		let elapsed_time_block_number = current_block - entry.last_update;
-		let elapsed_time_u32: u32 = elapsed_time_block_number
-			.try_into()
-			.ok()
-			.expect("blockchain will not exceed 2^32 blocks; qed");
-		let elapsed_time = BalanceType::from_num(elapsed_time_u32);
-		let exponent: BalanceType = -demurrage * elapsed_time;
-		let exp_result: BalanceType = exp(exponent).unwrap();
-		//.expect("demurrage should never overflow");
-		BalanceEntry {
-			principal: entry
-				.principal
-				.checked_mul(exp_result)
-				.expect("demurrage should never overflow"),
-			last_update: current_block,
+
+		match entry.apply_demurrage(demurrage, current_block) {
+			Ok(updated_entry) => updated_entry,
+			Err(e) => {
+				// This should never happen in production!
+				debug!("Error when applying demurrage: {:?}", e);
+
+				// Todo: is this the safe fallback, or shall we introduce expects?
+				Default::default()
+			},
 		}
 	}
 

--- a/balances/src/lib.rs
+++ b/balances/src/lib.rs
@@ -19,7 +19,7 @@
 pub use crate::weights::WeightInfo;
 use core::marker::PhantomData;
 use encointer_primitives::{
-	balances::{BalanceEntry, BalanceType, Demurrage, FeeConversionFactorType},
+	balances::{BalanceEntry, BalanceType, Demurrage, DemurrageError, FeeConversionFactorType},
 	communities::CommunityIdentifier,
 };
 use frame_support::{
@@ -254,16 +254,18 @@ impl<T: Config> Pallet<T> {
 		match entry.apply_demurrage(demurrage, current_block) {
 			Ok(updated_entry) => updated_entry,
 			Err(e) => {
-				// This should never happen in production! The `apply_demurrage` method is designed
-				// to only return an error when some blockchain invariants no longer hold like:
-				// * last_update < current_block
-				// * demurrage < 0
-				// * blocknumber > 2^32
-				//
-				// Still if such an invariant is violated, what should we do here? Shall we use an
-				// expect after all?
-				debug!("Error when applying demurrage: {:?}", e);
-				Default::default()
+				// This should never happen in production! We handle every potential error case
+				// explicitly to be sure  that we detect changes in the `DemurrageError` enum.
+
+				match e {
+					DemurrageError::LastBlockBiggerThanCurrent =>
+						unreachable!("block number monotonically increases; qed"),
+					DemurrageError::ElapsedBlocksMoreThan32Bits => unreachable!(
+						"This can only be reached around the year 2720 with 6 seconds block time; qed"
+					),
+					DemurrageError::DemurrageMustBePositive =>
+						unreachable!("Demurrage is always positive; qed"),
+				}
 			},
 		}
 	}

--- a/communities/src/benchmarking.rs
+++ b/communities/src/benchmarking.rs
@@ -125,7 +125,7 @@ benchmarks! {
 	update_demurrage {
 		let (cid, bootstrappers, community_metadata, demurrage, nominal_income) = setup_test_community::<T>();
 	} : {
-		assert_ok!(Communities::<T>::update_demurrage(RawOrigin::Root.into(), cid, Demurrage::from(23u32)));
+		assert_ok!(Communities::<T>::update_demurrage(RawOrigin::Root.into(), cid, Demurrage::from(0.5)));
 	}
 	verify {
 		assert_eq!(encointer_balances::Pallet::<T>::demurrage_per_block(&cid), 23);

--- a/communities/src/benchmarking.rs
+++ b/communities/src/benchmarking.rs
@@ -125,10 +125,10 @@ benchmarks! {
 	update_demurrage {
 		let (cid, bootstrappers, community_metadata, demurrage, nominal_income) = setup_test_community::<T>();
 	} : {
-		assert_ok!(Communities::<T>::update_demurrage(RawOrigin::Root.into(), cid, Demurrage::from(0.5)));
+		assert_ok!(Communities::<T>::update_demurrage(RawOrigin::Root.into(), cid, Demurrage::from_num(0.5)));
 	}
 	verify {
-		assert_eq!(encointer_balances::Pallet::<T>::demurrage_per_block(&cid), 23);
+		assert_eq!(encointer_balances::Pallet::<T>::demurrage_per_block(&cid), 0.5);
 	}
 
 	update_nominal_income {

--- a/communities/src/lib.rs
+++ b/communities/src/lib.rs
@@ -92,9 +92,7 @@ pub mod pallet {
 			community_metadata
 				.validate()
 				.map_err(|_| <Error<T>>::InvalidCommunityMetadata)?;
-			if let Some(d) = demurrage {
-				validate_demurrage(&d).map_err(|_| <Error<T>>::InvalidDemurrage)?;
-			}
+
 			if let Some(i) = nominal_income {
 				validate_nominal_income(&i).map_err(|_| <Error<T>>::InvalidNominalIncome)?;
 			}
@@ -130,7 +128,9 @@ pub mod pallet {
 			<CommunityMetadata<T>>::insert(&cid, &community_metadata);
 
 			if let Some(d) = demurrage {
-				<encointer_balances::Pallet<T>>::set_demurrage(&cid, d)
+				<encointer_balances::Pallet<T>>::set_demurrage(&cid, d)..map_err(|_| {
+					<Error<T>>::InvalidDemurrage
+				})
 			}
 			if let Some(i) = nominal_income {
 				<NominalIncome<T>>::insert(&cid, i)
@@ -256,7 +256,9 @@ pub mod pallet {
 			validate_demurrage(&demurrage).map_err(|_| <Error<T>>::InvalidDemurrage)?;
 			Self::ensure_cid_exists(&cid)?;
 
-			<encointer_balances::Pallet<T>>::set_demurrage(&cid, demurrage);
+			<encointer_balances::Pallet<T>>::set_demurrage(&cid, demurrage)..map_err(|_| {
+				<Error<T>>::InvalidDemurrage
+			})?;
 
 			info!(target: LOG, " updated demurrage for cid: {:?}", cid);
 			Self::deposit_event(Event::DemurrageUpdated(cid, demurrage));

--- a/communities/src/lib.rs
+++ b/communities/src/lib.rs
@@ -29,7 +29,7 @@ use encointer_primitives::{
 	balances::{BalanceEntry, BalanceType, Demurrage},
 	common::PalletString,
 	communities::{
-		consts::*, validate_demurrage, validate_nominal_income, CommunityIdentifier,
+		consts::*, validate_nominal_income, CommunityIdentifier,
 		CommunityMetadata as CommunityMetadataType, Degree, GeoHash, Location, LossyFrom,
 		NominalIncome as NominalIncomeType,
 	},

--- a/communities/src/lib.rs
+++ b/communities/src/lib.rs
@@ -253,8 +253,6 @@ pub mod pallet {
 			T::CommunityMaster::ensure_origin(origin)?;
 
 			Self::ensure_cid_exists(&cid)?;
-			validate_demurrage(&demurrage).map_err(|_| <Error<T>>::InvalidDemurrage)?;
-			Self::ensure_cid_exists(&cid)?;
 
 			<encointer_balances::Pallet<T>>::set_demurrage(&cid, demurrage)..map_err(|_| {
 				<Error<T>>::InvalidDemurrage

--- a/communities/src/lib.rs
+++ b/communities/src/lib.rs
@@ -128,9 +128,8 @@ pub mod pallet {
 			<CommunityMetadata<T>>::insert(&cid, &community_metadata);
 
 			if let Some(d) = demurrage {
-				<encointer_balances::Pallet<T>>::set_demurrage(&cid, d)..map_err(|_| {
-					<Error<T>>::InvalidDemurrage
-				})
+				<encointer_balances::Pallet<T>>::set_demurrage(&cid, d)
+					.map_err(|_| <Error<T>>::InvalidDemurrage)?;
 			}
 			if let Some(i) = nominal_income {
 				<NominalIncome<T>>::insert(&cid, i)
@@ -254,9 +253,8 @@ pub mod pallet {
 
 			Self::ensure_cid_exists(&cid)?;
 
-			<encointer_balances::Pallet<T>>::set_demurrage(&cid, demurrage)..map_err(|_| {
-				<Error<T>>::InvalidDemurrage
-			})?;
+			<encointer_balances::Pallet<T>>::set_demurrage(&cid, demurrage)
+				.map_err(|_| <Error<T>>::InvalidDemurrage)?;
 
 			info!(target: LOG, " updated demurrage for cid: {:?}", cid);
 			Self::deposit_event(Event::DemurrageUpdated(cid, demurrage));

--- a/primitives/src/balances.rs
+++ b/primitives/src/balances.rs
@@ -233,6 +233,18 @@ mod tests {
 		);
 	}
 
+	#[test]
+	fn apply_demurrage_with_overflowing_values_works() {
+		let demurrage = Demurrage::from_num(0.000048135220872218395);
+		let bal = BalanceEntry::<u32>::new(1.into(), 0);
+
+		// This produced a overflow before: https://github.com/encointer/encointer-node/issues/290
+		assert_abs_diff_eq(bal.apply_demurrage(demurrage, ONE_YEAR).unwrap().principal, 0f64);
+
+		// Just make a ridiculous assumption.
+		assert_abs_diff_eq(bal.apply_demurrage(demurrage, 100 * ONE_YEAR).unwrap().principal, 0f64);
+	}
+
 	#[rstest(
 		balance,
 		expected_result,

--- a/primitives/src/balances.rs
+++ b/primitives/src/balances.rs
@@ -121,9 +121,11 @@ pub fn demurrage_factor(
 		return Err(DemurrageError::DemurrageMustBePositive)
 	}
 
-	// We can only have errors here if one of the operations overflowed. However, we take the
-	// inverse of these operations at the end, which is why we can set the demurrage factor to
-	// 0 in this case.
+	// We can only have errors here if one of the operations overflowed.
+	//
+	// However, as we compute exp(-x), which goes to 0 for big x, we can
+	// approximate the result as 0 if we overflow somewhere on the way
+	// because of the big x.
 
 	// demurrage >= 0; hence exponent <= 0
 	let exponent = match (-demurrage_per_block).checked_mul(elapsed_blocks.into()) {

--- a/primitives/src/balances.rs
+++ b/primitives/src/balances.rs
@@ -68,7 +68,7 @@ where
 	/// Applies the demurrage and returns an updated BalanceEntry.
 	///
 	/// The following formula is applied to the principal:
-	/// 	updated_principal = old_principal * e^(-demurrage_per_block * elapsed_blocks)
+	///    updated_principal = old_principal * e^(-demurrage_per_block * elapsed_blocks)
 	///
 	/// **Note**: This function will be used at every single transaction that is paid with community
 	/// currency. It is important that it is as efficient as possible, but also that it is bullet-
@@ -131,7 +131,7 @@ pub fn demurrage_factor(
 		None => return Ok(0.into()),
 	};
 
-	Ok(exp(exponent).unwrap_or(0.into()))
+	Ok(exp(exponent).unwrap_or_else(|_| 0.into()))
 }
 
 #[derive(Encode, Decode, RuntimeDebug, Clone, Copy, PartialEq, Eq, TypeInfo, MaxEncodedLen)]

--- a/primitives/src/balances.rs
+++ b/primitives/src/balances.rs
@@ -76,22 +76,22 @@ where
 	pub fn apply_demurrage(
 		self,
 		demurrage_per_block: Demurrage,
-		current_block: BlockNumber,
+		current_block_number: BlockNumber,
 	) -> Result<BalanceEntry<BlockNumber>, DemurrageError> {
 		if demurrage_per_block < 0 {
 			return Err(DemurrageError::DemurrageMustBePositive)
 		}
 
-		if self.last_update == current_block {
+		if self.last_update == current_block_number {
 			// Nothing to be done, as no time elapsed.
 			return Ok(self)
 		}
 
 		if self.principal.eq(&0i16) {
-			return Ok(Self { principal: self.principal, last_update: current_block })
+			return Ok(Self { principal: self.principal, last_update: current_block_number })
 		}
 
-		let elapsed_blocks = current_block
+		let elapsed_blocks = current_block_number
 			.checked_sub(&self.last_update)
 			.ok_or(DemurrageError::LastBlockBiggerThanCurrent)?;
 
@@ -106,7 +106,7 @@ where
 			.checked_mul(demurrage_factor)
 			.expect("demurrage_factor [0,1), hence can't overflow; qed");
 
-		Ok(Self { principal, last_update: current_block })
+		Ok(Self { principal, last_update: current_block_number })
 	}
 }
 

--- a/primitives/src/balances.rs
+++ b/primitives/src/balances.rs
@@ -70,7 +70,7 @@ where
 	/// The following formula is applied to the principal:
 	/// 	updated_principal = old_principal * e^(-demurrage_per_block * elapsed_blocks)
 	///
-	/// **Note**: This function will be used at every single transaction that is pay with community
+	/// **Note**: This function will be used at every single transaction that is paid with community
 	/// currency. It is important that it is as efficient as possible, but also that it is bullet-
 	/// proof (no-hidden panics!!).
 	pub fn apply_demurrage(

--- a/primitives/src/balances.rs
+++ b/primitives/src/balances.rs
@@ -244,7 +244,7 @@ mod tests {
 	}
 
 	#[test]
-	fn apply_demurrage_with_block_number_bigger_than_u32max_returns_does_not_overfloww() {
+	fn apply_demurrage_with_block_number_bigger_than_u32max_does_not_overflow() {
 		let demurrage = Demurrage::from_num(0.000048135220872218395);
 		let bal = BalanceEntry::<u64>::new(1.into(), 0);
 
@@ -252,8 +252,7 @@ mod tests {
 	}
 
 	#[test]
-	fn apply_demurrage_with_block_number_not_monotonically_rising_returns_just_updates_last_block()
-	{
+	fn apply_demurrage_with_block_number_not_monotonically_rising_just_updates_last_block() {
 		let demurrage = Demurrage::from_num(0.000048135220872218395);
 		let bal = BalanceEntry::<u32>::new(1.into(), 1);
 
@@ -269,7 +268,7 @@ mod tests {
 	}
 
 	#[test]
-	fn apply_demurrage_with_0_elapsed_blocks_works() {
+	fn apply_demurrage_with_zero_elapsed_blocks_works() {
 		let demurrage = Demurrage::from_num(100);
 		let bal = BalanceEntry::<u32>::new(1.into(), 0);
 

--- a/primitives/src/balances.rs
+++ b/primitives/src/balances.rs
@@ -253,6 +253,28 @@ mod tests {
 		assert_abs_diff_eq(bal.apply_demurrage(demurrage, 100 * ONE_YEAR).unwrap().principal, 0f64);
 	}
 
+	#[test]
+	fn apply_demurrage_with_block_number_bigger_than_u32max_returns_an_error() {
+		let demurrage = Demurrage::from_num(0.000048135220872218395);
+		let bal = BalanceEntry::<u64>::new(1.into(), 0);
+
+		assert_eq!(
+			bal.apply_demurrage(demurrage, u32::MAX as u64 + 1).unwrap_err(),
+			DemurrageError::ElapsedBlocksMoreThan32Bits,
+		)
+	}
+
+	#[test]
+	fn apply_demurrage_with_block_number_not_monotonically_rising_returns_an_error() {
+		let demurrage = Demurrage::from_num(0.000048135220872218395);
+		let bal = BalanceEntry::<u64>::new(1.into(), 1);
+
+		assert_eq!(
+			bal.apply_demurrage(demurrage, 0).unwrap_err(),
+			DemurrageError::LastBlockBiggerThanCurrent,
+		)
+	}
+
 	#[rstest(
 		balance,
 		expected_result,

--- a/primitives/src/balances.rs
+++ b/primitives/src/balances.rs
@@ -74,6 +74,10 @@ where
 		demurrage_per_block: Demurrage,
 		current_block: BlockNumber,
 	) -> Result<BalanceEntry<BlockNumber>, DemurrageError> {
+		if demurrage_per_block < 0 {
+			return Err(DemurrageError::DemurrageMustBeNegative)
+		}
+
 		if self.last_update == current_block {
 			// Nothing to be done, as no time elapsed.
 			return Ok(self)
@@ -208,6 +212,15 @@ mod tests {
 		assert_abs_diff_eq(
 			bal.apply_demurrage(DEFAULT_DEMURRAGE, ONE_YEAR).unwrap().principal,
 			0f64,
+		);
+	}
+
+	#[test]
+	fn apply_demurrage_when_demurrage_is_negative_errs() {
+		let bal = BalanceEntry::<u32>::new(0.into(), 0);
+		assert_eq!(
+			bal.apply_demurrage(Demurrage::from_num(-0.5), ONE_YEAR).unwrap_err(),
+			DemurrageError::DemurrageMustBeNegative,
 		);
 	}
 

--- a/primitives/src/balances.rs
+++ b/primitives/src/balances.rs
@@ -125,7 +125,7 @@ pub fn demurrage_factor(
 	// inverse of these operations at the end, which is why we can set the demurrage factor to
 	// 0 in this case.
 
-	// demurrage > 0; hence exponent <= 0
+	// demurrage >= 0; hence exponent <= 0
 	let exponent = match (-demurrage_per_block).checked_mul(elapsed_blocks.into()) {
 		Some(exp) => exp,
 		None => return Ok(0.into()),

--- a/primitives/src/balances.rs
+++ b/primitives/src/balances.rs
@@ -267,12 +267,36 @@ mod tests {
 	#[test]
 	fn apply_demurrage_with_block_number_not_monotonically_rising_returns_an_error() {
 		let demurrage = Demurrage::from_num(0.000048135220872218395);
-		let bal = BalanceEntry::<u64>::new(1.into(), 1);
+		let bal = BalanceEntry::<u32>::new(1.into(), 1);
 
 		assert_eq!(
 			bal.apply_demurrage(demurrage, 0).unwrap_err(),
 			DemurrageError::LastBlockBiggerThanCurrent,
 		)
+	}
+
+	#[test]
+	fn apply_demurrage_with_zero_demurrage_works() {
+		let demurrage = Demurrage::from_num(0.0);
+		let bal = BalanceEntry::<u32>::new(1.into(), 0);
+
+		assert_abs_diff_eq(bal.apply_demurrage(demurrage, ONE_YEAR).unwrap().principal, 1f64);
+	}
+
+	#[test]
+	fn apply_demurrage_with_0_elapsed_blocks_works() {
+		let demurrage = Demurrage::from_num(100);
+		let bal = BalanceEntry::<u32>::new(1.into(), 0);
+
+		assert_abs_diff_eq(bal.apply_demurrage(demurrage, 0).unwrap().principal, 1f64);
+	}
+
+	#[test]
+	fn apply_demurrage_with_massive_demurrage_works() {
+		let demurrage = Demurrage::from_num(u32::MAX);
+		let bal = BalanceEntry::<u32>::new(1.into(), 0);
+
+		assert_abs_diff_eq(bal.apply_demurrage(demurrage, 100).unwrap().principal, 0f64);
 	}
 
 	#[rstest(

--- a/primitives/src/balances.rs
+++ b/primitives/src/balances.rs
@@ -184,6 +184,14 @@ mod tests {
 		assert_abs_diff_eq(bal.apply_demurrage(demurrage, ONE_YEAR).unwrap().principal, 0.5);
 	}
 
+	#[test]
+	fn reproduce_green_bay_error() {
+		// Value of the GreenBay community on Gesell, which produced the runtime panic.
+		let demurrage = Demurrage::from_num(0.000048135220872218395);
+		let bal = BalanceEntry::<u32>::new(1.into(), 0);
+		assert_abs_diff_eq(bal.apply_demurrage(demurrage, ONE_YEAR).unwrap().principal, 0.5);
+	}
+
 	#[rstest(
 		balance,
 		expected_result,

--- a/primitives/src/balances.rs
+++ b/primitives/src/balances.rs
@@ -78,6 +78,10 @@ where
 		demurrage_per_block: Demurrage,
 		current_block: BlockNumber,
 	) -> Result<BalanceEntry<BlockNumber>, DemurrageError> {
+		if demurrage_per_block < 0 {
+			return Err(DemurrageError::DemurrageMustBePositive)
+		}
+
 		if self.last_update == current_block {
 			// Nothing to be done, as no time elapsed.
 			return Ok(self)

--- a/primitives/src/communities.rs
+++ b/primitives/src/communities.rs
@@ -78,7 +78,11 @@ pub fn validate_demurrage(demurrage: &Demurrage) -> Result<(), RangeError> {
 		return Err(RangeError::LessThanZero)
 	}
 
-	// Just some safeguarding against overflows
+	// Just some safeguarding against overflows, but 1 is already a very high value:
+	//
+	// e^-(50) = 1.9e-22, i.e., after 50 blocks the demurrage is close to 100%.
+	//
+	// So the community does still have the choice of a huge demurrage.
 	if demurrage > &Demurrage::from_num(1) {
 		return Err(RangeError::TooHigh { limit: 1 })
 	}

--- a/primitives/src/communities.rs
+++ b/primitives/src/communities.rs
@@ -67,6 +67,7 @@ pub type MaxSpeedMpsType = u32;
 pub enum RangeError {
 	LessThanZero,
 	LessThanOrEqualZero,
+	TooHigh { limit: u32 },
 }
 
 /// Ensure that the demurrage is in a sane range.
@@ -75,6 +76,11 @@ pub enum RangeError {
 pub fn validate_demurrage(demurrage: &Demurrage) -> Result<(), RangeError> {
 	if demurrage < &Demurrage::from_num(0) {
 		return Err(RangeError::LessThanZero)
+	}
+
+	// Just some safeguarding against overflows
+	if demurrage > &Demurrage::from_num(1) {
+		return Err(RangeError::TooHigh { limit: 1 })
 	}
 	Ok(())
 }


### PR DESCRIPTION
Fixes potential overflows when computing the demurrage factor, see: 
* https://github.com/encointer/encointer-node/issues/290
* Closes https://github.com/encointer/pallets/pull/297