### PR TITLE
polkadot v1.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1581,7 +1581,7 @@ dependencies = [
 
 [[package]]
 name = "encointer-balances-tx-payment"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -1601,7 +1601,7 @@ dependencies = [
 
 [[package]]
 name = "encointer-balances-tx-payment-rpc"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "encointer-balances-tx-payment-rpc-runtime-api",
  "encointer-primitives",
@@ -1624,7 +1624,7 @@ dependencies = [
 
 [[package]]
 name = "encointer-balances-tx-payment-rpc-runtime-api"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -1636,7 +1636,7 @@ dependencies = [
 
 [[package]]
 name = "encointer-ceremonies-assignment"
-version = "1.2.0"
+version = "2.0.0"
 dependencies = [
  "encointer-primitives",
  "sp-core 24.0.0",
@@ -1646,7 +1646,7 @@ dependencies = [
 
 [[package]]
 name = "encointer-meetup-validation"
-version = "1.2.0"
+version = "2.0.0"
 dependencies = [
  "encointer-primitives",
  "parity-scale-codec",
@@ -1660,7 +1660,7 @@ dependencies = [
 
 [[package]]
 name = "encointer-primitives"
-version = "1.3.0"
+version = "2.0.0"
 dependencies = [
  "approx",
  "bs58 0.4.0",
@@ -1683,7 +1683,7 @@ dependencies = [
 
 [[package]]
 name = "encointer-rpc"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "jsonrpsee",
  "jsonrpsee-core",
@@ -1724,7 +1724,7 @@ checksum = "e48c92028aaa870e83d51c64e5d4e0b6981b360c522198c23959f219a4e1b15b"
 
 [[package]]
 name = "ep-core"
-version = "1.2.1"
+version = "2.0.0"
 dependencies = [
  "array-bytes",
  "impl-serde",
@@ -4107,7 +4107,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-balances"
-version = "1.2.0"
+version = "2.0.0"
 dependencies = [
  "approx",
  "encointer-primitives",
@@ -4127,7 +4127,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-bazaar"
-version = "1.1.0"
+version = "2.0.0"
 dependencies = [
  "encointer-primitives",
  "frame-benchmarking",
@@ -4145,7 +4145,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-bazaar-rpc"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "encointer-primitives",
  "encointer-rpc",
@@ -4163,7 +4163,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-bazaar-rpc-runtime-api"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -4173,7 +4173,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-ceremonies"
-version = "1.2.0"
+version = "2.0.0"
 dependencies = [
  "approx",
  "encointer-ceremonies-assignment",
@@ -4202,7 +4202,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-ceremonies-rpc"
-version = "1.2.0"
+version = "2.0.0"
 dependencies = [
  "encointer-primitives",
  "encointer-rpc",
@@ -4220,7 +4220,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-ceremonies-rpc-runtime-api"
-version = "1.2.0"
+version = "2.0.0"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -4230,7 +4230,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-communities"
-version = "1.3.0"
+version = "2.0.0"
 dependencies = [
  "approx",
  "encointer-primitives",
@@ -4251,7 +4251,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-communities-rpc"
-version = "1.2.0"
+version = "2.0.0"
 dependencies = [
  "encointer-primitives",
  "encointer-rpc",
@@ -4270,7 +4270,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-communities-rpc-runtime-api"
-version = "1.2.0"
+version = "2.0.0"
 dependencies = [
  "encointer-primitives",
  "sp-api",
@@ -4279,7 +4279,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-democracy"
-version = "1.2.0"
+version = "2.0.0"
 dependencies = [
  "approx",
  "encointer-primitives",
@@ -4307,7 +4307,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-faucet"
-version = "1.2.0"
+version = "2.0.0"
 dependencies = [
  "approx",
  "encointer-primitives",
@@ -4329,7 +4329,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-reputation-commitments"
-version = "1.2.0"
+version = "2.0.0"
 dependencies = [
  "approx",
  "encointer-primitives",
@@ -4352,7 +4352,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-scheduler"
-version = "1.1.0"
+version = "2.0.0"
 dependencies = [
  "encointer-primitives",
  "frame-benchmarking",
@@ -4371,7 +4371,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-vouches"
-version = "1.2.0"
+version = "2.0.0"
 dependencies = [
  "approx",
  "encointer-primitives",
@@ -7361,7 +7361,7 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "test-utils"
-version = "1.2.0"
+version = "2.0.0"
 dependencies = [
  "encointer-primitives",
  "frame-benchmarking",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1732,7 +1732,7 @@ dependencies = [
  "scale-info",
  "serde",
  "serde_json",
- "sp-arithmetic 18.0.0",
+ "sp-arithmetic",
  "sp-core 24.0.0",
  "sp-runtime",
  "sp-std 11.0.0",
@@ -1984,7 +1984,7 @@ dependencies = [
  "serde_json",
  "smallvec",
  "sp-api",
- "sp-arithmetic 19.0.0",
+ "sp-arithmetic",
  "sp-core 24.0.0",
  "sp-core-hashing-proc-macro",
  "sp-debug-derive 11.0.0",
@@ -5714,7 +5714,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "sp-arithmetic 19.0.0",
+ "sp-arithmetic",
  "sp-blockchain",
  "sp-core 24.0.0",
  "sp-runtime",
@@ -5887,7 +5887,7 @@ dependencies = [
  "log",
  "parking_lot 0.12.1",
  "prometheus",
- "sp-arithmetic 19.0.0",
+ "sp-arithmetic",
 ]
 
 [[package]]
@@ -6333,21 +6333,6 @@ dependencies = [
 
 [[package]]
 name = "sp-arithmetic"
-version = "18.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d3d3ff6d6d717d7563659e9e47e958d33ebd2d0b3d8b1a9961cf9832944375e"
-dependencies = [
- "integer-sqrt",
- "num-traits",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-std 10.0.0",
- "static_assertions",
-]
-
-[[package]]
-name = "sp-arithmetic"
 version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e41f710a77e9debd1c9b80f862709dce648e50f0904cde4117488e7d11d4796d"
@@ -6763,7 +6748,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-application-crypto",
- "sp-arithmetic 19.0.0",
+ "sp-arithmetic",
  "sp-core 24.0.0",
  "sp-io",
  "sp-std 11.0.0",
@@ -7084,7 +7069,7 @@ dependencies = [
  "scale-info",
  "serde",
  "smallvec",
- "sp-arithmetic 19.0.0",
+ "sp-arithmetic",
  "sp-core 24.0.0",
  "sp-debug-derive 11.0.0",
  "sp-std 11.0.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1616,7 +1616,7 @@ dependencies = [
  "sc-rpc-api",
  "sp-api",
  "sp-blockchain",
- "sp-core",
+ "sp-core 24.0.0",
  "sp-rpc",
  "sp-runtime",
  "thiserror",
@@ -1631,7 +1631,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api",
- "sp-std",
+ "sp-std 11.0.0",
 ]
 
 [[package]]
@@ -1639,9 +1639,9 @@ name = "encointer-ceremonies-assignment"
 version = "1.2.0"
 dependencies = [
  "encointer-primitives",
- "sp-core",
+ "sp-core 24.0.0",
  "sp-runtime",
- "sp-std",
+ "sp-std 11.0.0",
 ]
 
 [[package]]
@@ -1653,9 +1653,9 @@ dependencies = [
  "rstest",
  "scale-info",
  "serde",
- "sp-core",
+ "sp-core 24.0.0",
  "sp-runtime",
- "sp-std",
+ "sp-std 11.0.0",
 ]
 
 [[package]]
@@ -1673,10 +1673,10 @@ dependencies = [
  "scale-info",
  "serde",
  "serde_json",
- "sp-core",
+ "sp-core 24.0.0",
  "sp-io",
  "sp-runtime",
- "sp-std",
+ "sp-std 11.0.0",
  "substrate-geohash",
  "test-utils",
 ]
@@ -1724,18 +1724,18 @@ checksum = "e48c92028aaa870e83d51c64e5d4e0b6981b360c522198c23959f219a4e1b15b"
 
 [[package]]
 name = "ep-core"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "array-bytes",
- "impl-serde 0.3.2",
+ "impl-serde",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "serde_json",
- "sp-arithmetic",
- "sp-core",
+ "sp-arithmetic 18.0.0",
+ "sp-core 24.0.0",
  "sp-runtime",
- "sp-std",
+ "sp-std 11.0.0",
  "substrate-fixed",
 ]
 
@@ -1925,9 +1925,9 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "frame-benchmarking"
-version = "23.0.0"
+version = "24.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949ba5b5c9d552c37d7ad39bd837394c1d21727281ef32882539bc2ec6687b2d"
+checksum = "a01af5751a0e4492dc979c57586976403e7ab63641add1a9fd804cad4169f4f6"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -1940,12 +1940,12 @@ dependencies = [
  "serde",
  "sp-api",
  "sp-application-crypto",
- "sp-core",
+ "sp-core 24.0.0",
  "sp-io",
  "sp-runtime",
- "sp-runtime-interface",
- "sp-std",
- "sp-storage",
+ "sp-runtime-interface 20.0.0",
+ "sp-std 11.0.0",
+ "sp-storage 16.0.0",
  "static_assertions",
 ]
 
@@ -1963,9 +1963,9 @@ dependencies = [
 
 [[package]]
 name = "frame-support"
-version = "23.0.0"
+version = "24.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "609125451f5ffb1675998e07e64e05e4b3dad330b1537952ace5897d6ed24f0a"
+checksum = "c0dc5640279221fbd316a3a652963c1cb9d51630ea3f62a08a5ad7fa402f23a4"
 dependencies = [
  "aquamarine",
  "bitflags 1.3.2",
@@ -1984,10 +1984,10 @@ dependencies = [
  "serde_json",
  "smallvec",
  "sp-api",
- "sp-arithmetic",
- "sp-core",
+ "sp-arithmetic 19.0.0",
+ "sp-core 24.0.0",
  "sp-core-hashing-proc-macro",
- "sp-debug-derive",
+ "sp-debug-derive 11.0.0",
  "sp-genesis-builder",
  "sp-inherents",
  "sp-io",
@@ -1995,8 +1995,8 @@ dependencies = [
  "sp-runtime",
  "sp-staking",
  "sp-state-machine",
- "sp-std",
- "sp-tracing",
+ "sp-std 11.0.0",
+ "sp-tracing 13.0.0",
  "sp-weights",
  "static_assertions",
  "tt-call",
@@ -2004,9 +2004,9 @@ dependencies = [
 
 [[package]]
 name = "frame-support-procedural"
-version = "18.0.0"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd22a1ed96e765ec763bbaef2089ed8bb5f8539df40181ddac57be7be74685c7"
+checksum = "f22719c65353a0010a084cb2040e2e6569aff34562e59119cb66ddd7ecfa588c"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -2023,9 +2023,9 @@ dependencies = [
 
 [[package]]
 name = "frame-support-procedural-tools"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82858452d9332de312f5ff411fd8aecee2323a344b241078f565b8c3c2e47d38"
+checksum = "e046ecdc04dd66f17d760525631f553ddcbea6f09423f78fcf52b47c97656cd0"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -2036,9 +2036,9 @@ dependencies = [
 
 [[package]]
 name = "frame-support-procedural-tools-derive"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c7a09be6bd676fc01c5dd5ba057ba1f7e492e071d4a5fd7c579d99a96093d6"
+checksum = "4034ebf9ca7497fa3893191fe3e81adcd3d7cd1c232e60ef41ef58ea0c445ae9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2047,9 +2047,9 @@ dependencies = [
 
 [[package]]
 name = "frame-system"
-version = "23.0.0"
+version = "24.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40dc2f4182ad4c05275b0d3f38e3e74bd1cd17231f28ce1e879177fd9829887c"
+checksum = "dc19d4d4037b695805385d56983da173bbb969f68e0e4e6a1240bb30118e87d7"
 dependencies = [
  "cfg-if",
  "frame-support",
@@ -2057,10 +2057,10 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core",
+ "sp-core 24.0.0",
  "sp-io",
  "sp-runtime",
- "sp-std",
+ "sp-std 11.0.0",
  "sp-version",
  "sp-weights",
 ]
@@ -2617,15 +2617,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
 dependencies = [
  "parity-scale-codec",
-]
-
-[[package]]
-name = "impl-serde"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4551f042f3438e64dbd6226b20527fc84a6e1fe65688b58746a2f53623f25f5c"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -4081,9 +4072,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-asset-tx-payment"
-version = "23.0.0"
+version = "24.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64b0aea073ae2b627ddb7e775abb7872df8efb7fabd7c50dd05d3ca6ef0c72a4"
+checksum = "0a7e58838852ea75ab55a57316d5a81344d8e7917da4490abffbb3a81ffb8872"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4092,17 +4083,17 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core",
+ "sp-core 24.0.0",
  "sp-io",
  "sp-runtime",
- "sp-std",
+ "sp-std 11.0.0",
 ]
 
 [[package]]
 name = "pallet-balances"
-version = "23.0.0"
+version = "24.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0486a52507072bd738dc851acf7b42def3645db10777f93dccdaa5933e41269b"
+checksum = "7c17ec19ad23b26866ad7d60cdf8b613f653db7f44232aa25009811441908e2b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4111,7 +4102,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-runtime",
- "sp-std",
+ "sp-std 11.0.0",
 ]
 
 [[package]]
@@ -4130,7 +4121,7 @@ dependencies = [
  "scale-info",
  "sp-io",
  "sp-runtime",
- "sp-std",
+ "sp-std 11.0.0",
  "test-utils",
 ]
 
@@ -4146,9 +4137,9 @@ dependencies = [
  "pallet-encointer-communities",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
+ "sp-core 24.0.0",
  "sp-io",
- "sp-std",
+ "sp-std 11.0.0",
  "test-utils",
 ]
 
@@ -4177,7 +4168,7 @@ dependencies = [
  "encointer-primitives",
  "frame-support",
  "sp-api",
- "sp-std",
+ "sp-std 11.0.0",
 ]
 
 [[package]]
@@ -4201,11 +4192,11 @@ dependencies = [
  "rstest",
  "scale-info",
  "sp-application-crypto",
- "sp-core",
+ "sp-core 24.0.0",
  "sp-io",
  "sp-keystore",
  "sp-runtime",
- "sp-std",
+ "sp-std 11.0.0",
  "test-utils",
 ]
 
@@ -4234,7 +4225,7 @@ dependencies = [
  "encointer-primitives",
  "frame-support",
  "sp-api",
- "sp-std",
+ "sp-std 11.0.0",
 ]
 
 [[package]]
@@ -4251,10 +4242,10 @@ dependencies = [
  "pallet-encointer-scheduler",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
+ "sp-core 24.0.0",
  "sp-io",
  "sp-runtime",
- "sp-std",
+ "sp-std 11.0.0",
  "test-utils",
 ]
 
@@ -4272,7 +4263,7 @@ dependencies = [
  "sc-rpc-api",
  "sp-api",
  "sp-blockchain",
- "sp-core",
+ "sp-core 24.0.0",
  "sp-runtime",
  "thiserror",
 ]
@@ -4283,7 +4274,7 @@ version = "1.2.0"
 dependencies = [
  "encointer-primitives",
  "sp-api",
- "sp-std",
+ "sp-std 11.0.0",
 ]
 
 [[package]]
@@ -4306,11 +4297,11 @@ dependencies = [
  "rstest",
  "scale-info",
  "sp-application-crypto",
- "sp-core",
+ "sp-core 23.0.0",
  "sp-io",
  "sp-keystore",
  "sp-runtime",
- "sp-std",
+ "sp-std 11.0.0",
  "test-utils",
 ]
 
@@ -4329,10 +4320,10 @@ dependencies = [
  "pallet-treasury",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
+ "sp-core 24.0.0",
  "sp-io",
  "sp-runtime",
- "sp-std",
+ "sp-std 11.0.0",
  "test-utils",
 ]
 
@@ -4352,10 +4343,10 @@ dependencies = [
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
+ "sp-core 24.0.0",
  "sp-io",
  "sp-runtime",
- "sp-std",
+ "sp-std 11.0.0",
  "test-utils",
 ]
 
@@ -4374,7 +4365,7 @@ dependencies = [
  "scale-info",
  "sp-io",
  "sp-runtime",
- "sp-std",
+ "sp-std 11.0.0",
  "test-utils",
 ]
 
@@ -4391,19 +4382,20 @@ dependencies = [
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
+ "sp-core 24.0.0",
  "sp-io",
  "sp-runtime",
- "sp-std",
+ "sp-std 11.0.0",
  "test-utils",
 ]
 
 [[package]]
 name = "pallet-timestamp"
-version = "22.0.0"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "924bc62e043df933e6067a2a70a71a16823253e46765e36800f0dc60a0a59018"
+checksum = "dac4e66316d53673471420fb887b6a74e2507df169ced62584507ff0fb065c6b"
 dependencies = [
+ "docify",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -4413,40 +4405,40 @@ dependencies = [
  "sp-inherents",
  "sp-io",
  "sp-runtime",
- "sp-std",
- "sp-storage",
+ "sp-std 11.0.0",
+ "sp-storage 16.0.0",
  "sp-timestamp",
 ]
 
 [[package]]
 name = "pallet-transaction-payment"
-version = "23.0.0"
+version = "24.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eeaaeaf89f80fe3d19ff9ed60430423a7ea70ca91747b04be830499334d55d3"
+checksum = "f4cbb78b8499af1d338072950e4aef6acf3cc630afdb8e19b00306e5252d0386"
 dependencies = [
  "frame-support",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core",
+ "sp-core 24.0.0",
  "sp-io",
  "sp-runtime",
- "sp-std",
+ "sp-std 11.0.0",
 ]
 
 [[package]]
 name = "pallet-transaction-payment-rpc"
-version = "25.0.0"
+version = "26.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62ba760a19d5fb425068f0176b60c45be8e4e34ce8df41943cf7addf732d06cf"
+checksum = "30a7857973b918e71367acb7c284c829612aa9c91a6ba1fb2985d56fbe224545"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",
  "sp-api",
  "sp-blockchain",
- "sp-core",
+ "sp-core 24.0.0",
  "sp-rpc",
  "sp-runtime",
  "sp-weights",
@@ -4454,9 +4446,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
-version = "23.0.0"
+version = "24.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8ee4c219399d7353548641d31aea760007f88223d6de72048fd9d13a9a6601"
+checksum = "402155004abb33b7f2eedfa60ba77fb6f898e62db979a796e013714d18a1c9c2"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -4467,9 +4459,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-treasury"
-version = "22.0.0"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14f099cd65be6adbd3602e5b3df680a5ab868b79c990c5c7b3977e849728632e"
+checksum = "9dd64a50b82946d4ccf2178b7f3927ebac562b2ef31cecda53d31f3ff53a57c4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4480,7 +4472,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-runtime",
- "sp-std",
+ "sp-std 11.0.0",
 ]
 
 [[package]]
@@ -4815,7 +4807,7 @@ checksum = "9f3486ccba82358b11a77516035647c34ba167dfa53312630de83b12bd4f3d66"
 dependencies = [
  "fixed-hash",
  "impl-codec",
- "impl-serde 0.4.0",
+ "impl-serde",
  "scale-info",
  "uint",
 ]
@@ -5525,37 +5517,37 @@ dependencies = [
 
 [[package]]
 name = "sc-allocator"
-version = "18.0.0"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f75d11155f65cf4e548b916a95fd3c1193d3fa89cbece489e3627cb5cd93e77c"
+checksum = "2bd6e58990dcb1eae76db49c456ded9a7906ee194857cf1dfb00da8bbc8cf73d"
 dependencies = [
  "log",
- "sp-core",
- "sp-wasm-interface",
+ "sp-core 24.0.0",
+ "sp-wasm-interface 17.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-block-builder"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d5dc368497d940a5744cf427253a4b2f8d2a2cad9b2fbb897a270a939e54b5f"
+checksum = "4653cc3665319f76451f651bc5e3eb84965802293daeaf2def5bfe9c1310171b"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
  "sp-api",
  "sp-block-builder",
  "sp-blockchain",
- "sp-core",
+ "sp-core 24.0.0",
  "sp-inherents",
  "sp-runtime",
 ]
 
 [[package]]
 name = "sc-chain-spec"
-version = "22.0.0"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26e51780635e06b9ff2c41a953c57dcc83d86c9459ee432f24775a44b61f2bd3"
+checksum = "e5fae1616d342e570fb4770c9f1a73ab8e1aecb9c5b71020404f8e45db458260"
 dependencies = [
  "memmap2",
  "sc-chain-spec-derive",
@@ -5566,16 +5558,16 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-blockchain",
- "sp-core",
+ "sp-core 24.0.0",
  "sp-runtime",
  "sp-state-machine",
 ]
 
 [[package]]
 name = "sc-chain-spec-derive"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b01ae962b09bc4c95661eed1d6c4996cf72b54f522d0e41d81ae1da65d7bd3c"
+checksum = "88a074891d17c03c58b1314c9add361a5a7fb28d4d3addd7a32dca8b119bd877"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -5585,9 +5577,9 @@ dependencies = [
 
 [[package]]
 name = "sc-client-api"
-version = "23.0.0"
+version = "24.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c17ac3b6dcc569998527e9228f6370d22ba84136f4c1753f6ba4d07c41a3f1"
+checksum = "d49efb455b1b276557ba3cac01c2e42811148cc73149858296e4ae96707dc70e"
 dependencies = [
  "fnv",
  "futures",
@@ -5600,21 +5592,22 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-consensus",
- "sp-core",
+ "sp-core 24.0.0",
  "sp-database",
- "sp-externalities",
+ "sp-externalities 0.22.0",
  "sp-runtime",
  "sp-state-machine",
  "sp-statement-store",
- "sp-storage",
+ "sp-storage 16.0.0",
+ "sp-trie",
  "substrate-prometheus-endpoint",
 ]
 
 [[package]]
 name = "sc-consensus"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc2effbf5b5be7e7b5a0d448d6b83f446cd2425b9be0ab55b97bde8f60a8f46"
+checksum = "f5f8da1ef0f036209b80d8bde5c8990ea1a86241532d84b5fd15f5e721da849c"
 dependencies = [
  "async-trait",
  "futures",
@@ -5629,7 +5622,7 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-consensus",
- "sp-core",
+ "sp-core 24.0.0",
  "sp-runtime",
  "sp-state-machine",
  "substrate-prometheus-endpoint",
@@ -5638,9 +5631,9 @@ dependencies = [
 
 [[package]]
 name = "sc-executor"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e6b38c64210870649f89b476295ccd7c078ed7c2b9a3c82f413ad2c9396b63a"
+checksum = "5cfeaa8dc2a70ed5820667d3251266ed156f38d8062c2f976aa7c618411f1776"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -5648,35 +5641,35 @@ dependencies = [
  "sc-executor-wasmtime",
  "schnellru",
  "sp-api",
- "sp-core",
- "sp-externalities",
+ "sp-core 24.0.0",
+ "sp-externalities 0.22.0",
  "sp-io",
  "sp-panic-handler",
- "sp-runtime-interface",
+ "sp-runtime-interface 20.0.0",
  "sp-trie",
  "sp-version",
- "sp-wasm-interface",
+ "sp-wasm-interface 17.0.0",
  "tracing",
 ]
 
 [[package]]
 name = "sc-executor-common"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7023e1d9c86b817995a72e294b98f196cc3eb9c162f0b69ba95c3b0bd841ef32"
+checksum = "5d404519f2a636d5977b1ac16c90aeb4129fe4609a5b284960a2dcb005c08da6"
 dependencies = [
  "sc-allocator",
  "sp-maybe-compressed-blob",
- "sp-wasm-interface",
+ "sp-wasm-interface 17.0.0",
  "thiserror",
  "wasm-instrument",
 ]
 
 [[package]]
 name = "sc-executor-wasmtime"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61689d40f3840a20d8987cb2a86d3841f2c3ab851a5cea0c6f466a062abbcd"
+checksum = "a82515a0cb74a2acb58f6ced20fae56eeb87ba4d813e60e46cf190a53d44c931"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -5685,16 +5678,16 @@ dependencies = [
  "rustix 0.36.15",
  "sc-allocator",
  "sc-executor-common",
- "sp-runtime-interface",
- "sp-wasm-interface",
+ "sp-runtime-interface 20.0.0",
+ "sp-wasm-interface 17.0.0",
  "wasmtime",
 ]
 
 [[package]]
 name = "sc-network"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df0d414c9e17d563a0c0dce01c6b6f10aa50d9ba0e904c2fe5e6b2aaf845f5de"
+checksum = "3edad0e7930c2572d6920dc257bc03af6f40ba272bc45602edd0a045d94e5e59"
 dependencies = [
  "array-bytes",
  "async-channel",
@@ -5721,9 +5714,9 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "sp-arithmetic",
+ "sp-arithmetic 19.0.0",
  "sp-blockchain",
- "sp-core",
+ "sp-core 24.0.0",
  "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror",
@@ -5734,9 +5727,9 @@ dependencies = [
 
 [[package]]
 name = "sc-network-common"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91d09f99d3845d5bb325641a3de1db8049bccca29e8272e65b8ea415c1153b01"
+checksum = "b418c79cea8ab5b43f5bbe7ee95da7d6490bdfedbe92a9b07a714ca4f09a2426"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",
@@ -5752,9 +5745,9 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc"
-version = "24.0.0"
+version = "25.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f86ce48d8c8c6b4ebaf4775955cc79985732db5407e4893e0976be8f6b28eb5b"
+checksum = "ede50e654b3e0c076bb9beb041612af80f07dfb883cc05d8aaae1c7a1bb72761"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -5771,7 +5764,7 @@ dependencies = [
  "serde_json",
  "sp-api",
  "sp-blockchain",
- "sp-core",
+ "sp-core 24.0.0",
  "sp-keystore",
  "sp-offchain",
  "sp-rpc",
@@ -5784,9 +5777,9 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc-api"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60585da26d11aefb112d3a6925cc75fd76bee1961b2de615e6207df2b86a459c"
+checksum = "1cac4149b7427beed423006c78e0b75c0193ac01d6e66ff0dd8a1909747cf593"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -5795,7 +5788,7 @@ dependencies = [
  "scale-info",
  "serde",
  "serde_json",
- "sp-core",
+ "sp-core 24.0.0",
  "sp-rpc",
  "sp-runtime",
  "sp-version",
@@ -5804,9 +5797,9 @@ dependencies = [
 
 [[package]]
 name = "sc-telemetry"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba96178e1d0286ecc4a37fbf39a4660d8d10640baedffb58ff18de7162d117cb"
+checksum = "4b46193a2979c86da75fc43276d222359757ea257b512fe6e4128e7a50b0bb22"
 dependencies = [
  "chrono",
  "futures",
@@ -5824,9 +5817,9 @@ dependencies = [
 
 [[package]]
 name = "sc-tracing"
-version = "23.0.0"
+version = "24.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e86aa30a30596a5ca9e0492474d907edff1e5e569a121bb4eb178f4a262b8d1"
+checksum = "4fcb4398268e83957ebbc84e6290307198e817caa47386135d3de6ba3316203a"
 dependencies = [
  "ansi_term",
  "atty",
@@ -5842,10 +5835,10 @@ dependencies = [
  "serde",
  "sp-api",
  "sp-blockchain",
- "sp-core",
+ "sp-core 24.0.0",
  "sp-rpc",
  "sp-runtime",
- "sp-tracing",
+ "sp-tracing 13.0.0",
  "thiserror",
  "tracing",
  "tracing-log",
@@ -5854,9 +5847,9 @@ dependencies = [
 
 [[package]]
 name = "sc-tracing-proc-macro"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f602d1fa418385ed0e25be1305c9b03f68ff7ccb3b5df88a2145e7e1fb9117e"
+checksum = "71bd05d3f24c0c2489c57b90a76db883c23c25577718ca05c9b0181fd427f501"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -5866,9 +5859,9 @@ dependencies = [
 
 [[package]]
 name = "sc-transaction-pool-api"
-version = "23.0.0"
+version = "24.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "792c4841d8fba48d4a61e03db45854d8273dee31ae0d4ffb98af5176d0e31a03"
+checksum = "c4f1b864d0ae8f1891eb310672c12fc160d24e37ef297d5ef0db257558fe13b1"
 dependencies = [
  "async-trait",
  "futures",
@@ -5876,16 +5869,16 @@ dependencies = [
  "parity-scale-codec",
  "serde",
  "sp-blockchain",
- "sp-core",
+ "sp-core 24.0.0",
  "sp-runtime",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-utils"
-version = "9.0.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "563bde62fa4681746c8960d434fa65e7ea40c7fab46692b26998132f43e1e100"
+checksum = "e8b01c8eed623f999d402e44679d42ad42586afd4638aaed38708a307b59f4d7"
 dependencies = [
  "async-channel",
  "futures",
@@ -5894,7 +5887,7 @@ dependencies = [
  "log",
  "parking_lot 0.12.1",
  "prometheus",
- "sp-arithmetic",
+ "sp-arithmetic 19.0.0",
 ]
 
 [[package]]
@@ -6289,21 +6282,21 @@ dependencies = [
 
 [[package]]
 name = "sp-api"
-version = "21.0.0"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86901915aaf9c73f9a8588fae10072c6082e7bf169edae175950410b77ad8103"
+checksum = "ddc5213210472ba2becdc094fbb9d30c4455753b1a608962797e1e971c3e5ec4"
 dependencies = [
  "hash-db",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-api-proc-macro",
- "sp-core",
- "sp-externalities",
+ "sp-core 24.0.0",
+ "sp-externalities 0.22.0",
  "sp-metadata-ir",
  "sp-runtime",
  "sp-state-machine",
- "sp-std",
+ "sp-std 11.0.0",
  "sp-trie",
  "sp-version",
  "thiserror",
@@ -6311,9 +6304,9 @@ dependencies = [
 
 [[package]]
 name = "sp-api-proc-macro"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "972809a3e3a583423bca2ee6d08eb5397814ef6b265abf43e888c4ed9916ff83"
+checksum = "20e7f093302d30b9d35436db024376459bdc9da7530abcacf5d87c32a67d94fd"
 dependencies = [
  "Inflector",
  "blake2",
@@ -6326,16 +6319,16 @@ dependencies = [
 
 [[package]]
 name = "sp-application-crypto"
-version = "25.0.0"
+version = "26.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fa730e4f3a2aec3f4ee777410599a86eb17067ee5410c58ab496e88d7bb840c"
+checksum = "b74454c936a45ac55c8de95b9fd8b5e38f8b43d97df8f4274dd6777b20d95569"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core",
+ "sp-core 24.0.0",
  "sp-io",
- "sp-std",
+ "sp-std 11.0.0",
 ]
 
 [[package]]
@@ -6349,27 +6342,42 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-std",
+ "sp-std 10.0.0",
+ "static_assertions",
+]
+
+[[package]]
+name = "sp-arithmetic"
+version = "19.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e41f710a77e9debd1c9b80f862709dce648e50f0904cde4117488e7d11d4796d"
+dependencies = [
+ "integer-sqrt",
+ "num-traits",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-std 11.0.0",
  "static_assertions",
 ]
 
 [[package]]
 name = "sp-block-builder"
-version = "21.0.0"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "149acca1cfe20a2fc888e2e04b2811f7fd04a5bc47630a5d6191664f4ed7b224"
+checksum = "6c6a066e310d4c0c240829d7bb5d6bd01dde55d03e15b665f0372b40952f37e6"
 dependencies = [
  "sp-api",
  "sp-inherents",
  "sp-runtime",
- "sp-std",
+ "sp-std 11.0.0",
 ]
 
 [[package]]
 name = "sp-blockchain"
-version = "23.0.0"
+version = "24.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4d1f97e0cb623f919b6c6dbcd1d6438b8d8c456df4d045fb2778251d9d7803"
+checksum = "f506119858f25a73ed9d61a2ead0d5b97b5141055b3b4a12b9b82e530b06c673"
 dependencies = [
  "futures",
  "log",
@@ -6386,14 +6394,14 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e74272780c5c6ea026b3e66cdd7b369b90e1e94c17d91c41e2359224f2439ea"
+checksum = "04e142e27f140d50701e613d925f61482fafccb7d90933ee30d7bae54d293ea3"
 dependencies = [
  "async-trait",
  "futures",
  "log",
- "sp-core",
+ "sp-core 24.0.0",
  "sp-inherents",
  "sp-runtime",
  "sp-state-machine",
@@ -6402,9 +6410,9 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus-grandpa"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c750af0e64f19a5c364748c49339900e12f6ecd577f71879052604fd7f9312c4"
+checksum = "04d20516ed05a6a17f712050d6be385ca53c16b2d49938a29ca05e07f7aa5118"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -6413,10 +6421,10 @@ dependencies = [
  "serde",
  "sp-api",
  "sp-application-crypto",
- "sp-core",
+ "sp-core 24.0.0",
  "sp-keystore",
  "sp-runtime",
- "sp-std",
+ "sp-std 11.0.0",
 ]
 
 [[package]]
@@ -6436,7 +6444,7 @@ dependencies = [
  "futures",
  "hash-db",
  "hash256-std-hasher",
- "impl-serde 0.4.0",
+ "impl-serde",
  "lazy_static",
  "libsecp256k1",
  "log",
@@ -6452,12 +6460,58 @@ dependencies = [
  "secp256k1",
  "secrecy",
  "serde",
- "sp-core-hashing",
- "sp-debug-derive",
- "sp-externalities",
- "sp-runtime-interface",
- "sp-std",
- "sp-storage",
+ "sp-core-hashing 11.0.0",
+ "sp-debug-derive 10.0.0",
+ "sp-externalities 0.21.0",
+ "sp-runtime-interface 19.0.0",
+ "sp-std 10.0.0",
+ "sp-storage 15.0.0",
+ "ss58-registry",
+ "substrate-bip39",
+ "thiserror",
+ "tiny-bip39",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "sp-core"
+version = "24.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7921d278ed2aebbb21a644c96e09663dc49a6139d1e2e063c059dc9f866e149b"
+dependencies = [
+ "array-bytes",
+ "bitflags 1.3.2",
+ "blake2",
+ "bounded-collections",
+ "bs58 0.5.0",
+ "dyn-clonable",
+ "ed25519-zebra",
+ "futures",
+ "hash-db",
+ "hash256-std-hasher",
+ "impl-serde",
+ "lazy_static",
+ "libsecp256k1",
+ "log",
+ "merlin",
+ "parity-scale-codec",
+ "parking_lot 0.12.1",
+ "paste",
+ "primitive-types",
+ "rand 0.8.5",
+ "regex",
+ "scale-info",
+ "schnorrkel",
+ "secp256k1",
+ "secrecy",
+ "serde",
+ "sp-core-hashing 12.0.0",
+ "sp-debug-derive 11.0.0",
+ "sp-externalities 0.22.0",
+ "sp-runtime-interface 20.0.0",
+ "sp-std 11.0.0",
+ "sp-storage 16.0.0",
  "ss58-registry",
  "substrate-bip39",
  "thiserror",
@@ -6481,21 +6535,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-core-hashing-proc-macro"
-version = "11.0.0"
+name = "sp-core-hashing"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d8681fa136cf504ba2b722fcb10d78df147c15d201b997e06c4c8c72258001a"
+checksum = "a7cb5c31aa385d6997a5b73fdc9837c1c0145559205198555c3000739a474767"
+dependencies = [
+ "blake2b_simd",
+ "byteorder",
+ "digest 0.10.7",
+ "sha2 0.10.7",
+ "sha3",
+ "twox-hash",
+]
+
+[[package]]
+name = "sp-core-hashing-proc-macro"
+version = "12.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a4327a220777a8d492ed3d0bcd4c769cbb030301e7d4a2d9e09513d690c313b"
 dependencies = [
  "quote",
- "sp-core-hashing",
+ "sp-core-hashing 12.0.0",
  "syn 2.0.38",
 ]
 
 [[package]]
 name = "sp-database"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac16ca1b4f309dd51a7a06b1843b73e6e81ff70a05dac17d3c8f9c86e4fba5da"
+checksum = "ab25f79468af89010a8eb84e6bf56068b59929a55291c03519f47208360f3ebe"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.1",
@@ -6513,6 +6581,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-debug-derive"
+version = "11.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16f7d375610590566e11882bf5b5a4b8d0666a96ba86808b2650bbbd9be50bf8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
+]
+
+[[package]]
 name = "sp-externalities"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6520,42 +6599,54 @@ checksum = "588cf40c36de918f545d712ad1a70631ae71653e4a321506dfcd8fa6fd26453c"
 dependencies = [
  "environmental",
  "parity-scale-codec",
- "sp-std",
- "sp-storage",
+ "sp-std 10.0.0",
+ "sp-storage 15.0.0",
+]
+
+[[package]]
+name = "sp-externalities"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ede074871514ca7c5d2eca9563515d858c6220b47ae815714ed4393a4e99db4a"
+dependencies = [
+ "environmental",
+ "parity-scale-codec",
+ "sp-std 11.0.0",
+ "sp-storage 16.0.0",
 ]
 
 [[package]]
 name = "sp-genesis-builder"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae51f8a24e1be6593be94581f3465a10d7c86ce403cbf9dcf703d14f35309d1"
+checksum = "10b9f0251a09b578393f3297abe54a29abdb7e93c17e89a88dc1cabb8e2d5a2d"
 dependencies = [
  "serde_json",
  "sp-api",
  "sp-runtime",
- "sp-std",
+ "sp-std 11.0.0",
 ]
 
 [[package]]
 name = "sp-inherents"
-version = "21.0.0"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4355b6a68001ff5308a09fe069c778c184030ee3b95271dd44841d056ecadf13"
+checksum = "439882da80e9bcfd1ba53df7ec5070d4d7f2a9a93f988aa3598f99ee5bfc76eb"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
  "sp-runtime",
- "sp-std",
+ "sp-std 11.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sp-io"
-version = "25.0.0"
+version = "26.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9926dba7d67d87e40f49e18ff6cfc01373d5be13e3d373f02182bb5ec8ab37b"
+checksum = "88fb6e281de5054565f07a9f79504d21133e115db549993c99f1b21236c677a5"
 dependencies = [
  "bytes",
  "ed25519-dalek",
@@ -6564,13 +6655,13 @@ dependencies = [
  "parity-scale-codec",
  "rustversion",
  "secp256k1",
- "sp-core",
- "sp-externalities",
+ "sp-core 24.0.0",
+ "sp-externalities 0.22.0",
  "sp-keystore",
- "sp-runtime-interface",
+ "sp-runtime-interface 20.0.0",
  "sp-state-machine",
- "sp-std",
- "sp-tracing",
+ "sp-std 11.0.0",
+ "sp-tracing 13.0.0",
  "sp-trie",
  "tracing",
  "tracing-core",
@@ -6578,34 +6669,34 @@ dependencies = [
 
 [[package]]
 name = "sp-keyring"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dfcca2fad349d5fd197a56b4deef229b872c9172a8267d77c81a9f45a38f18a"
+checksum = "05f09927534d2233e135e4b4a0c758554d0ff66178f6e9cfba2e151dfeac97b3"
 dependencies = [
  "lazy_static",
- "sp-core",
+ "sp-core 24.0.0",
  "sp-runtime",
  "strum",
 ]
 
 [[package]]
 name = "sp-keystore"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f0f9546dd151881c60e75355806f1cbbc893f64aa465fc5bf87a47de59467b"
+checksum = "8b9f19e773319d96223ce8dba960267e6cb977907537a8f738746ceb86592413"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.1",
- "sp-core",
- "sp-externalities",
+ "sp-core 24.0.0",
+ "sp-externalities 0.22.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sp-maybe-compressed-blob"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cb1a26782e618f26b43ec8c6ecd799657134cd12af1902ceddaf1fad8031a1b"
+checksum = "377a0e22a104a1a83804562fba6702537af6a36df9ee2049c89c3be9148b42b1"
 dependencies = [
  "thiserror",
  "zstd 0.12.4",
@@ -6613,32 +6704,32 @@ dependencies = [
 
 [[package]]
 name = "sp-metadata-ir"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d493f8324241f20d80cbc920fa0ab7a173907d0bf1a10812098a924cdff48d7"
+checksum = "eb0dec8af38c68358600da59cf14424e1230fe9ae1d4b4f64a098288145c0775"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",
  "scale-info",
- "sp-std",
+ "sp-std 11.0.0",
 ]
 
 [[package]]
 name = "sp-offchain"
-version = "21.0.0"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e1b9996004e6a39c06e6d66bd7684c8a07e73dd9137a2b6f2bbfde675d636a"
+checksum = "50b1501eb4ede6471162ff48c85ccabb21434b698c8b61e2651f85c00bc1656f"
 dependencies = [
  "sp-api",
- "sp-core",
+ "sp-core 24.0.0",
  "sp-runtime",
 ]
 
 [[package]]
 name = "sp-panic-handler"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261572cc0db4b41cf7587b4f7bdc15b8f83f748f17ae1c3c2f56a3e8e62ee913"
+checksum = "cd099ba2d6c1bfe5d0c79aa56e440fa3c9257eadfc0c782c09cdc2122b1e60ed"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -6647,20 +6738,20 @@ dependencies = [
 
 [[package]]
 name = "sp-rpc"
-version = "21.0.0"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5828020dd51228aeee12a571720f3354deb95bc159f5edf4b7f2ffb3e023a12e"
+checksum = "1d8534ae0a6043f70a93054bf0d3da27436637a8134ed44667c360e7a955cb3d"
 dependencies = [
  "rustc-hash",
  "serde",
- "sp-core",
+ "sp-core 24.0.0",
 ]
 
 [[package]]
 name = "sp-runtime"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f645e9e2c82d052ea48ed987a8789daca1c03f9b5ed1aa49cd080092eda85330"
+checksum = "46c0641e1a9d340960b562bcceea1457680fd0e109fc1040f8f5364fd7bc2506"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -6672,10 +6763,10 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-application-crypto",
- "sp-arithmetic",
- "sp-core",
+ "sp-arithmetic 19.0.0",
+ "sp-core 24.0.0",
  "sp-io",
- "sp-std",
+ "sp-std 11.0.0",
  "sp-weights",
 ]
 
@@ -6689,12 +6780,31 @@ dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "primitive-types",
- "sp-externalities",
- "sp-runtime-interface-proc-macro",
- "sp-std",
- "sp-storage",
- "sp-tracing",
- "sp-wasm-interface",
+ "sp-externalities 0.21.0",
+ "sp-runtime-interface-proc-macro 13.0.0",
+ "sp-std 10.0.0",
+ "sp-storage 15.0.0",
+ "sp-tracing 12.0.0",
+ "sp-wasm-interface 16.0.0",
+ "static_assertions",
+]
+
+[[package]]
+name = "sp-runtime-interface"
+version = "20.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17a4030ad93f05c93f2cc294c74bc5fea227f90fb3d1426d4a6f165e017fb7ea"
+dependencies = [
+ "bytes",
+ "impl-trait-for-tuples",
+ "parity-scale-codec",
+ "primitive-types",
+ "sp-externalities 0.22.0",
+ "sp-runtime-interface-proc-macro 14.0.0",
+ "sp-std 11.0.0",
+ "sp-storage 16.0.0",
+ "sp-tracing 13.0.0",
+ "sp-wasm-interface 17.0.0",
  "static_assertions",
 ]
 
@@ -6712,41 +6822,54 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-session"
-version = "22.0.0"
+name = "sp-runtime-interface-proc-macro"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff5d53ba296b793574fc12b6ebf49d6755d24439979290682ca58d759db5bb73"
+checksum = "b232943ee7ca83a6d56face33b8af12e9fb470a15a53835f4e12a6e452a41c1c"
+dependencies = [
+ "Inflector",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
+]
+
+[[package]]
+name = "sp-session"
+version = "23.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfd062688577cc54493ba6f58383bfed89c66d5ef7b7c3747293b0da06c7f795"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api",
- "sp-core",
+ "sp-core 24.0.0",
  "sp-keystore",
  "sp-runtime",
  "sp-staking",
- "sp-std",
+ "sp-std 11.0.0",
 ]
 
 [[package]]
 name = "sp-staking"
-version = "21.0.0"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acb11c6a7765d2df277110fe25bba075f697aba999b29a6c9b55eb2b95401b0"
+checksum = "1d3b2a4a7aa67a9adb2a8f49ed516f6694b5fa70792ab9b0125934b1c8cdc2e3"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core",
+ "sp-core 24.0.0",
  "sp-runtime",
- "sp-std",
+ "sp-std 11.0.0",
 ]
 
 [[package]]
 name = "sp-state-machine"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "771dce7d78335718ab8475984b6dbc1f374777049ed1c308186679e611333be2"
+checksum = "2bf4c76bea1a9e4a2e79afe70f42f1d368a8a45308e58f19bfd755c5ddb2b4a3"
 dependencies = [
  "hash-db",
  "log",
@@ -6754,10 +6877,10 @@ dependencies = [
  "parking_lot 0.12.1",
  "rand 0.8.5",
  "smallvec",
- "sp-core",
- "sp-externalities",
+ "sp-core 24.0.0",
+ "sp-externalities 0.22.0",
  "sp-panic-handler",
- "sp-std",
+ "sp-std 11.0.0",
  "sp-trie",
  "thiserror",
  "tracing",
@@ -6766,9 +6889,9 @@ dependencies = [
 
 [[package]]
 name = "sp-statement-store"
-version = "5.0.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49c431b349889565a6b7f13eaa8216af8f826b015cbe1c9ef21999a44edd61d7"
+checksum = "a11bbdc403457dd7a850078936aa7cc753c617b7bbeba5f5766ce5a55b2bf124"
 dependencies = [
  "aes-gcm 0.10.2",
  "curve25519-dalek 4.0.0",
@@ -6780,11 +6903,11 @@ dependencies = [
  "sha2 0.10.7",
  "sp-api",
  "sp-application-crypto",
- "sp-core",
- "sp-externalities",
+ "sp-core 24.0.0",
+ "sp-externalities 0.22.0",
  "sp-runtime",
- "sp-runtime-interface",
- "sp-std",
+ "sp-runtime-interface 20.0.0",
+ "sp-std 11.0.0",
  "thiserror",
  "x25519-dalek 2.0.0",
 ]
@@ -6796,30 +6919,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed09ef1760e8be9b64b7f739f1cf9a94528130be475d8e4f2d1be1e690c9f9c"
 
 [[package]]
+name = "sp-std"
+version = "11.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c91d32e165d08a14098ce5ec923eaec59d1d0583758a18a770beec1b780b0d0"
+
+[[package]]
 name = "sp-storage"
 version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c20f503280c004d94033a32cb84274ede30ef0b4b634770b1e7d595f8245bda4"
 dependencies = [
- "impl-serde 0.4.0",
+ "impl-serde",
  "parity-scale-codec",
  "ref-cast",
  "serde",
- "sp-debug-derive",
- "sp-std",
+ "sp-debug-derive 10.0.0",
+ "sp-std 10.0.0",
+]
+
+[[package]]
+name = "sp-storage"
+version = "16.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac9660ecd48314443e73ad0f44d58b76426666a1343d72f6f65664e174da9244"
+dependencies = [
+ "impl-serde",
+ "parity-scale-codec",
+ "ref-cast",
+ "serde",
+ "sp-debug-derive 11.0.0",
+ "sp-std 11.0.0",
 ]
 
 [[package]]
 name = "sp-timestamp"
-version = "21.0.0"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00d60953f7fc9b4f51bbcbac8f0cd8d6e6266a7cc18f661330308bbcec1eb053"
+checksum = "3b0ab4b6b2d31db93e7da68894ccb7c5a305524cea051109820b958361d162be"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
  "sp-inherents",
  "sp-runtime",
- "sp-std",
+ "sp-std 11.0.0",
  "thiserror",
 ]
 
@@ -6830,7 +6973,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebabec43485ebdb2fdb5c6f9b388590d4797a3888024d74724ada2f16b2113b8"
 dependencies = [
  "parity-scale-codec",
- "sp-std",
+ "sp-std 10.0.0",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "sp-tracing"
+version = "13.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69a61948986d2a9f8d67d60884ff0277d910df09ebe08d0e1f309da777516453"
+dependencies = [
+ "parity-scale-codec",
+ "sp-std 11.0.0",
  "tracing",
  "tracing-core",
  "tracing-subscriber",
@@ -6838,9 +6994,9 @@ dependencies = [
 
 [[package]]
 name = "sp-trie"
-version = "24.0.0"
+version = "25.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78585a84d02d1c71e8eb8c00ed586c22a46ad4e773d9ff65c8ed3b8e98b9f51"
+checksum = "4bb2d292eb90452dcb0909fb44e74bf04395e3ffa37a66c0f1635a00600382a4"
 dependencies = [
  "ahash 0.8.3",
  "hash-db",
@@ -6852,8 +7008,8 @@ dependencies = [
  "parking_lot 0.12.1",
  "scale-info",
  "schnellru",
- "sp-core",
- "sp-std",
+ "sp-core 24.0.0",
+ "sp-std 11.0.0",
  "thiserror",
  "tracing",
  "trie-db",
@@ -6862,27 +7018,27 @@ dependencies = [
 
 [[package]]
 name = "sp-version"
-version = "24.0.0"
+version = "25.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68a8d11b816cd2c68467c697aecca868ab5828af02ef093681a88554d045b878"
+checksum = "125da59ea46ecb23860e7d895f6f2882f596b71ffca0ae4887558aac541f4342"
 dependencies = [
- "impl-serde 0.4.0",
+ "impl-serde",
  "parity-scale-codec",
  "parity-wasm",
  "scale-info",
  "serde",
  "sp-core-hashing-proc-macro",
  "sp-runtime",
- "sp-std",
+ "sp-std 11.0.0",
  "sp-version-proc-macro",
  "thiserror",
 ]
 
 [[package]]
 name = "sp-version-proc-macro"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6de7bbf860de93bb9b0ccd8e4a74e0dc40089e7192c397bac2b357d4da74e20c"
+checksum = "92897ffa04436cbd100c49ea1f8b637cb68e2a9fe144115f4b545b5ace2f47e2"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -6900,24 +7056,38 @@ dependencies = [
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
- "sp-std",
+ "sp-std 10.0.0",
+ "wasmtime",
+]
+
+[[package]]
+name = "sp-wasm-interface"
+version = "17.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf43bb0c8eb76dc41057ce0fb6b744b94c9aec28b31dff53a1efc4f04ef25384"
+dependencies = [
+ "anyhow",
+ "impl-trait-for-tuples",
+ "log",
+ "parity-scale-codec",
+ "sp-std 11.0.0",
  "wasmtime",
 ]
 
 [[package]]
 name = "sp-weights"
-version = "22.0.0"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86566cae93412e40bea0db9e6b110a7379105412a9aed1af73b5d2fb69cb7000"
+checksum = "4e1cef0aad13ed8a8522a6e86ace16fb97ab220c16d2357e628352b528582693"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
  "smallvec",
- "sp-arithmetic",
- "sp-core",
- "sp-debug-derive",
- "sp-std",
+ "sp-arithmetic 19.0.0",
+ "sp-core 24.0.0",
+ "sp-debug-derive 11.0.0",
+ "sp-std 11.0.0",
 ]
 
 [[package]]
@@ -7058,9 +7228,9 @@ dependencies = [
 
 [[package]]
 name = "substrate-prometheus-endpoint"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "055e4661d7d20f68388a26419216035df64a06f34506b947c8a6e2db49d85461"
+checksum = "7e99fe4e955b8d7c25bd3a88a6907933867d11ef6194ef935e865a9e87c320ff"
 dependencies = [
  "hyper",
  "log",
@@ -7205,12 +7375,12 @@ dependencies = [
  "pallet-encointer-scheduler",
  "pallet-timestamp",
  "parity-scale-codec",
- "sp-core",
+ "sp-core 24.0.0",
  "sp-inherents",
  "sp-io",
  "sp-keyring",
  "sp-runtime",
- "sp-std",
+ "sp-std 11.0.0",
 ]
 
 [[package]]
@@ -7526,9 +7696,9 @@ dependencies = [
 
 [[package]]
 name = "trie-db"
-version = "0.27.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "767abe6ffed88a1889671a102c2861ae742726f52e0a5a425b92c9fbfa7e9c85"
+checksum = "ff28e0f815c2fea41ebddf148e008b077d2faddb026c9555b29696114d602642"
 dependencies = [
  "hash-db",
  "hashbrown 0.13.2",

--- a/README.md
+++ b/README.md
@@ -62,6 +62,13 @@ use `cargo-release` we exclude non-public crates explicitly in tomls
 
 ```
 cargo install cargo-release
-cargo release --execute
+
+# check workspace dependency tree
+cargo tree --workspace -i ep-core
+
+# add --execute if you're sure
+cargo release publish -p ep-core -p encointer-primitives -p test-utils -p pallet-encointer-scheduler -p pallet-encointer-balances -p pallet-encointer-communities
+cargo release publish -p encointer-ceremonies-assignment -p encointer-meetup-validation -p pallet-encointer-ceremonies -p pallet-encointer-bazaar -p pallet-encointer-reputation-commitments -p pallet-encointer-faucet
+cargo release publish -p encointer-rpc -p encointer-balances-tx-payment -p encointer-balances-tx-payment-rpc-runtime-api -p encointer-balances-tx-payment-rpc -p pallet-encointer-bazaar-rpc-runtime-api -p pallet-encointer-bazaar-rpc -p pallet-encointer-ceremonies-rpc-runtime-api -p pallet-encointer-ceremonies-rpc -p pallet-encointer-communities-rpc-runtime-api -p pallet-encointer-communities-rpc
 ```
 

--- a/balances-tx-payment/Cargo.toml
+++ b/balances-tx-payment/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "encointer-balances-tx-payment"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Encointer Association <info@encointer.org>"]
 edition = "2021"
 description = "Balances tx payment for the Encointer blockchain runtime"
@@ -11,9 +11,9 @@ license = "GPL-3.0-or-later"
 [dependencies]
 log = { version = "0.4.20", default-features = false }
 
-encointer-primitives = { path = "../primitives", default-features = false, version = "1.3.0" }
-pallet-encointer-balances = { path = "../balances", default-features = false, version = "1.2.0" }
-pallet-encointer-ceremonies = { path = "../ceremonies", default-features = false, version = "1.2.0" }
+encointer-primitives = { path = "../primitives", default-features = false, version = "2.0.0" }
+pallet-encointer-balances = { path = "../balances", default-features = false, version = "2.0.0" }
+pallet-encointer-ceremonies = { path = "../ceremonies", default-features = false, version = "2.0.0" }
 
 # substrate dependencies
 frame-support = { default-features = false, version = "24.0.0" }

--- a/balances-tx-payment/Cargo.toml
+++ b/balances-tx-payment/Cargo.toml
@@ -9,26 +9,26 @@ repository = "https://github.com/encointer/pallets"
 license = "GPL-3.0-or-later"
 
 [dependencies]
-log = { version = "0.4.14", default-features = false }
+log = { version = "0.4.20", default-features = false }
 
 encointer-primitives = { path = "../primitives", default-features = false, version = "1.3.0" }
 pallet-encointer-balances = { path = "../balances", default-features = false, version = "1.2.0" }
 pallet-encointer-ceremonies = { path = "../ceremonies", default-features = false, version = "1.2.0" }
 
 # substrate dependencies
-frame-support = { default-features = false, version = "23.0.0" }
-frame-system = { default-features = false, version = "23.0.0" }
-pallet-asset-tx-payment = { default-features = false, version = "23.0.0" }
-pallet-transaction-payment = { default-features = false, version = "23.0.0" }
-sp-runtime = { default-features = false, version = "26.0.0" }
+frame-support = { default-features = false, version = "24.0.0" }
+frame-system = { default-features = false, version = "24.0.0" }
+pallet-asset-tx-payment = { default-features = false, version = "24.0.0" }
+pallet-transaction-payment = { default-features = false, version = "24.0.0" }
+sp-runtime = { default-features = false, version = "27.0.0" }
 
 [dev-dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [
+codec = { package = "parity-scale-codec", version = "3.6.4", default-features = false, features = [
     "derive",
 ] }
 rstest = "0.12.0"
-scale-info = { version = "2.5.0", default-features = false }
-sp-io = "25.0.0"
+scale-info = { version = "2.9.0", default-features = false }
+sp-io = "26.0.0"
 test-utils = { path = "../test-utils" }
 
 [features]

--- a/balances-tx-payment/rpc/Cargo.toml
+++ b/balances-tx-payment/rpc/Cargo.toml
@@ -9,13 +9,13 @@ repository = "https://github.com/encointer/pallets"
 license = "GPL-3.0-or-later"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
-jsonrpsee = { version = "0.16.2", features = [
+codec = { package = "parity-scale-codec", version = "3.6.4", default-features = false }
+jsonrpsee = { version = "0.16.3", features = [
     "client-core",
     "server",
     "macros",
 ] }
-log = "0.4.14"
+log = "0.4.20"
 parking_lot = "0.12.0"
 thiserror = "1.0.31"
 
@@ -25,12 +25,12 @@ encointer-primitives = { path = "../../primitives", version = "1.3.0" }
 encointer-rpc = { path = "../../rpc", version = "0.1.0" }
 
 # substrate deps
-pallet-transaction-payment = { default-features = false, version = "23.0.0" }
-pallet-transaction-payment-rpc = { default-features = false, version = "25.0.0" }
-sc-rpc = "24.0.0"
-sc-rpc-api = "0.28.0"
-sp-api = "21.0.0"
-sp-blockchain = "23.0.0"
-sp-core = "23.0.0"
-sp-rpc = "21.0.0"
-sp-runtime = "26.0.0"
+pallet-transaction-payment = { default-features = false, version = "24.0.0" }
+pallet-transaction-payment-rpc = { default-features = false, version = "26.0.0" }
+sc-rpc = "25.0.0"
+sc-rpc-api = "0.29.0"
+sp-api = "22.0.0"
+sp-blockchain = "24.0.0"
+sp-core = "24.0.0"
+sp-rpc = "22.0.0"
+sp-runtime = "27.0.0"

--- a/balances-tx-payment/rpc/Cargo.toml
+++ b/balances-tx-payment/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "encointer-balances-tx-payment-rpc"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Encointer Association <info@encointer.org>"]
 edition = "2021"
 description = "Balances tx payment rpc for the Encointer blockchain runtime"
@@ -20,9 +20,9 @@ parking_lot = "0.12.0"
 thiserror = "1.0.31"
 
 # local deps
-encointer-balances-tx-payment-rpc-runtime-api = { package = "encointer-balances-tx-payment-rpc-runtime-api", path = "runtime-api", version = "1.0.0" }
-encointer-primitives = { path = "../../primitives", version = "1.3.0" }
-encointer-rpc = { path = "../../rpc", version = "0.1.0" }
+encointer-balances-tx-payment-rpc-runtime-api = { package = "encointer-balances-tx-payment-rpc-runtime-api", path = "runtime-api", version = "2.0.0" }
+encointer-primitives = { path = "../../primitives", version = "2.0.0" }
+encointer-rpc = { path = "../../rpc", version = "2.0.0" }
 
 # substrate deps
 pallet-transaction-payment = { default-features = false, version = "24.0.0" }

--- a/balances-tx-payment/rpc/runtime-api/Cargo.toml
+++ b/balances-tx-payment/rpc/runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "encointer-balances-tx-payment-rpc-runtime-api"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Encointer Association <info@encointer.org>"]
 edition = "2021"
 description = "Balances tx payment rpc runtime api for the Encointer blockchain runtime"
@@ -10,7 +10,7 @@ license = "GPL-3.0-or-later"
 
 [dependencies]
 # local deps
-encointer-primitives = { path = "../../../primitives", default-features = false, version = "1.3.0" }
+encointer-primitives = { path = "../../../primitives", default-features = false, version = "2.0.0" }
 
 # substrate deps
 codec = { package = "parity-scale-codec", version = "3.6.4", default-features = false, features = [

--- a/balances-tx-payment/rpc/runtime-api/Cargo.toml
+++ b/balances-tx-payment/rpc/runtime-api/Cargo.toml
@@ -13,13 +13,13 @@ license = "GPL-3.0-or-later"
 encointer-primitives = { path = "../../../primitives", default-features = false, version = "1.3.0" }
 
 # substrate deps
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [
+codec = { package = "parity-scale-codec", version = "3.6.4", default-features = false, features = [
     "derive",
 ] }
-frame-support = { default-features = false, version = "23.0.0" }
-scale-info = { version = "2.5.0", default-features = false }
-sp-api = { default-features = false, version = "21.0.0" }
-sp-std = { default-features = false, version = "10.0.0" }
+frame-support = { default-features = false, version = "24.0.0" }
+scale-info = { version = "2.9.0", default-features = false }
+sp-api = { default-features = false, version = "22.0.0" }
+sp-std = { default-features = false, version = "11.0.0" }
 
 [features]
 default = ["std"]

--- a/balances/Cargo.toml
+++ b/balances/Cargo.toml
@@ -10,27 +10,27 @@ license = "GPL-3.0-or-later"
 
 [dependencies]
 approx = { version = "0.5.1", optional = true }
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [
+codec = { package = "parity-scale-codec", version = "3.6.4", default-features = false, features = [
     "derive",
 ] }
-log = { version = "0.4.14", default-features = false }
-scale-info = { version = "2.5.0", default-features = false }
+log = { version = "0.4.20", default-features = false }
+scale-info = { version = "2.9.0", default-features = false }
 
 # local deps
 encointer-primitives = { path = "../primitives", default-features = false, features = ["serde_derive"], version = "1.3.0" }
 
 # substrate deps
-frame-benchmarking = { default-features = false, optional = true, version = "23.0.0" }
-frame-support = { default-features = false, version = "23.0.0" }
-frame-system = { default-features = false, version = "23.0.0" }
-pallet-asset-tx-payment = { default-features = false, version = "23.0.0" }
-pallet-transaction-payment = { default-features = false, version = "23.0.0" }
-sp-runtime = { default-features = false, version = "26.0.0" }
-sp-std = { default-features = false, version = "10.0.0" }
+frame-benchmarking = { default-features = false, optional = true, version = "24.0.0" }
+frame-support = { default-features = false, version = "24.0.0" }
+frame-system = { default-features = false, version = "24.0.0" }
+pallet-asset-tx-payment = { default-features = false, version = "24.0.0" }
+pallet-transaction-payment = { default-features = false, version = "24.0.0" }
+sp-runtime = { default-features = false, version = "27.0.0" }
+sp-std = { default-features = false, version = "11.0.0" }
 
 [dev-dependencies]
 approx = "0.5.1"
-sp-io = "25.0.0"
+sp-io = "26.0.0"
 test-utils = { path = "../test-utils" }
 
 [features]

--- a/balances/Cargo.toml
+++ b/balances/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-encointer-balances"
-version = "1.2.0"
+version = "2.0.0"
 authors = ["Encointer Association <info@encointer.org>"]
 edition = "2021"
 description = "Balances pallet for the Encointer blockchain runtime"
@@ -17,7 +17,7 @@ log = { version = "0.4.20", default-features = false }
 scale-info = { version = "2.9.0", default-features = false }
 
 # local deps
-encointer-primitives = { path = "../primitives", default-features = false, features = ["serde_derive"], version = "1.3.0" }
+encointer-primitives = { path = "../primitives", default-features = false, features = ["serde_derive"], version = "2.0.0" }
 
 # substrate deps
 frame-benchmarking = { default-features = false, optional = true, version = "24.0.0" }

--- a/bazaar/Cargo.toml
+++ b/bazaar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-encointer-bazaar"
-version = "1.1.0"
+version = "2.0.0"
 authors = ["Encointer Association <info@encointer.org>"]
 edition = "2021"
 description = "Bazaar pallet for the Encointer blockchain runtime"
@@ -16,8 +16,8 @@ log = { version = "0.4.20", default-features = false }
 scale-info = { version = "2.9.0", default-features = false }
 
 # local deps
-encointer-communities = { package = "pallet-encointer-communities", path = "../communities", default-features = false, version = "1.3.0" }
-encointer-primitives = { path = "../primitives", default-features = false, features = ["serde_derive"], version = "1.3.0" }
+encointer-communities = { package = "pallet-encointer-communities", path = "../communities", default-features = false, version = "2.0.0" }
+encointer-primitives = { path = "../primitives", default-features = false, features = ["serde_derive"], version = "2.0.0" }
 
 # substrate deps
 frame-benchmarking = { default-features = false, optional = true, version = "24.0.0" }

--- a/bazaar/Cargo.toml
+++ b/bazaar/Cargo.toml
@@ -9,25 +9,25 @@ repository = "https://github.com/encointer/pallets"
 license = "GPL-3.0-or-later"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [
+codec = { package = "parity-scale-codec", version = "3.6.4", default-features = false, features = [
     "derive",
 ] }
-log = { version = "0.4.14", default-features = false }
-scale-info = { version = "2.5.0", default-features = false }
+log = { version = "0.4.20", default-features = false }
+scale-info = { version = "2.9.0", default-features = false }
 
 # local deps
 encointer-communities = { package = "pallet-encointer-communities", path = "../communities", default-features = false, version = "1.3.0" }
 encointer-primitives = { path = "../primitives", default-features = false, features = ["serde_derive"], version = "1.3.0" }
 
 # substrate deps
-frame-benchmarking = { default-features = false, optional = true, version = "23.0.0" }
-frame-support = { default-features = false, version = "23.0.0" }
-frame-system = { default-features = false, version = "23.0.0" }
-sp-core = { default-features = false, version = "23.0.0" }
-sp-std = { default-features = false, version = "10.0.0" }
+frame-benchmarking = { default-features = false, optional = true, version = "24.0.0" }
+frame-support = { default-features = false, version = "24.0.0" }
+frame-system = { default-features = false, version = "24.0.0" }
+sp-core = { default-features = false, version = "24.0.0" }
+sp-std = { default-features = false, version = "11.0.0" }
 
 [dev-dependencies]
-sp-io = "25.0.0"
+sp-io = "26.0.0"
 test-utils = { path = "../test-utils" }
 
 [features]

--- a/bazaar/rpc/Cargo.toml
+++ b/bazaar/rpc/Cargo.toml
@@ -9,12 +9,12 @@ repository = "https://github.com/encointer/pallets"
 license = "GPL-3.0-or-later"
 
 [dependencies]
-jsonrpsee = { version = "0.16.2", features = [
+jsonrpsee = { version = "0.16.3", features = [
     "client-core",
     "server",
     "macros",
 ] }
-log = "0.4.14"
+log = "0.4.20"
 parking_lot = "0.12.0"
 thiserror = "1.0.31"
 
@@ -24,8 +24,8 @@ encointer-primitives = { path = "../../primitives", version = "1.3.0" }
 encointer-rpc = { path = "../../rpc", version = "0.1.0" }
 
 # substrate deps
-sc-rpc = "24.0.0"
-sc-rpc-api = "0.28.0"
-sp-api = "21.0.0"
-sp-blockchain = "23.0.0"
-sp-runtime = "26.0.0"
+sc-rpc = "25.0.0"
+sc-rpc-api = "0.29.0"
+sp-api = "22.0.0"
+sp-blockchain = "24.0.0"
+sp-runtime = "27.0.0"

--- a/bazaar/rpc/Cargo.toml
+++ b/bazaar/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-encointer-bazaar-rpc"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Encointer Association <info@encointer.org>"]
 edition = "2021"
 description = "Bazaar rpc for the Encointer blockchain runtime"
@@ -19,9 +19,9 @@ parking_lot = "0.12.0"
 thiserror = "1.0.31"
 
 # local deps
-encointer-bazaar-rpc-runtime-api = { package = "pallet-encointer-bazaar-rpc-runtime-api", path = "runtime-api", version = "1.0.0" }
-encointer-primitives = { path = "../../primitives", version = "1.3.0" }
-encointer-rpc = { path = "../../rpc", version = "0.1.0" }
+encointer-bazaar-rpc-runtime-api = { package = "pallet-encointer-bazaar-rpc-runtime-api", path = "runtime-api", version = "2.0.0" }
+encointer-primitives = { path = "../../primitives", version = "2.0.0" }
+encointer-rpc = { path = "../../rpc", version = "2.0.0" }
 
 # substrate deps
 sc-rpc = "25.0.0"

--- a/bazaar/rpc/runtime-api/Cargo.toml
+++ b/bazaar/rpc/runtime-api/Cargo.toml
@@ -13,9 +13,9 @@ license = "GPL-3.0-or-later"
 encointer-primitives = { path = "../../../primitives", default-features = false, version = "1.3.0" }
 
 # substrate deps
-frame-support = { default-features = false, version = "23.0.0" }
-sp-api = { default-features = false, version = "21.0.0" }
-sp-std = { default-features = false, version = "10.0.0" }
+frame-support = { default-features = false, version = "24.0.0" }
+sp-api = { default-features = false, version = "22.0.0" }
+sp-std = { default-features = false, version = "11.0.0" }
 
 [features]
 default = ["std"]

--- a/bazaar/rpc/runtime-api/Cargo.toml
+++ b/bazaar/rpc/runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-encointer-bazaar-rpc-runtime-api"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Encointer Association <info@encointer.org>"]
 edition = "2021"
 description = "Bazaar rpc runtime API for the Encointer blockchain runtime"
@@ -10,7 +10,7 @@ license = "GPL-3.0-or-later"
 
 [dependencies]
 # local deps
-encointer-primitives = { path = "../../../primitives", default-features = false, version = "1.3.0" }
+encointer-primitives = { path = "../../../primitives", default-features = false, version = "2.0.0" }
 
 # substrate deps
 frame-support = { default-features = false, version = "24.0.0" }

--- a/ceremonies/Cargo.toml
+++ b/ceremonies/Cargo.toml
@@ -9,11 +9,11 @@ repository = "https://github.com/encointer/pallets"
 license = "GPL-3.0-or-later"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [
+codec = { package = "parity-scale-codec", version = "3.6.4", default-features = false, features = [
     "derive",
 ] }
-log = { version = "0.4.14", default-features = false }
-scale-info = { version = "2.5.0", default-features = false }
+log = { version = "0.4.20", default-features = false }
+scale-info = { version = "2.9.0", default-features = false }
 
 # local deps
 encointer-balances = { package = "pallet-encointer-balances", path = "../balances", default-features = false, version = "1.2.0" }
@@ -24,24 +24,24 @@ encointer-primitives = { path = "../primitives", default-features = false, featu
 encointer-scheduler = { package = "pallet-encointer-scheduler", path = "../scheduler", default-features = false, version = "1.1.0" }
 
 # substrate deps
-frame-support = { default-features = false, version = "23.0.0" }
-frame-system = { default-features = false, version = "23.0.0" }
-pallet-timestamp = { default-features = false, version = "22.0.0" }
-sp-core = { default-features = false, version = "23.0.0" }
-sp-io = { default-features = false, version = "25.0.0" }
-sp-runtime = { default-features = false, version = "26.0.0" }
-sp-std = { default-features = false, version = "10.0.0" }
+frame-support = { default-features = false, version = "24.0.0" }
+frame-system = { default-features = false, version = "24.0.0" }
+pallet-timestamp = { default-features = false, version = "23.0.0" }
+sp-core = { default-features = false, version = "24.0.0" }
+sp-io = { default-features = false, version = "26.0.0" }
+sp-runtime = { default-features = false, version = "27.0.0" }
+sp-std = { default-features = false, version = "11.0.0" }
 
 # benchmarking
-frame-benchmarking = { default-features = false, optional = true, version = "23.0.0" }
-sp-application-crypto = { default-features = false, optional = true, version = "25.0.0" }
+frame-benchmarking = { default-features = false, optional = true, version = "24.0.0" }
+sp-application-crypto = { default-features = false, optional = true, version = "26.0.0" }
 
 [dev-dependencies]
 approx = "0.5.1"
 itertools = "0.10.3"
 rstest = "0.12.0"
-sp-io = "25.0.0"
-sp-keystore = "0.29.0"
+sp-io = "26.0.0"
+sp-keystore = "0.30.0"
 test-utils = { path = "../test-utils" }
 
 [features]

--- a/ceremonies/Cargo.toml
+++ b/ceremonies/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-encointer-ceremonies"
-version = "1.2.0"
+version = "2.0.0"
 authors = ["Encointer Association <info@encointer.org>"]
 edition = "2021"
 description = "Ceremonies pallet for the Encointer blockchain runtime"
@@ -16,12 +16,12 @@ log = { version = "0.4.20", default-features = false }
 scale-info = { version = "2.9.0", default-features = false }
 
 # local deps
-encointer-balances = { package = "pallet-encointer-balances", path = "../balances", default-features = false, version = "1.2.0" }
-encointer-ceremonies-assignment = { path = "assignment", default-features = false, version = "1.2.0" }
-encointer-communities = { package = "pallet-encointer-communities", path = "../communities", default-features = false, version = "1.3.0" }
-encointer-meetup-validation = { path = "meetup-validation", default-features = false, version = "1.2.0" }
-encointer-primitives = { path = "../primitives", default-features = false, features = ["serde_derive"], version = "1.3.0" }
-encointer-scheduler = { package = "pallet-encointer-scheduler", path = "../scheduler", default-features = false, version = "1.1.0" }
+encointer-balances = { package = "pallet-encointer-balances", path = "../balances", default-features = false, version = "2.0.0" }
+encointer-ceremonies-assignment = { path = "assignment", default-features = false, version = "2.0.0" }
+encointer-communities = { package = "pallet-encointer-communities", path = "../communities", default-features = false, version = "2.0.0" }
+encointer-meetup-validation = { path = "meetup-validation", default-features = false, version = "2.0.0" }
+encointer-primitives = { path = "../primitives", default-features = false, features = ["serde_derive"], version = "2.0.0" }
+encointer-scheduler = { package = "pallet-encointer-scheduler", path = "../scheduler", default-features = false, version = "2.0.0" }
 
 # substrate deps
 frame-support = { default-features = false, version = "24.0.0" }

--- a/ceremonies/assignment/Cargo.toml
+++ b/ceremonies/assignment/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "encointer-ceremonies-assignment"
-version = "1.2.0"
+version = "2.0.0"
 authors = ["Encointer Association <info@encointer.org>"]
 edition = "2021"
 description = "Ceremonies assignments for the Encointer blockchain runtime"
@@ -10,7 +10,7 @@ license = "GPL-3.0-or-later"
 
 [dependencies]
 # local deps
-encointer-primitives = { path = "../../primitives", default-features = false, version = "1.3.0" }
+encointer-primitives = { path = "../../primitives", default-features = false, version = "2.0.0" }
 
 # substrate deps
 sp-runtime = { default-features = false, version = "27.0.0" }

--- a/ceremonies/assignment/Cargo.toml
+++ b/ceremonies/assignment/Cargo.toml
@@ -13,11 +13,11 @@ license = "GPL-3.0-or-later"
 encointer-primitives = { path = "../../primitives", default-features = false, version = "1.3.0" }
 
 # substrate deps
-sp-runtime = { default-features = false, version = "26.0.0" }
-sp-std = { default-features = false, version = "10.0.0" }
+sp-runtime = { default-features = false, version = "27.0.0" }
+sp-std = { default-features = false, version = "11.0.0" }
 
 [dev-dependencies]
-sp-core = "23.0.0"
+sp-core = "24.0.0"
 
 [features]
 default = ["std"]

--- a/ceremonies/meetup-validation/Cargo.toml
+++ b/ceremonies/meetup-validation/Cargo.toml
@@ -9,10 +9,10 @@ repository = "https://github.com/encointer/pallets"
 license = "GPL-3.0-or-later"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [
+codec = { package = "parity-scale-codec", version = "3.6.4", default-features = false, features = [
     "derive",
 ] }
-scale-info = { version = "2.5.0", default-features = false }
+scale-info = { version = "2.9.0", default-features = false }
 serde = { version = "1.0.136", default-features = false, features = [
     "derive",
     "alloc",
@@ -22,12 +22,12 @@ serde = { version = "1.0.136", default-features = false, features = [
 encointer-primitives = { path = "../../primitives", default-features = false, version = "1.3.0" }
 
 # substrate deps
-sp-runtime = { default-features = false, version = "26.0.0" }
-sp-std = { default-features = false, version = "10.0.0" }
+sp-runtime = { default-features = false, version = "27.0.0" }
+sp-std = { default-features = false, version = "11.0.0" }
 
 [dev-dependencies]
 rstest = "0.12.0"
-sp-core = "23.0.0"
+sp-core = "24.0.0"
 
 [features]
 default = ["std"]

--- a/ceremonies/meetup-validation/Cargo.toml
+++ b/ceremonies/meetup-validation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "encointer-meetup-validation"
-version = "1.2.0"
+version = "2.0.0"
 authors = ["Encointer Association <info@encointer.org>"]
 edition = "2021"
 description = "Meetup validation for the Encointer blockchain runtime"
@@ -19,7 +19,7 @@ serde = { version = "1.0.136", default-features = false, features = [
 ] }
 
 # local deps
-encointer-primitives = { path = "../../primitives", default-features = false, version = "1.3.0" }
+encointer-primitives = { path = "../../primitives", default-features = false, version = "2.0.0" }
 
 # substrate deps
 sp-runtime = { default-features = false, version = "27.0.0" }

--- a/ceremonies/rpc/Cargo.toml
+++ b/ceremonies/rpc/Cargo.toml
@@ -9,12 +9,12 @@ repository = "https://github.com/encointer/pallets"
 license = "GPL-3.0-or-later"
 
 [dependencies]
-jsonrpsee = { version = "0.16.2", features = [
+jsonrpsee = { version = "0.16.3", features = [
     "client-core",
     "server",
     "macros",
 ] }
-log = "0.4.14"
+log = "0.4.20"
 parking_lot = "0.12.0"
 thiserror = "1.0.31"
 
@@ -24,8 +24,8 @@ encointer-primitives = { path = "../../primitives", version = "1.3.0" }
 encointer-rpc = { path = "../../rpc", version = "0.1.0" }
 
 # substrate deps
-sc-rpc = "24.0.0"
-sc-rpc-api = "0.28.0"
-sp-api = "21.0.0"
-sp-blockchain = "23.0.0"
-sp-runtime = "26.0.0"
+sc-rpc = "25.0.0"
+sc-rpc-api = "0.29.0"
+sp-api = "22.0.0"
+sp-blockchain = "24.0.0"
+sp-runtime = "27.0.0"

--- a/ceremonies/rpc/Cargo.toml
+++ b/ceremonies/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-encointer-ceremonies-rpc"
-version = "1.2.0"
+version = "2.0.0"
 authors = ["Encointer Association <info@encointer.org>"]
 edition = "2021"
 description = "Ceremonies rpc for the Encointer blockchain runtime"
@@ -19,9 +19,9 @@ parking_lot = "0.12.0"
 thiserror = "1.0.31"
 
 # local deps
-encointer-ceremonies-rpc-runtime-api = { package = "pallet-encointer-ceremonies-rpc-runtime-api", path = "runtime-api", version = "1.2.0" }
-encointer-primitives = { path = "../../primitives", version = "1.3.0" }
-encointer-rpc = { path = "../../rpc", version = "0.1.0" }
+encointer-ceremonies-rpc-runtime-api = { package = "pallet-encointer-ceremonies-rpc-runtime-api", path = "runtime-api", version = "2.0.0" }
+encointer-primitives = { path = "../../primitives", version = "2.0.0" }
+encointer-rpc = { path = "../../rpc", version = "2.0.0" }
 
 # substrate deps
 sc-rpc = "25.0.0"

--- a/ceremonies/rpc/runtime-api/Cargo.toml
+++ b/ceremonies/rpc/runtime-api/Cargo.toml
@@ -13,9 +13,9 @@ license = "GPL-3.0-or-later"
 encointer-primitives = { path = "../../../primitives", default-features = false, version = "1.3.0" }
 
 # substrate deps
-frame-support = { default-features = false, version = "23.0.0" }
-sp-api = { default-features = false, version = "21.0.0" }
-sp-std = { default-features = false, version = "10.0.0" }
+frame-support = { default-features = false, version = "24.0.0" }
+sp-api = { default-features = false, version = "22.0.0" }
+sp-std = { default-features = false, version = "11.0.0" }
 
 [features]
 default = ["std"]

--- a/ceremonies/rpc/runtime-api/Cargo.toml
+++ b/ceremonies/rpc/runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-encointer-ceremonies-rpc-runtime-api"
-version = "1.2.0"
+version = "2.0.0"
 authors = ["Encointer Association <info@encointer.org>"]
 edition = "2021"
 description = "Ceremonies rpc runtime API for the Encointer blockchain runtime"
@@ -10,7 +10,7 @@ license = "GPL-3.0-or-later"
 
 [dependencies]
 # local deps
-encointer-primitives = { path = "../../../primitives", default-features = false, version = "1.3.0" }
+encointer-primitives = { path = "../../../primitives", default-features = false, version = "2.0.0" }
 
 # substrate deps
 frame-support = { default-features = false, version = "24.0.0" }

--- a/communities/Cargo.toml
+++ b/communities/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-encointer-communities"
-version = "1.3.0"
+version = "2.0.0"
 authors = ["Encointer Association <info@encointer.org>"]
 edition = "2021"
 description = "Communities pallet for the Encointer blockchain runtime"
@@ -16,9 +16,9 @@ log = { version = "0.4.20", default-features = false }
 scale-info = { version = "2.9.0", default-features = false }
 
 # local deps
-encointer-balances = { package = "pallet-encointer-balances", path = "../balances", default-features = false, version = "1.2.0" }
-encointer-primitives = { path = "../primitives", default-features = false, features = ["serde_derive"], version = "1.3.0" }
-encointer-scheduler = { package = "pallet-encointer-scheduler", path = "../scheduler", default-features = false, version = "1.1.0" }
+encointer-balances = { package = "pallet-encointer-balances", path = "../balances", default-features = false, version = "2.0.0" }
+encointer-primitives = { path = "../primitives", default-features = false, features = ["serde_derive"], version = "2.0.0" }
+encointer-scheduler = { package = "pallet-encointer-scheduler", path = "../scheduler", default-features = false, version = "2.0.0" }
 
 # substrate deps
 frame-benchmarking = { default-features = false, optional = true, version = "24.0.0" }

--- a/communities/Cargo.toml
+++ b/communities/Cargo.toml
@@ -9,11 +9,11 @@ repository = "https://github.com/encointer/pallets"
 license = "GPL-3.0-or-later"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [
+codec = { package = "parity-scale-codec", version = "3.6.4", default-features = false, features = [
     "derive",
 ] }
-log = { version = "0.4.14", default-features = false }
-scale-info = { version = "2.5.0", default-features = false }
+log = { version = "0.4.20", default-features = false }
+scale-info = { version = "2.9.0", default-features = false }
 
 # local deps
 encointer-balances = { package = "pallet-encointer-balances", path = "../balances", default-features = false, version = "1.2.0" }
@@ -21,16 +21,16 @@ encointer-primitives = { path = "../primitives", default-features = false, featu
 encointer-scheduler = { package = "pallet-encointer-scheduler", path = "../scheduler", default-features = false, version = "1.1.0" }
 
 # substrate deps
-frame-benchmarking = { default-features = false, optional = true, version = "23.0.0" }
-frame-support = { default-features = false, version = "23.0.0" }
-frame-system = { default-features = false, version = "23.0.0" }
-sp-io = { default-features = false, version = "25.0.0" }
-sp-runtime = { default-features = false, version = "26.0.0" }
-sp-std = { default-features = false, version = "10.0.0" }
+frame-benchmarking = { default-features = false, optional = true, version = "24.0.0" }
+frame-support = { default-features = false, version = "24.0.0" }
+frame-system = { default-features = false, version = "24.0.0" }
+sp-io = { default-features = false, version = "26.0.0" }
+sp-runtime = { default-features = false, version = "27.0.0" }
+sp-std = { default-features = false, version = "11.0.0" }
 
 [dev-dependencies]
 approx = "0.5.1"
-sp-core = "23.0.0"
+sp-core = "24.0.0"
 test-utils = { path = "../test-utils" }
 
 [features]

--- a/communities/rpc/Cargo.toml
+++ b/communities/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-encointer-communities-rpc"
-version = "1.2.0"
+version = "2.0.0"
 authors = ["Encointer Association <info@encointer.org>"]
 edition = "2021"
 description = "Communities rpc for the Encointer blockchain runtime"
@@ -19,9 +19,9 @@ parking_lot = "0.12.0"
 thiserror = "1.0.31"
 
 # local deps
-encointer-communities-rpc-runtime-api = { package = "pallet-encointer-communities-rpc-runtime-api", path = "runtime-api", version = "1.2.0" }
-encointer-primitives = { path = "../../primitives", version = "1.3.0" }
-encointer-rpc = { path = "../../rpc", version = "0.1.0" }
+encointer-communities-rpc-runtime-api = { package = "pallet-encointer-communities-rpc-runtime-api", path = "runtime-api", version = "2.0.0" }
+encointer-primitives = { path = "../../primitives", version = "2.0.0" }
+encointer-rpc = { path = "../../rpc", version = "2.0.0" }
 
 # substrate deps
 sc-rpc = "25.0.0"

--- a/communities/rpc/Cargo.toml
+++ b/communities/rpc/Cargo.toml
@@ -9,12 +9,12 @@ repository = "https://github.com/encointer/pallets"
 license = "GPL-3.0-or-later"
 
 [dependencies]
-jsonrpsee = { version = "0.16.2", features = [
+jsonrpsee = { version = "0.16.3", features = [
     "client-core",
     "server",
     "macros",
 ] }
-log = "0.4.14"
+log = "0.4.20"
 parking_lot = "0.12.0"
 thiserror = "1.0.31"
 
@@ -24,11 +24,11 @@ encointer-primitives = { path = "../../primitives", version = "1.3.0" }
 encointer-rpc = { path = "../../rpc", version = "0.1.0" }
 
 # substrate deps
-sc-rpc = "24.0.0"
-sc-rpc-api = "0.28.0"
-sp-api = "21.0.0"
-sp-blockchain = "23.0.0"
-sp-runtime = "26.0.0"
+sc-rpc = "25.0.0"
+sc-rpc-api = "0.29.0"
+sp-api = "22.0.0"
+sp-blockchain = "24.0.0"
+sp-runtime = "27.0.0"
 
 [dev-dependencies]
-sp-core = "23.0.0"
+sp-core = "24.0.0"

--- a/communities/rpc/runtime-api/Cargo.toml
+++ b/communities/rpc/runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-encointer-communities-rpc-runtime-api"
-version = "1.2.0"
+version = "2.0.0"
 authors = ["Encointer Association <info@encointer.org>"]
 edition = "2021"
 description = "Communities rpc runtime api for the Encointer blockchain runtime"
@@ -10,7 +10,7 @@ license = "GPL-3.0-or-later"
 
 [dependencies]
 # local deps
-encointer-primitives = { path = "../../../primitives", default-features = false, version = "1.3.0" }
+encointer-primitives = { path = "../../../primitives", default-features = false, version = "2.0.0" }
 
 # substrate deps
 sp-api = { default-features = false, version = "22.0.0" }

--- a/communities/rpc/runtime-api/Cargo.toml
+++ b/communities/rpc/runtime-api/Cargo.toml
@@ -13,8 +13,8 @@ license = "GPL-3.0-or-later"
 encointer-primitives = { path = "../../../primitives", default-features = false, version = "1.3.0" }
 
 # substrate deps
-sp-api = { default-features = false, version = "21.0.0" }
-sp-std = { default-features = false, version = "10.0.0" }
+sp-api = { default-features = false, version = "22.0.0" }
+sp-std = { default-features = false, version = "11.0.0" }
 
 [features]
 default = ["std"]

--- a/democracy/Cargo.toml
+++ b/democracy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-encointer-democracy"
-version = "1.2.0"
+version = "2.0.0"
 authors = ["Encointer Association <info@encointer.org>"]
 edition = "2021"
 description = "Democracy pallet for the Encointer blockchain runtime"
@@ -15,10 +15,10 @@ log = { version = "0.4.20", default-features = false }
 scale-info = { version = "2.9.0", default-features = false }
 
 # local deps
-encointer-ceremonies = { package = "pallet-encointer-ceremonies", path = "../ceremonies", default-features = false, version = "1.2.0" }
-encointer-communities = { package = "pallet-encointer-communities", path = "../communities", default-features = false, version = "1.3.0" }
-encointer-primitives = { path = "../primitives", default-features = false, version = "1.3.0" }
-encointer-scheduler = { package = "pallet-encointer-scheduler", path = "../scheduler", default-features = false, version = "1.1.0" }
+encointer-ceremonies = { package = "pallet-encointer-ceremonies", path = "../ceremonies", default-features = false, version = "2.0.0" }
+encointer-communities = { package = "pallet-encointer-communities", path = "../communities", default-features = false, version = "2.0.0" }
+encointer-primitives = { path = "../primitives", default-features = false, version = "2.0.0" }
+encointer-scheduler = { package = "pallet-encointer-scheduler", path = "../scheduler", default-features = false, version = "2.0.0" }
 
 # substrate deps
 frame-support = { default-features = false, version = "24.0.0" }

--- a/democracy/Cargo.toml
+++ b/democracy/Cargo.toml
@@ -10,9 +10,9 @@ license = "GPL-3.0-or-later"
 publish = false
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-log = { version = "0.4.14", default-features = false }
-scale-info = { version = "2.5.0", default-features = false }
+codec = { package = "parity-scale-codec", version = "3.6.4", default-features = false, features = ["derive"] }
+log = { version = "0.4.20", default-features = false }
+scale-info = { version = "2.9.0", default-features = false }
 
 # local deps
 encointer-ceremonies = { package = "pallet-encointer-ceremonies", path = "../ceremonies", default-features = false, version = "1.2.0" }
@@ -21,16 +21,16 @@ encointer-primitives = { path = "../primitives", default-features = false, versi
 encointer-scheduler = { package = "pallet-encointer-scheduler", path = "../scheduler", default-features = false, version = "1.1.0" }
 
 # substrate deps
-frame-support = { default-features = false, version = "23.0.0" }
-frame-system = { default-features = false, version = "23.0.0" }
-pallet-timestamp = { default-features = false, version = "22.0.0" }
-sp-io = { default-features = false, version = "25.0.0" }
-sp-runtime = { default-features = false, version = "26.0.0" }
-sp-std = { default-features = false, version = "10.0.0" }
+frame-support = { default-features = false, version = "24.0.0" }
+frame-system = { default-features = false, version = "24.0.0" }
+pallet-timestamp = { default-features = false, version = "23.0.0" }
+sp-io = { default-features = false, version = "26.0.0" }
+sp-runtime = { default-features = false, version = "27.0.0" }
+sp-std = { default-features = false, version = "11.0.0" }
 
 # benchmarking
-frame-benchmarking = { default-features = false, optional = true, version = "23.0.0" }
-sp-application-crypto = { default-features = false, optional = true, version = "25.0.0" }
+frame-benchmarking = { default-features = false, optional = true, version = "24.0.0" }
+sp-application-crypto = { default-features = false, optional = true, version = "26.0.0" }
 sp-core = { default-features = false, optional = true, version = "23.0.0" }
 
 [dev-dependencies]
@@ -39,8 +39,8 @@ encointer-ceremonies = { package = "pallet-encointer-ceremonies", path = "../cer
 encointer-balances = { package = "pallet-encointer-balances", path = "../balances", default-features = false }
 itertools = "0.10.3"
 rstest = "0.12.0"
-sp-io = "25.0.0"
-sp-keystore = "0.29.0"
+sp-io = "26.0.0"
+sp-keystore = "0.30.0"
 test-utils = { path = "../test-utils" }
 
 [features]

--- a/faucet/Cargo.toml
+++ b/faucet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-encointer-faucet"
-version = "1.2.0"
+version = "2.0.0"
 authors = ["Encointer Association <info@encointer.org>"]
 edition = "2021"
 description = "Faucet pallet for the Encointer blockchain runtime"
@@ -17,9 +17,9 @@ log = { version = "0.4.20", default-features = false }
 scale-info = { version = "2.9.0", default-features = false }
 
 # local deps
-encointer-communities = { package = "pallet-encointer-communities", path = "../communities", default-features = false, version = "1.3.0" }
-encointer-primitives = { path = "../primitives", default-features = false, features = ["serde_derive"], version = "1.3.0" }
-encointer-reputation-commitments = { package = "pallet-encointer-reputation-commitments", path = "../reputation-commitments", default-features = false, version = "1.2.0" }
+encointer-communities = { package = "pallet-encointer-communities", path = "../communities", default-features = false, version = "2.0.0" }
+encointer-primitives = { path = "../primitives", default-features = false, features = ["serde_derive"], version = "2.0.0" }
+encointer-reputation-commitments = { package = "pallet-encointer-reputation-commitments", path = "../reputation-commitments", default-features = false, version = "2.0.0" }
 
 # substrate deps
 frame-benchmarking = { default-features = false, optional = true, version = "24.0.0" }

--- a/faucet/Cargo.toml
+++ b/faucet/Cargo.toml
@@ -10,11 +10,11 @@ license = "GPL-3.0-or-later"
 
 [dependencies]
 approx = { version = "0.5.1", optional = true }
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [
+codec = { package = "parity-scale-codec", version = "3.6.4", default-features = false, features = [
     "derive",
 ] }
-log = { version = "0.4.14", default-features = false }
-scale-info = { version = "2.5.0", default-features = false }
+log = { version = "0.4.20", default-features = false }
+scale-info = { version = "2.9.0", default-features = false }
 
 # local deps
 encointer-communities = { package = "pallet-encointer-communities", path = "../communities", default-features = false, version = "1.3.0" }
@@ -22,17 +22,17 @@ encointer-primitives = { path = "../primitives", default-features = false, featu
 encointer-reputation-commitments = { package = "pallet-encointer-reputation-commitments", path = "../reputation-commitments", default-features = false, version = "1.2.0" }
 
 # substrate deps
-frame-benchmarking = { default-features = false, optional = true, version = "23.0.0" }
-frame-support = { default-features = false, version = "23.0.0" }
-frame-system = { default-features = false, version = "23.0.0" }
-pallet-treasury = { default-features = false, version = "22.0.0" }
-sp-core = { default-features = false, version = "23.0.0" }
-sp-runtime = { default-features = false, version = "26.0.0" }
-sp-std = { default-features = false, version = "10.0.0" }
+frame-benchmarking = { default-features = false, optional = true, version = "24.0.0" }
+frame-support = { default-features = false, version = "24.0.0" }
+frame-system = { default-features = false, version = "24.0.0" }
+pallet-treasury = { default-features = false, version = "23.0.0" }
+sp-core = { default-features = false, version = "24.0.0" }
+sp-runtime = { default-features = false, version = "27.0.0" }
+sp-std = { default-features = false, version = "11.0.0" }
 
 [dev-dependencies]
 approx = "0.5.1"
-sp-io = "25.0.0"
+sp-io = "26.0.0"
 test-utils = { path = "../test-utils" }
 
 [features]

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "encointer-primitives"
-version = "1.3.0"
+version = "2.0.0"
 authors = ["Encointer Association <info@encointer.org>"]
 edition = "2021"
 description = "Primitives for the Encointer blockchain runtime"
@@ -26,7 +26,7 @@ serde = { version = "1.0.136", optional = true, default-features = false, featur
 ] }
 
 # local deps
-ep-core = { path = "core", default-features = false, version = "1.2.0" }
+ep-core = { path = "core", default-features = false, version = "2.0.0" }
 
 # substrate deps
 frame-support = { default-features = false, version = "24.0.0" }

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -10,14 +10,14 @@ license = "GPL-3.0-or-later"
 
 [dependencies]
 bs58 = { version = "0.4.0", default-features = false, features = ["alloc"] }
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [
+codec = { package = "parity-scale-codec", version = "3.6.4", default-features = false, features = [
     "derive",
     "max-encoded-len",
 ] }
 crc = "2.1.0"
 geohash = { package = "substrate-geohash", version = "0.13.0" }
-log = { version = "0.4.14", default-features = false }
-scale-info = { version = "2.5.0", default-features = false, features = [
+log = { version = "0.4.20", default-features = false }
+scale-info = { version = "2.9.0", default-features = false, features = [
     "derive",
 ] }
 serde = { version = "1.0.136", optional = true, default-features = false, features = [
@@ -29,11 +29,11 @@ serde = { version = "1.0.136", optional = true, default-features = false, featur
 ep-core = { path = "core", default-features = false, version = "1.2.0" }
 
 # substrate deps
-frame-support = { default-features = false, version = "23.0.0" }
-sp-core = { default-features = false, version = "23.0.0" }
-sp-io = { default-features = false, version = "25.0.0" }
-sp-runtime = { default-features = false, version = "26.0.0" }
-sp-std = { default-features = false, version = "10.0.0" }
+frame-support = { default-features = false, version = "24.0.0" }
+sp-core = { default-features = false, version = "24.0.0" }
+sp-io = { default-features = false, version = "26.0.0" }
+sp-runtime = { default-features = false, version = "27.0.0" }
+sp-std = { default-features = false, version = "11.0.0" }
 
 [dev-dependencies]
 approx = "0.5.1"

--- a/primitives/core/Cargo.toml
+++ b/primitives/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ep-core"
-version = "1.2.1"
+version = "2.0.0"
 authors = ["Encointer Association <info@encointer.org>"]
 edition = "2021"
 description = "Core primitives for the Encointer blockchain runtime"

--- a/primitives/core/Cargo.toml
+++ b/primitives/core/Cargo.toml
@@ -10,7 +10,7 @@ license = "GPL-3.0-or-later"
 
 [dependencies]
 array-bytes = "6.1.0"
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [
+codec = { package = "parity-scale-codec", version = "3.6.4", default-features = false, features = [
     "derive",
 ] }
 fixed = { package = "substrate-fixed", default-features = false, version = "0.5.9" }
@@ -24,9 +24,9 @@ serde = { version = "1.0.136", optional = true, default-features = false, featur
 ] }
 
 sp-arithmetic = { default-features = false, version = "18.0.0" }
-sp-core = { default-features = false, version = "23.0.0" }
-sp-runtime = { default-features = false, version = "26.0.0" }
-sp-std = { default-features = false, version = "10.0.0" }
+sp-core = { default-features = false, version = "24.0.0" }
+sp-runtime = { default-features = false, version = "27.0.0" }
+sp-std = { default-features = false, version = "11.0.0" }
 
 [dev-dependencies]
 serde_json = "1.0.79"

--- a/primitives/core/Cargo.toml
+++ b/primitives/core/Cargo.toml
@@ -23,7 +23,7 @@ serde = { version = "1.0.136", optional = true, default-features = false, featur
     "alloc",
 ] }
 
-sp-arithmetic = { default-features = false, version = "18.0.0" }
+sp-arithmetic = { default-features = false, version = "19.0.0" }
 sp-core = { default-features = false, version = "24.0.0" }
 sp-runtime = { default-features = false, version = "27.0.0" }
 sp-std = { default-features = false, version = "11.0.0" }

--- a/reputation-commitments/Cargo.toml
+++ b/reputation-commitments/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-encointer-reputation-commitments"
-version = "1.2.0"
+version = "2.0.0"
 authors = ["Encointer Association <info@encointer.org>"]
 edition = "2021"
 description = "Reputation commitments pallet for the Encointer blockchain runtime"
@@ -15,10 +15,10 @@ log = { version = "0.4.20", default-features = false }
 scale-info = { version = "2.9.0", default-features = false }
 
 # local deps
-encointer-ceremonies = { package = "pallet-encointer-ceremonies", path = "../ceremonies", default-features = false, version = "1.2.0" }
-encointer-communities = { package = "pallet-encointer-communities", path = "../communities", default-features = false, version = "1.3.0" }
-encointer-primitives = { path = "../primitives", default-features = false, features = ["serde_derive"], version = "1.3.0" }
-encointer-scheduler = { package = "pallet-encointer-scheduler", path = "../scheduler", default-features = false, version = "1.1.0" }
+encointer-ceremonies = { package = "pallet-encointer-ceremonies", path = "../ceremonies", default-features = false, version = "2.0.0" }
+encointer-communities = { package = "pallet-encointer-communities", path = "../communities", default-features = false, version = "2.0.0" }
+encointer-primitives = { path = "../primitives", default-features = false, features = ["serde_derive"], version = "2.0.0" }
+encointer-scheduler = { package = "pallet-encointer-scheduler", path = "../scheduler", default-features = false, version = "2.0.0" }
 
 # substrate deps
 frame-benchmarking = { default-features = false, optional = true, version = "24.0.0" }

--- a/reputation-commitments/Cargo.toml
+++ b/reputation-commitments/Cargo.toml
@@ -10,9 +10,9 @@ license = "GPL-3.0-or-later"
 
 [dependencies]
 approx = { version = "0.5.1", optional = true }
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-log = { version = "0.4.14", default-features = false }
-scale-info = { version = "2.5.0", default-features = false }
+codec = { package = "parity-scale-codec", version = "3.6.4", default-features = false, features = ["derive"] }
+log = { version = "0.4.20", default-features = false }
+scale-info = { version = "2.9.0", default-features = false }
 
 # local deps
 encointer-ceremonies = { package = "pallet-encointer-ceremonies", path = "../ceremonies", default-features = false, version = "1.2.0" }
@@ -21,17 +21,17 @@ encointer-primitives = { path = "../primitives", default-features = false, featu
 encointer-scheduler = { package = "pallet-encointer-scheduler", path = "../scheduler", default-features = false, version = "1.1.0" }
 
 # substrate deps
-frame-benchmarking = { default-features = false, optional = true, version = "23.0.0" }
-frame-support = { default-features = false, version = "23.0.0" }
-frame-system = { default-features = false, version = "23.0.0" }
-pallet-timestamp = { default-features = false, version = "22.0.0" }
-sp-core = { default-features = false, version = "23.0.0" }
-sp-runtime = { default-features = false, version = "26.0.0" }
-sp-std = { default-features = false, version = "10.0.0" }
+frame-benchmarking = { default-features = false, optional = true, version = "24.0.0" }
+frame-support = { default-features = false, version = "24.0.0" }
+frame-system = { default-features = false, version = "24.0.0" }
+pallet-timestamp = { default-features = false, version = "23.0.0" }
+sp-core = { default-features = false, version = "24.0.0" }
+sp-runtime = { default-features = false, version = "27.0.0" }
+sp-std = { default-features = false, version = "11.0.0" }
 
 [dev-dependencies]
 approx = "0.5.1"
-sp-io = "25.0.0"
+sp-io = "26.0.0"
 test-utils = { path = "../test-utils" }
 
 [features]

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "encointer-rpc"
-version = "0.1.0"
+version = "2.0.0"
 authors = ["Encointer Association <info@encointer.org>"]
 edition = "2021"
 description = "RPC for the Encointer blockchain runtime"

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/encointer/pallets"
 license = "GPL-3.0-or-later"
 
 [dependencies]
-jsonrpsee = { version = "0.16.2" }
-jsonrpsee-core = { version = "0.16.2" }
-jsonrpsee-types = { version = "0.16.2" }
+jsonrpsee = { version = "0.16.3" }
+jsonrpsee-core = { version = "0.16.3" }
+jsonrpsee-types = { version = "0.16.3" }
 thiserror = "1.0.31"

--- a/scheduler/Cargo.toml
+++ b/scheduler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-encointer-scheduler"
-version = "1.1.0"
+version = "2.0.0"
 authors = ["Encointer Association <info@encointer.org>"]
 edition = "2021"
 description = "Scheduler pallet for the Encointer blockchain runtime"
@@ -17,7 +17,7 @@ log = { version = "0.4.20", default-features = false }
 scale-info = { version = "2.9.0", default-features = false, features = ["derive"] }
 
 # local deps
-encointer-primitives = { path = "../primitives", default-features = false, features = ["serde_derive"], version = "1.3.0" }
+encointer-primitives = { path = "../primitives", default-features = false, features = ["serde_derive"], version = "2.0.0" }
 
 # substrate deps
 frame-benchmarking = { default-features = false, optional = true, version = "24.0.0" }

--- a/scheduler/Cargo.toml
+++ b/scheduler/Cargo.toml
@@ -9,26 +9,26 @@ repository = "https://github.com/encointer/pallets"
 license = "GPL-3.0-or-later"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [
+codec = { package = "parity-scale-codec", version = "3.6.4", default-features = false, features = [
     "derive",
 ] }
 impl-trait-for-tuples = { version = "0.2.2", default-features = false }
-log = { version = "0.4.14", default-features = false }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+log = { version = "0.4.20", default-features = false }
+scale-info = { version = "2.9.0", default-features = false, features = ["derive"] }
 
 # local deps
 encointer-primitives = { path = "../primitives", default-features = false, features = ["serde_derive"], version = "1.3.0" }
 
 # substrate deps
-frame-benchmarking = { default-features = false, optional = true, version = "23.0.0" }
-frame-support = { default-features = false, version = "23.0.0" }
-frame-system = { default-features = false, version = "23.0.0" }
-pallet-timestamp = { default-features = false, version = "22.0.0" }
-sp-runtime = { default-features = false, version = "26.0.0" }
-sp-std = { default-features = false, version = "10.0.0" }
+frame-benchmarking = { default-features = false, optional = true, version = "24.0.0" }
+frame-support = { default-features = false, version = "24.0.0" }
+frame-system = { default-features = false, version = "24.0.0" }
+pallet-timestamp = { default-features = false, version = "23.0.0" }
+sp-runtime = { default-features = false, version = "27.0.0" }
+sp-std = { default-features = false, version = "11.0.0" }
 
 [dev-dependencies]
-sp-io = "25.0.0"
+sp-io = "26.0.0"
 test-utils = { path = "../test-utils" }
 
 [features]

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test-utils"
-version = "1.2.0"
+version = "2.0.0"
 authors = ["Encointer Association <info@encointer.org>"]
 edition = "2021"
 description = "Test utils for the Encointer blockchain runtime"

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -10,10 +10,10 @@ license = "GPL-3.0-or-later"
 publish = false
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [
+codec = { package = "parity-scale-codec", version = "3.6.4", default-features = false, features = [
     "derive",
 ] }
-log = "0.4.14"
+log = "0.4.20"
 # local deps
 encointer-balances = { package = "pallet-encointer-balances", path = "../balances" }
 encointer-ceremonies = { package = "pallet-encointer-ceremonies", path = "../ceremonies" }
@@ -22,14 +22,14 @@ encointer-primitives = { path = "../primitives" }
 encointer-scheduler = { package = "pallet-encointer-scheduler", path = "../scheduler" }
 
 # substrate deps
-frame-benchmarking = "23.0.0"
-frame-support = "23.0.0"
-frame-system = "23.0.0"
-pallet-balances = "23.0.0"
-pallet-timestamp = "22.0.0"
-sp-core = "23.0.0"
-sp-inherents = "21.0.0"
-sp-io = "25.0.0"
-sp-keyring = "26.0.0"
-sp-runtime = "26.0.0"
-sp-std = "10.0.0"
+frame-benchmarking = "24.0.0"
+frame-support = "24.0.0"
+frame-system = "24.0.0"
+pallet-balances = "24.0.0"
+pallet-timestamp = "23.0.0"
+sp-core = "24.0.0"
+sp-inherents = "22.0.0"
+sp-io = "26.0.0"
+sp-keyring = "27.0.0"
+sp-runtime = "27.0.0"
+sp-std = "11.0.0"

--- a/vouches/Cargo.toml
+++ b/vouches/Cargo.toml
@@ -11,25 +11,25 @@ publish = false
 
 [dependencies]
 approx = { version = "0.5.1", optional = true }
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-log = { version = "0.4.14", default-features = false }
-scale-info = { version = "2.5.0", default-features = false }
+codec = { package = "parity-scale-codec", version = "3.6.4", default-features = false, features = ["derive"] }
+log = { version = "0.4.20", default-features = false }
+scale-info = { version = "2.9.0", default-features = false }
 
 # local deps
 encointer-primitives = { path = "../primitives", default-features = false, features = ["serde_derive"], version = "1.3.0" }
 
 # substrate deps
-frame-benchmarking = { default-features = false, optional = true, version = "23.0.0" }
-frame-support = { default-features = false, version = "23.0.0" }
-frame-system = { default-features = false, version = "23.0.0" }
-pallet-timestamp = { default-features = false, version = "22.0.0" }
-sp-core = { default-features = false, version = "23.0.0" }
-sp-runtime = { default-features = false, version = "26.0.0" }
-sp-std = { default-features = false, version = "10.0.0" }
+frame-benchmarking = { default-features = false, optional = true, version = "24.0.0" }
+frame-support = { default-features = false, version = "24.0.0" }
+frame-system = { default-features = false, version = "24.0.0" }
+pallet-timestamp = { default-features = false, version = "23.0.0" }
+sp-core = { default-features = false, version = "24.0.0" }
+sp-runtime = { default-features = false, version = "27.0.0" }
+sp-std = { default-features = false, version = "11.0.0" }
 
 [dev-dependencies]
 approx = "0.5.1"
-sp-io = "25.0.0"
+sp-io = "26.0.0"
 test-utils = { path = "../test-utils" }
 
 [features]

--- a/vouches/Cargo.toml
+++ b/vouches/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-encointer-vouches"
-version = "1.2.0"
+version = "2.0.0"
 authors = ["Encointer Association <info@encointer.org>"]
 edition = "2021"
 description = "Vouches pallet for the Encointer blockchain runtime"
@@ -16,7 +16,7 @@ log = { version = "0.4.20", default-features = false }
 scale-info = { version = "2.9.0", default-features = false }
 
 # local deps
-encointer-primitives = { path = "../primitives", default-features = false, features = ["serde_derive"], version = "1.3.0" }
+encointer-primitives = { path = "../primitives", default-features = false, features = ["serde_derive"], version = "2.0.0" }
 
 # substrate deps
 frame-benchmarking = { default-features = false, optional = true, version = "24.0.0" }


### PR DESCRIPTION
bumping all dependencies to polkadot-v1.2.0
bumping crate versions unified to "2.0.0"
* we must prevent that older node builds accidentally update to higher polkadot dependencies. that will make every polkadot update a breaking change and major version bump

published like that with commands in readme