### PR TITLE
tolerate noshows without loss of reputation

### DIFF
--- a/ceremonies/src/benchmarking.rs
+++ b/ceremonies/src/benchmarking.rs
@@ -221,7 +221,7 @@ benchmarks! {
 		assert_eq!(ReputableCount::<T>::get((cid, cindex)), 1);
 		assert_eq!(
 			Pallet::<T>::participant_reputation((cid, cindex - 1), zoran_account),
-			Reputation::VerifiedLinked
+			Reputation::VerifiedLinked(cindex)
 		);
 	}
 
@@ -246,7 +246,7 @@ benchmarks! {
 		assert_eq!(NewbieCount::<T>::get((cid, cindex)), 0);
 		assert_eq!(
 			Pallet::<T>::participant_reputation((cid, cindex - 1), zoran_account),
-			Reputation::VerifiedLinked
+			Reputation::VerifiedLinked(cindex)
 		);
 	}
 
@@ -267,7 +267,7 @@ benchmarks! {
 		assert_eq!(ReputableCount::<T>::get((cid, cindex)), 1);
 		assert_eq!(
 			Pallet::<T>::participant_reputation((cid, cindex - 1), &zoran_account),
-			Reputation::VerifiedLinked
+			Reputation::VerifiedLinked(cindex)
 		);
 	}: _(RawOrigin::Signed(zoran_account.clone()), cid, Some((cid, cindex - 1)))
 	verify {

--- a/ceremonies/src/lib.rs
+++ b/ceremonies/src/lib.rs
@@ -150,17 +150,18 @@ pub mod pallet {
 					Self::participant_reputation(
 						(p.community_identifier, p.ceremony_index),
 						&p.attendee_public
-					) == Reputation::VerifiedUnlinked,
+					)
+					.is_verified_and_unlinked_for_cindex(cindex),
 					Error::<T>::AttendanceUnverifiedOrAlreadyUsed
 				);
 
 				ensure!(p.verify_signature(), Error::<T>::BadProofOfAttendanceSignature);
 
-				// this reputation must now be burned so it can not be used again
+				// this reputation must now be flagged so it can not be used again in the same cycle
 				<ParticipantReputation<T>>::insert(
 					(p.community_identifier, p.ceremony_index),
 					&p.attendee_public,
-					Reputation::VerifiedLinked,
+					Reputation::VerifiedLinked(cindex),
 				);
 				// register participant as reputable
 				<ParticipantReputation<T>>::insert(
@@ -253,7 +254,7 @@ pub mod pallet {
 				);
 
 				ensure!(
-					Self::participant_reputation(cc, &sender) == Reputation::VerifiedLinked,
+					Self::participant_reputation(cc, &sender) == Reputation::VerifiedLinked(cindex),
 					Error::<T>::ReputationMustBeLinked
 				);
 

--- a/ceremonies/src/lib.rs
+++ b/ceremonies/src/lib.rs
@@ -70,7 +70,7 @@ pub mod pallet {
 	use frame_support::pallet_prelude::*;
 	use frame_system::pallet_prelude::*;
 
-	const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(2);
 	#[pallet::pallet]
 	#[pallet::storage_version(STORAGE_VERSION)]
 	#[pallet::without_storage_info]

--- a/democracy/src/tests.rs
+++ b/democracy/src/tests.rs
@@ -100,11 +100,11 @@ fn proposal_submission_works() {
 		let alice = alice();
 
 		// invalid
-		EncointerCeremonies::fake_reputation((cid, 2), &alice, Reputation::VerifiedLinked);
+		EncointerCeremonies::fake_reputation((cid, 2), &alice, Reputation::VerifiedLinked(0));
 		// valid
-		EncointerCeremonies::fake_reputation((cid, 3), &alice, Reputation::VerifiedLinked);
-		EncointerCeremonies::fake_reputation((cid, 4), &alice, Reputation::VerifiedLinked);
-		EncointerCeremonies::fake_reputation((cid, 5), &alice, Reputation::VerifiedLinked);
+		EncointerCeremonies::fake_reputation((cid, 3), &alice, Reputation::VerifiedLinked(0));
+		EncointerCeremonies::fake_reputation((cid, 4), &alice, Reputation::VerifiedLinked(0));
+		EncointerCeremonies::fake_reputation((cid, 5), &alice, Reputation::VerifiedLinked(0));
 
 		let proposal_action =
 			ProposalAction::UpdateNominalIncome(cid, NominalIncomeType::from(100u32));
@@ -185,7 +185,7 @@ fn eligible_reputations_works_with_different_reputations() {
 			Ok(1)
 		);
 
-		EncointerCeremonies::fake_reputation((cid2, 3), &alice, Reputation::VerifiedLinked);
+		EncointerCeremonies::fake_reputation((cid2, 3), &alice, Reputation::VerifiedLinked(0));
 		assert_eq!(
 			EncointerDemocracy::validate_and_commit_reputations(
 				1,
@@ -201,7 +201,7 @@ fn eligible_reputations_works_with_different_reputations() {
 		EncointerCeremonies::fake_reputation((cid3, 4), &alice, Reputation::Unverified);
 		EncointerCeremonies::fake_reputation((cid3, 5), &alice, Reputation::UnverifiedReputable);
 		EncointerCeremonies::fake_reputation((cid4, 4), &alice, Reputation::VerifiedUnlinked);
-		EncointerCeremonies::fake_reputation((cid4, 3), &alice, Reputation::VerifiedLinked);
+		EncointerCeremonies::fake_reputation((cid4, 3), &alice, Reputation::VerifiedLinked(0));
 		assert_eq!(
 			EncointerDemocracy::validate_and_commit_reputations(
 				1,
@@ -225,7 +225,7 @@ fn eligible_reputations_works_with_used_reputations() {
 			proposal_action
 		));
 
-		EncointerCeremonies::fake_reputation((cid, 5), &alice, Reputation::VerifiedLinked);
+		EncointerCeremonies::fake_reputation((cid, 5), &alice, Reputation::VerifiedLinked(0));
 
 		// commit reputation
 		EncointerDemocracy::validate_and_commit_reputations(
@@ -235,7 +235,7 @@ fn eligible_reputations_works_with_used_reputations() {
 		)
 		.ok();
 
-		EncointerCeremonies::fake_reputation((cid, 4), &alice, Reputation::VerifiedLinked);
+		EncointerCeremonies::fake_reputation((cid, 4), &alice, Reputation::VerifiedLinked(0));
 
 		assert_eq!(
 			EncointerDemocracy::validate_and_commit_reputations(
@@ -260,7 +260,7 @@ fn eligible_reputations_works_with_inexistent_reputations() {
 			proposal_action
 		));
 
-		EncointerCeremonies::fake_reputation((cid, 4), &alice, Reputation::VerifiedLinked);
+		EncointerCeremonies::fake_reputation((cid, 4), &alice, Reputation::VerifiedLinked(0));
 
 		assert_eq!(
 			EncointerDemocracy::validate_and_commit_reputations(
@@ -287,8 +287,8 @@ fn eligible_reputations_works_with_cids() {
 			proposal_action
 		));
 
-		EncointerCeremonies::fake_reputation((cid, 5), &alice, Reputation::VerifiedLinked);
-		EncointerCeremonies::fake_reputation((cid2, 5), &alice, Reputation::VerifiedLinked);
+		EncointerCeremonies::fake_reputation((cid, 5), &alice, Reputation::VerifiedLinked(0));
+		EncointerCeremonies::fake_reputation((cid2, 5), &alice, Reputation::VerifiedLinked(0));
 
 		assert_eq!(
 			EncointerDemocracy::validate_and_commit_reputations(
@@ -313,9 +313,9 @@ fn eligible_reputations_fails_with_invalid_cindex() {
 			proposal_action
 		));
 
-		EncointerCeremonies::fake_reputation((cid, 1), &alice, Reputation::VerifiedLinked);
-		EncointerCeremonies::fake_reputation((cid, 4), &alice, Reputation::VerifiedLinked);
-		EncointerCeremonies::fake_reputation((cid, 6), &alice, Reputation::VerifiedLinked);
+		EncointerCeremonies::fake_reputation((cid, 1), &alice, Reputation::VerifiedLinked(0));
+		EncointerCeremonies::fake_reputation((cid, 4), &alice, Reputation::VerifiedLinked(0));
+		EncointerCeremonies::fake_reputation((cid, 6), &alice, Reputation::VerifiedLinked(0));
 
 		assert_eq!(
 			EncointerDemocracy::validate_and_commit_reputations(
@@ -339,8 +339,8 @@ fn voting_works() {
 			ProposalAction::SetInactivityTimeout(InactivityTimeoutType::from(100u32));
 
 		EncointerCeremonies::fake_reputation((cid, 3), &alice, Reputation::Unverified);
-		EncointerCeremonies::fake_reputation((cid, 4), &alice, Reputation::VerifiedLinked);
-		EncointerCeremonies::fake_reputation((cid, 5), &alice, Reputation::VerifiedLinked);
+		EncointerCeremonies::fake_reputation((cid, 4), &alice, Reputation::VerifiedLinked(0));
+		EncointerCeremonies::fake_reputation((cid, 5), &alice, Reputation::VerifiedLinked(0));
 
 		assert_err!(
 			EncointerDemocracy::vote(
@@ -369,9 +369,9 @@ fn voting_works() {
 		assert_eq!(tally.ayes, 2);
 
 		EncointerCeremonies::fake_reputation((cid2, 4), &alice, Reputation::Unverified);
-		EncointerCeremonies::fake_reputation((cid2, 5), &alice, Reputation::VerifiedLinked);
-		EncointerCeremonies::fake_reputation((cid, 2), &alice, Reputation::VerifiedLinked);
-		EncointerCeremonies::fake_reputation((cid2, 6), &alice, Reputation::VerifiedLinked);
+		EncointerCeremonies::fake_reputation((cid2, 5), &alice, Reputation::VerifiedLinked(0));
+		EncointerCeremonies::fake_reputation((cid, 2), &alice, Reputation::VerifiedLinked(0));
+		EncointerCeremonies::fake_reputation((cid2, 6), &alice, Reputation::VerifiedLinked(0));
 
 		assert_ok!(EncointerDemocracy::vote(
 			RuntimeOrigin::signed(alice.clone()),
@@ -500,7 +500,7 @@ fn do_update_proposal_state_works() {
 			EncointerCeremonies::fake_reputation(
 				(cid, 5),
 				&account_id(&p),
-				Reputation::VerifiedLinked,
+				Reputation::VerifiedLinked(0),
 			);
 		}
 
@@ -563,9 +563,9 @@ fn update_proposal_state_extrinsic_works() {
 		let alice = alice();
 		let cid = register_test_community::<TestRuntime>(None, 10.0, 10.0);
 
-		EncointerCeremonies::fake_reputation((cid, 3), &alice, Reputation::VerifiedLinked);
-		EncointerCeremonies::fake_reputation((cid, 4), &alice, Reputation::VerifiedLinked);
-		EncointerCeremonies::fake_reputation((cid, 5), &alice, Reputation::VerifiedLinked);
+		EncointerCeremonies::fake_reputation((cid, 3), &alice, Reputation::VerifiedLinked(0));
+		EncointerCeremonies::fake_reputation((cid, 4), &alice, Reputation::VerifiedLinked(0));
+		EncointerCeremonies::fake_reputation((cid, 5), &alice, Reputation::VerifiedLinked(0));
 
 		assert_ok!(EncointerDemocracy::submit_proposal(
 			RuntimeOrigin::signed(alice.clone()),
@@ -591,11 +591,11 @@ fn test_get_electorate_works() {
 		let alice = alice();
 		let bob = bob();
 
-		EncointerCeremonies::fake_reputation((cid, 4), &alice, Reputation::VerifiedLinked);
-		EncointerCeremonies::fake_reputation((cid, 5), &alice, Reputation::VerifiedLinked);
-		EncointerCeremonies::fake_reputation((cid2, 3), &bob, Reputation::VerifiedLinked);
-		EncointerCeremonies::fake_reputation((cid2, 4), &bob, Reputation::VerifiedLinked);
-		EncointerCeremonies::fake_reputation((cid2, 5), &bob, Reputation::VerifiedLinked);
+		EncointerCeremonies::fake_reputation((cid, 4), &alice, Reputation::VerifiedLinked(0));
+		EncointerCeremonies::fake_reputation((cid, 5), &alice, Reputation::VerifiedLinked(0));
+		EncointerCeremonies::fake_reputation((cid2, 3), &bob, Reputation::VerifiedLinked(0));
+		EncointerCeremonies::fake_reputation((cid2, 4), &bob, Reputation::VerifiedLinked(0));
+		EncointerCeremonies::fake_reputation((cid2, 5), &bob, Reputation::VerifiedLinked(0));
 
 		let proposal_action = ProposalAction::SetInactivityTimeout(8);
 		assert_ok!(EncointerDemocracy::submit_proposal(
@@ -627,7 +627,7 @@ fn is_passing_works() {
 			EncointerCeremonies::fake_reputation(
 				(cid, 5),
 				&account_id(&p),
-				Reputation::VerifiedLinked,
+				Reputation::VerifiedLinked(0),
 			);
 		}
 
@@ -703,10 +703,10 @@ fn proposal_happy_flow() {
 		let cid2 = register_test_community::<TestRuntime>(None, 10.0, 10.0);
 		let alice = alice();
 
-		EncointerCeremonies::fake_reputation((cid, 3), &alice, Reputation::VerifiedLinked);
-		EncointerCeremonies::fake_reputation((cid, 4), &alice, Reputation::VerifiedLinked);
-		EncointerCeremonies::fake_reputation((cid, 5), &alice, Reputation::VerifiedLinked);
-		EncointerCeremonies::fake_reputation((cid2, 3), &alice, Reputation::VerifiedLinked);
+		EncointerCeremonies::fake_reputation((cid, 3), &alice, Reputation::VerifiedLinked(0));
+		EncointerCeremonies::fake_reputation((cid, 4), &alice, Reputation::VerifiedLinked(0));
+		EncointerCeremonies::fake_reputation((cid, 5), &alice, Reputation::VerifiedLinked(0));
+		EncointerCeremonies::fake_reputation((cid2, 3), &alice, Reputation::VerifiedLinked(0));
 
 		let proposal_action =
 			ProposalAction::UpdateNominalIncome(cid, NominalIncomeType::from(13037u32));

--- a/primitives/src/ceremonies.rs
+++ b/primitives/src/ceremonies.rs
@@ -59,12 +59,9 @@ pub enum Reputation {
 
 impl Reputation {
 	pub fn is_verified(&self) -> bool {
-		match self {
-			Self::VerifiedLinked(_) => true,
-			Self::VerifiedUnlinked => true,
-			_ => false,
-		}
+		matches!(self, Self::VerifiedLinked(_) | Self::VerifiedUnlinked)
 	}
+
 	pub fn is_verified_and_unlinked_for_cindex(&self, cindex: CeremonyIndexType) -> bool {
 		match self {
 			Self::VerifiedUnlinked => true,

--- a/primitives/src/ceremonies.rs
+++ b/primitives/src/ceremonies.rs
@@ -16,7 +16,7 @@
 
 use crate::communities::{CommunityIdentifier, Location};
 pub use crate::scheduler::CeremonyIndexType;
-use crate::scheduler::{CeremonyIndexShort, CeremonyPhaseType};
+use crate::scheduler::CeremonyPhaseType;
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 #[cfg(feature = "serde_derive")]
@@ -58,10 +58,17 @@ pub enum Reputation {
 }
 
 impl Reputation {
-	pub fn is_verified(self) -> bool {
+	pub fn is_verified(&self) -> bool {
 		match self {
 			Self::VerifiedLinked(_) => true,
 			Self::VerifiedUnlinked => true,
+			_ => false,
+		}
+	}
+	pub fn is_verified_and_unlinked_for_cindex(&self, cindex: CeremonyIndexType) -> bool {
+		match self {
+			Self::VerifiedUnlinked => true,
+			Self::VerifiedLinked(c) => *c != cindex,
 			_ => false,
 		}
 	}

--- a/primitives/src/scheduler.rs
+++ b/primitives/src/scheduler.rs
@@ -22,6 +22,17 @@ use serde::{Deserialize, Serialize};
 
 pub type CeremonyIndexType = u32;
 
+/// a very short type for ceremony index which can be wrapped in an enum variant
+#[derive(Default, Encode, Decode, Copy, Clone, PartialEq, Eq, Debug, TypeInfo, MaxEncodedLen)]
+#[cfg_attr(feature = "serde_derive", derive(Serialize, Deserialize))]
+pub struct CeremonyIndexShort(u8);
+
+impl From<CeremonyIndexType> for CeremonyIndexShort {
+	fn from(cindex: CeremonyIndexType) -> Self {
+		Self((cindex % 256) as u8)
+	}
+}
+
 #[derive(Default, Encode, Decode, Copy, Clone, PartialEq, Eq, Debug, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(feature = "serde_derive", derive(Serialize, Deserialize))]
 pub enum CeremonyPhaseType {

--- a/primitives/src/scheduler.rs
+++ b/primitives/src/scheduler.rs
@@ -22,17 +22,6 @@ use serde::{Deserialize, Serialize};
 
 pub type CeremonyIndexType = u32;
 
-/// a very short type for ceremony index which can be wrapped in an enum variant
-#[derive(Default, Encode, Decode, Copy, Clone, PartialEq, Eq, Debug, TypeInfo, MaxEncodedLen)]
-#[cfg_attr(feature = "serde_derive", derive(Serialize, Deserialize))]
-pub struct CeremonyIndexShort(u8);
-
-impl From<CeremonyIndexType> for CeremonyIndexShort {
-	fn from(cindex: CeremonyIndexType) -> Self {
-		Self((cindex % 256) as u8)
-	}
-}
-
 #[derive(Default, Encode, Decode, Copy, Clone, PartialEq, Eq, Debug, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(feature = "serde_derive", derive(Serialize, Deserialize))]
 pub enum CeremonyPhaseType {


### PR DESCRIPTION
closes #365 

breaking change of reputation enum. needs state migration and adjustments in wallet and rpc

I don't see how the breaking change could be avoided: On the one hand, we want to tolerate noshows (reusing Reputation::VerifiedLinked for a later cycle), on the other hand, we don't want to allow reusing reputation to register several accounts for the same cycles (reusing Reputation::VerifiedLinked for the same cycle)
The only computationally efficient (lazy) way of matching both requirements is by wrapping the cindex in VerifiedLinked variant

_remark:_ I did consider wrapping a `u8` instead of `CeremonyIndexType = u32` and just apply modulo `% 256` to reduce state bloat. As long as ReputationLifetime is < 256, that would still be unambiguous. I decided to go for lower complexity and higher state size

migration strategy:
As we can't ensure a specific CeremonyPhase for the state migration to run, we should set all `VerifiedLinked` to `VerifiedLinked(cindex)` if migration happens during _Registering_ or _Assigning_ and to `VerifiedLinked(cindex + 1)` during _Attesting_. This way, the first cycle will not benefit from noshow tolerance, but we do avoid double-use of reputation
