### PR TITLE
[balances] allow configurable source for the blocknumber

### DIFF
--- a/balances/src/lib.rs
+++ b/balances/src/lib.rs
@@ -82,6 +82,8 @@ pub mod pallet {
 		type WeightInfo: WeightInfo;
 
 		type CeremonyMaster: EnsureOrigin<Self::Origin>;
+
+		type GetCurrentBlockNumber: GetCurrentBlockNumber<Self::BlockNumber>;
 	}
 
 	#[pallet::call]
@@ -249,7 +251,7 @@ impl<T: Config> Pallet<T> {
 		entry: BalanceEntry<T::BlockNumber>,
 		demurrage: Demurrage,
 	) -> BalanceEntry<T::BlockNumber> {
-		let current_block = frame_system::Pallet::<T>::block_number();
+		let current_block = <T as Config>::GetCurrentBlockNumber::get_current_block_number();
 
 		entry.apply_demurrage(demurrage, current_block)
 	}
@@ -379,5 +381,16 @@ impl<T: Config> Pallet<T> {
 	pub fn purge_balances(cid: CommunityIdentifier) {
 		#[allow(deprecated)]
 		<Balance<T>>::remove_prefix(cid, None);
+	}
+}
+
+/// Allows configuring the source of the blocknumber.
+pub trait GetCurrentBlockNumber<BlockNumber> {
+	fn get_current_block_number() -> BlockNumber;
+}
+
+impl<T: frame_system::Config> GetCurrentBlockNumber<T::BlockNumber> for frame_system::Pallet<T> {
+	fn get_current_block_number() -> T::BlockNumber {
+		frame_system::Pallet::<T>::block_number()
 	}
 }

--- a/balances/src/mock.rs
+++ b/balances/src/mock.rs
@@ -49,6 +49,7 @@ impl dut::Config for TestRuntime {
 	type ExistentialDeposit = ExistentialDeposit;
 	type WeightInfo = ();
 	type CeremonyMaster = EnsureAlice;
+	type GetCurrentBlockNumber = System;
 }
 
 // boilerplate


### PR DESCRIPTION
I consider this an intermediate step such that we can change the blocknumber source to the current parentchain blocknumber in the community sidechain. In the future, I think that we might want to abstract the whole `ApplyDemurrage` associated type. I will formulate an issue for this soon.