### PR TITLE
Implement sign and signature verification on `ProofOfAttendance`

### DIFF
--- a/ceremonies/src/lib.rs
+++ b/ceremonies/src/lib.rs
@@ -153,9 +153,8 @@ pub mod pallet {
 					) == Reputation::VerifiedUnlinked,
 					Error::<T>::AttendanceUnverifiedOrAlreadyUsed
 				);
-				if Self::verify_attendee_signature(p.clone()).is_err() {
-					return Err(<Error<T>>::BadProofOfAttendanceSignature.into())
-				};
+
+				ensure!(p.verify_signature(), Error::<T>::BadProofOfAttendanceSignature);
 
 				// this reputation must now be burned so it can not be used again
 				<ParticipantReputation<T>>::insert(
@@ -1705,18 +1704,6 @@ impl<T: Config> Pallet<T> {
 		}
 
 		Ok(result)
-	}
-
-	fn verify_attendee_signature(
-		proof: ProofOfAttendance<T::Signature, T::AccountId>,
-	) -> DispatchResult {
-		match proof.attendee_signature.verify(
-			&(proof.prover_public, proof.ceremony_index).encode()[..],
-			&proof.attendee_public,
-		) {
-			true => Ok(()),
-			false => Err(<Error<T>>::BadAttendeeSignature.into()),
-		}
 	}
 
 	pub fn get_meetup_location(

--- a/ceremonies/src/lib.rs
+++ b/ceremonies/src/lib.rs
@@ -156,7 +156,6 @@ pub mod pallet {
 
 				ensure!(p.verify_signature(), Error::<T>::BadProofOfAttendanceSignature);
 
-
 				// this reputation must now be burned so it can not be used again
 				<ParticipantReputation<T>>::insert(
 					(p.community_identifier, p.ceremony_index),

--- a/ceremonies/src/tests.rs
+++ b/ceremonies/src/tests.rs
@@ -131,14 +131,7 @@ fn prove_attendance(
 	cindex: CeremonyIndexType,
 	attendee: &sr25519::Pair,
 ) -> TestProofOfAttendance {
-	let msg = (prover.clone(), cindex);
-	ProofOfAttendance {
-		prover_public: prover,
-		community_identifier: cid,
-		ceremony_index: cindex,
-		attendee_public: account_id(attendee),
-		attendee_signature: Signature::from(attendee.sign(&msg.encode())),
-	}
+	TestProofOfAttendance::signed(prover, cid, cindex, attendee)
 }
 
 /// Wrapper for EncointerCeremonies::register_participant that reduces boilerplate code.

--- a/primitives/src/ceremonies.rs
+++ b/primitives/src/ceremonies.rs
@@ -235,7 +235,7 @@ where
 	pub fn verify_signature(&self) -> bool {
 		self.attendee_signature.verify(
 			&(self.prover_public.clone(), self.ceremony_index).encode()[..],
-			&self.attendee_public.clone().into(),
+			&self.attendee_public,
 		)
 	}
 

--- a/primitives/src/ceremonies.rs
+++ b/primitives/src/ceremonies.rs
@@ -21,8 +21,8 @@ use crate::communities::{CommunityIdentifier, Location};
 
 use codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
-use sp_core::{Pair, RuntimeDebug, H256};
-use sp_runtime::traits::{BlakeTwo256, Hash, IdentifyAccount, Verify};
+use sp_core::{Pair, RuntimeDebug};
+use sp_runtime::traits::{IdentifyAccount, Verify};
 
 pub use crate::scheduler::CeremonyIndexType;
 

--- a/primitives/src/ceremonies.rs
+++ b/primitives/src/ceremonies.rs
@@ -21,7 +21,7 @@ use crate::communities::{CommunityIdentifier, Location};
 
 use codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
-use sp_core::{RuntimeDebug, H256};
+use sp_core::{Pair, RuntimeDebug, H256};
 use sp_runtime::traits::{BlakeTwo256, Hash, IdentifyAccount, Verify};
 
 pub use crate::scheduler::CeremonyIndexType;
@@ -213,6 +213,8 @@ impl CommunityReputation {
 	}
 }
 
+pub type AccountIdFor<Signature> = <<Signature as Verify>::Signer as IdentifyAccount>::AccountId;
+
 #[derive(
 	Encode, Decode, Copy, Clone, PartialEq, Eq, Default, RuntimeDebug, TypeInfo, MaxEncodedLen,
 )]
@@ -226,17 +228,36 @@ pub struct ProofOfAttendance<Signature, AccountId> {
 	pub attendee_signature: Signature,
 }
 
-impl<Signature, AccountId: Clone + Encode> ProofOfAttendance<Signature, AccountId> {
-	/// get the hash of the proof without the attendee signature,
-	/// as the signature is non-deterministic.
-	pub fn hash(&self) -> H256 {
-		(
-			self.prover_public.clone(),
-			self.ceremony_index,
-			self.community_identifier,
-			self.attendee_public.clone(),
+impl<Signature: Verify> ProofOfAttendance<Signature, AccountIdFor<Signature>>
+where
+	AccountIdFor<Signature>: Clone + Encode,
+{
+	pub fn verify_signature(&self) -> bool {
+		self.attendee_signature.verify(
+			&(self.prover_public.clone(), self.ceremony_index).encode()[..],
+			&self.attendee_public.clone().into(),
 		)
-			.using_encoded(BlakeTwo256::hash)
+	}
+
+	pub fn signed<Signer>(
+		prover_public: AccountIdFor<Signature>,
+		cid: CommunityIdentifier,
+		cindex: CeremonyIndexType,
+		attendee: Signer,
+	) -> Self
+	where
+		Signer: Pair,
+		Signature: From<Signer::Signature>,
+		AccountIdFor<Signature>: From<Signer::Public>,
+	{
+		let msg = (prover_public.clone(), cindex);
+		ProofOfAttendance {
+			prover_public,
+			community_identifier: cid,
+			ceremony_index: cindex,
+			attendee_public: attendee.public().into(),
+			attendee_signature: attendee.sign(&msg.encode()).into(),
+		}
 	}
 }
 
@@ -376,5 +397,19 @@ mod tests {
 		.sign(&alice);
 
 		assert!(claim.verify_signature())
+	}
+
+	#[test]
+	fn proof_of_attendance_signing_works() {
+		let alice = AccountKeyring::Alice.pair();
+
+		let proof = ProofOfAttendance::<Signature, _>::signed(
+			alice.public().into(),
+			Default::default(),
+			1,
+			alice,
+		);
+
+		assert!(proof.verify_signature())
 	}
 }

--- a/primitives/src/ceremonies.rs
+++ b/primitives/src/ceremonies.rs
@@ -243,7 +243,7 @@ where
 		prover_public: AccountIdFor<Signature>,
 		cid: CommunityIdentifier,
 		cindex: CeremonyIndexType,
-		attendee: Signer,
+		attendee: &Signer,
 	) -> Self
 	where
 		Signer: Pair,
@@ -407,7 +407,7 @@ mod tests {
 			alice.public().into(),
 			Default::default(),
 			1,
-			alice,
+			&alice,
 		);
 
 		assert!(proof.verify_signature())


### PR DESCRIPTION
 I just implemented this because I wanted to verify my dart proof of attendances in a simple unit test here. (Hint: dart already correctly signs proof of attendances ;))