### PR TITLE
Ab/faucet without treasury

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         os: [ ubuntu-latest ]
         check: [ cargo build --release,
                  cargo test --all --features runtime-benchmarks --features try-runtime,
-                 cargo fmt --all -- --check,
+                 cargo +nightly fmt --all -- --check,
                  cargo clippy -- -D warnings
         ]
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4183,7 +4183,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-faucet"
-version = "6.1.1"
+version = "6.2.0"
 dependencies = [
  "approx",
  "encointer-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4193,7 +4193,6 @@ dependencies = [
  "log",
  "pallet-encointer-communities",
  "pallet-encointer-reputation-commitments",
- "pallet-treasury",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
@@ -4331,26 +4330,6 @@ dependencies = [
  "sp-api",
  "sp-runtime",
  "sp-weights",
-]
-
-[[package]]
-name = "pallet-treasury"
-version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1605eb5083a2cd172544f33c6e59eca2e23ac49f02f13d1562b1b8a409df9c60"
-dependencies = [
- "docify",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "impl-trait-for-tuples",
- "pallet-balances",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core",
- "sp-runtime",
- "sp-std",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4183,7 +4183,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-faucet"
-version = "6.1.0"
+version = "6.1.1"
 dependencies = [
  "approx",
  "encointer-primitives",

--- a/faucet/Cargo.toml
+++ b/faucet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-encointer-faucet"
-version = "6.1.0"
+version = "6.1.1"
 authors = ["Encointer Association <info@encointer.org>"]
 edition = "2021"
 description = "Faucet pallet for the Encointer blockchain runtime"

--- a/faucet/Cargo.toml
+++ b/faucet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-encointer-faucet"
-version = "6.1.1"
+version = "6.2.0"
 authors = ["Encointer Association <info@encointer.org>"]
 edition = "2021"
 description = "Faucet pallet for the Encointer blockchain runtime"

--- a/faucet/Cargo.toml
+++ b/faucet/Cargo.toml
@@ -23,7 +23,6 @@ pallet-encointer-reputation-commitments = { workspace = true }
 frame-benchmarking = { workspace = true, optional = true }
 frame-support = { workspace = true }
 frame-system = { workspace = true }
-pallet-treasury = { workspace = true }
 sp-core = { workspace = true }
 sp-runtime = { workspace = true }
 sp-std = { workspace = true }
@@ -43,7 +42,6 @@ std = [
     "log/std",
     "pallet-encointer-communities/std",
     "pallet-encointer-reputation-commitments/std",
-    "pallet-treasury/std",
     "parity-scale-codec/std",
     "scale-info/std",
     "sp-core/std",
@@ -57,7 +55,6 @@ runtime-benchmarks = [
     "frame-system/runtime-benchmarks",
     "pallet-encointer-communities/runtime-benchmarks",
     "pallet-encointer-reputation-commitments/runtime-benchmarks",
-    "pallet-treasury/runtime-benchmarks",
 ]
 try-runtime = [
     "frame-system/try-runtime",

--- a/faucet/src/lib.rs
+++ b/faucet/src/lib.rs
@@ -33,7 +33,10 @@ use frame_system::{self as frame_system, ensure_signed};
 use log::info;
 use parity_scale_codec::Decode;
 use sp_core::H256;
-use sp_runtime::{traits::Hash, SaturatedConversion, Saturating};
+use sp_runtime::{
+	traits::{AccountIdConversion, Hash},
+	SaturatedConversion, Saturating,
+};
 use sp_std::convert::TryInto;
 pub use weights::WeightInfo;
 
@@ -41,6 +44,7 @@ pub use weights::WeightInfo;
 const LOG: &str = "encointer";
 
 pub use pallet::*;
+
 #[cfg(feature = "runtime-benchmarks")]
 mod benchmarking;
 #[cfg(test)]
@@ -71,12 +75,13 @@ pub mod pallet {
 		frame_system::Config
 		+ pallet_encointer_reputation_commitments::Config
 		+ pallet_encointer_communities::Config
-		+ pallet_treasury::Config
 	{
 		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 		type Currency: Currency<Self::AccountId> + NamedReservableCurrency<Self::AccountId>;
 		type ControllerOrigin: EnsureOrigin<Self::RuntimeOrigin>;
 		type WeightInfo: WeightInfo;
+
+		/// The treasury's pallet id, used for deriving its sovereign account ID.
 		#[pallet::constant]
 		type PalletId: Get<PalletId>;
 	}
@@ -89,7 +94,7 @@ pub mod pallet {
 		ReserveIdentifierOf<T>: From<[u8; 8]>,
 	{
 		#[pallet::call_index(0)]
-		#[pallet::weight((<T as Config>::WeightInfo::create_faucet(), DispatchClass::Normal, Pays::Yes))]
+		#[pallet::weight((< T as Config >::WeightInfo::create_faucet(), DispatchClass::Normal, Pays::Yes))]
 		pub fn create_faucet(
 			origin: OriginFor<T>,
 			name: FaucetNameType,
@@ -104,7 +109,7 @@ pub mod pallet {
 			if let Some(wl) = whitelist.clone() {
 				for cid in &wl {
 					if !all_communities.contains(cid) {
-						return Err(<Error<T>>::InvalidCommunityIdentifierInWhitelist.into());
+						return Err(<Error<T>>::InvalidCommunityIdentifierInWhitelist.into())
 					}
 				}
 			}
@@ -123,7 +128,7 @@ pub mod pallet {
 				.expect("32 bytes can always construct an AccountId32");
 
 			if <Faucets<T>>::contains_key(&faucet_account) {
-				return Err(<Error<T>>::FaucetAlreadyExists.into());
+				return Err(<Error<T>>::FaucetAlreadyExists.into())
 			}
 
 			<T as Config>::Currency::reserve_named(
@@ -152,7 +157,7 @@ pub mod pallet {
 			Ok(().into())
 		}
 		#[pallet::call_index(1)]
-		#[pallet::weight((<T as Config>::WeightInfo::drip(), DispatchClass::Normal, Pays::Yes))]
+		#[pallet::weight((< T as Config >::WeightInfo::drip(), DispatchClass::Normal, Pays::Yes))]
 		pub fn drip(
 			origin: OriginFor<T>,
 			faucet_account: T::AccountId,
@@ -165,7 +170,7 @@ pub mod pallet {
 
 			if let Some(wl) = faucet.whitelist {
 				if !wl.contains(&cid) {
-					return Err(<Error<T>>::CommunityNotInWhitelist.into());
+					return Err(<Error<T>>::CommunityNotInWhitelist.into())
 				}
 			}
 
@@ -195,7 +200,7 @@ pub mod pallet {
 		}
 
 		#[pallet::call_index(2)]
-		#[pallet::weight((<T as Config>::WeightInfo::dissolve_faucet(), DispatchClass::Normal, Pays::Yes))]
+		#[pallet::weight((< T as Config >::WeightInfo::dissolve_faucet(), DispatchClass::Normal, Pays::Yes))]
 		pub fn dissolve_faucet(
 			origin: OriginFor<T>,
 			faucet_account: T::AccountId,
@@ -224,7 +229,7 @@ pub mod pallet {
 		}
 
 		#[pallet::call_index(3)]
-		#[pallet::weight((<T as Config>::WeightInfo::close_faucet(), DispatchClass::Normal, Pays::Yes))]
+		#[pallet::weight((< T as Config >::WeightInfo::close_faucet(), DispatchClass::Normal, Pays::Yes))]
 		pub fn close_faucet(
 			origin: OriginFor<T>,
 			faucet_account: T::AccountId,
@@ -234,8 +239,8 @@ pub mod pallet {
 
 			ensure!(from == faucet.creator, <Error<T>>::NotCreator);
 			ensure!(
-				<T as Config>::Currency::free_balance(&faucet_account)
-					< faucet.drip_amount.saturating_mul(2u32.saturated_into()),
+				<T as Config>::Currency::free_balance(&faucet_account) <
+					faucet.drip_amount.saturating_mul(2u32.saturated_into()),
 				<Error<T>>::FaucetNotEmpty
 			);
 
@@ -247,7 +252,7 @@ pub mod pallet {
 			<Faucets<T>>::remove(&faucet_account);
 			<T as Config>::Currency::transfer(
 				&faucet_account,
-				&<pallet_treasury::Pallet<T>>::account_id(),
+				&Self::catch_basin_account_id(),
 				<T as Config>::Currency::free_balance(&faucet_account),
 				AllowDeath,
 			)?;
@@ -283,6 +288,11 @@ pub mod pallet {
 				.expect("[u8; 32] can always be converted to [u8; 8]");
 			reserve_id.into()
 		}
+
+		/// returns the account id where remaining funds of closed faucets go
+		pub fn catch_basin_account_id() -> T::AccountId {
+			T::PalletId::get().into_account_truncating()
+		}
 	}
 
 	#[derive(frame_support::DefaultNoBound)]
@@ -301,7 +311,7 @@ pub mod pallet {
 	}
 
 	#[pallet::event]
-	#[pallet::generate_deposit(pub(super) fn deposit_event)]
+	#[pallet::generate_deposit(pub (super) fn deposit_event)]
 	pub enum Event<T: Config> {
 		/// faucet dripped | facuet account, receiver account, balance
 		Dripped(T::AccountId, T::AccountId, BalanceOf<T>),

--- a/faucet/src/mock.rs
+++ b/faucet/src/mock.rs
@@ -45,97 +45,12 @@ frame_support::construct_runtime!(
 		EncointerCeremonies: pallet_encointer_ceremonies::{Pallet, Call, Storage, Config<T>, Event<T>},
 		EncointerReputationCommitments:pallet_encointer_reputation_commitments::{Pallet, Call, Storage, Event<T>},
 		EncointerCommunities: pallet_encointer_communities::{Pallet, Call, Storage, Event<T>},
-		Treasury: pallet_treasury::{Pallet, Call, Storage, Config<T>, Event<T>},
 	}
 );
-
-thread_local! {
-	pub static PAID: RefCell<BTreeMap<(u128, u32), u64>> = RefCell::new(BTreeMap::new());
-	pub static STATUS: RefCell<BTreeMap<u64, PaymentStatus>> = RefCell::new(BTreeMap::new());
-	pub static LAST_ID: RefCell<u64> = RefCell::new(0u64);
-}
-
-/// set status for a given payment id
-#[cfg(feature = "runtime-benchmarks")]
-fn set_status(id: u64, s: PaymentStatus) {
-	STATUS.with(|m| m.borrow_mut().insert(id, s));
-}
-pub struct TestPay;
-impl Pay for TestPay {
-	type Beneficiary = u128;
-	type Balance = u64;
-	type Id = u64;
-	type AssetKind = u32;
-	type Error = ();
-
-	fn pay(
-		_who: &Self::Beneficiary,
-		_asset_kind: Self::AssetKind,
-		_amount: Self::Balance,
-	) -> Result<Self::Id, Self::Error> {
-		Ok(LAST_ID.with(|lid| {
-			let x = *lid.borrow();
-			lid.replace(x + 1);
-			x
-		}))
-	}
-	fn check_payment(id: Self::Id) -> PaymentStatus {
-		STATUS.with(|s| s.borrow().get(&id).cloned().unwrap_or(PaymentStatus::Unknown))
-	}
-	#[cfg(feature = "runtime-benchmarks")]
-	fn ensure_successful(_: &Self::Beneficiary, _: Self::AssetKind, _: Self::Balance) {}
-	#[cfg(feature = "runtime-benchmarks")]
-	fn ensure_concluded(id: Self::Id) {
-		set_status(id, PaymentStatus::Failure)
-	}
-}
-pub struct MulBy<N>(PhantomData<N>);
-impl<N: Get<u64>> ConversionFromAssetBalance<u64, u32, u64> for MulBy<N> {
-	type Error = ();
-	fn from_asset_balance(balance: u64, _asset_id: u32) -> Result<u64, Self::Error> {
-		return balance.checked_mul(N::get()).ok_or(());
-	}
-	#[cfg(feature = "runtime-benchmarks")]
-	fn ensure_successful(_: u32) {}
-}
-
-parameter_types! {
-	pub const ProposalBond: Permill = Permill::from_percent(5);
-	pub const Burn: Permill = Permill::from_percent(50);
-	pub const TreasuryPalletId: PalletId = PalletId(*b"py/trsry");
-	pub const SpendPayoutPeriod: u64 = 5;
-}
-impl pallet_treasury::Config for TestRuntime {
-	type PalletId = TreasuryPalletId;
-	type Currency = pallet_balances::Pallet<TestRuntime>;
-	type ApproveOrigin = EnsureAlice;
-	type RejectOrigin = EnsureAlice;
-	type RuntimeEvent = RuntimeEvent;
-	type OnSlash = ();
-	type ProposalBond = ProposalBond;
-	type ProposalBondMinimum = ConstU64<1>;
-	type ProposalBondMaximum = ();
-	type SpendPeriod = ConstU64<2>;
-	type Burn = Burn;
-	type BurnDestination = (); // Just gets burned.
-	type WeightInfo = ();
-	type SpendFunds = ();
-	type MaxApprovals = ConstU32<100>;
-	type SpendOrigin = frame_support::traits::NeverEnsureOrigin<u64>;
-	type AssetKind = u32;
-	type Beneficiary = u128;
-	type BeneficiaryLookup = IdentityLookup<Self::Beneficiary>;
-	type Paymaster = TestPay;
-	type BalanceConverter = MulBy<ConstU64<2>>;
-	type PayoutPeriod = SpendPayoutPeriod;
-	#[cfg(feature = "runtime-benchmarks")]
-	type BenchmarkHelper = ();
-}
 
 parameter_types! {
 	pub const FaucetPalletId: PalletId = PalletId(*b"faucetId");
 }
-
 impl dut::Config for TestRuntime {
 	type RuntimeEvent = RuntimeEvent;
 	type ControllerOrigin = EnsureAlice;

--- a/faucet/src/mock.rs
+++ b/faucet/src/mock.rs
@@ -18,17 +18,9 @@
 
 use crate as dut;
 use encointer_primitives::balances::BalanceType;
-use frame_support::{
-	pallet_prelude::Get,
-	parameter_types,
-	traits::{
-		tokens::{ConversionFromAssetBalance, Pay, PaymentStatus},
-		ConstU64,
-	},
-	PalletId,
-};
-use sp_runtime::{BuildStorage, Permill};
-use std::{cell::RefCell, collections::BTreeMap, marker::PhantomData};
+use frame_support::{parameter_types, PalletId};
+use sp_runtime::BuildStorage;
+
 use test_utils::*;
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<TestRuntime>;

--- a/faucet/src/tests.rs
+++ b/faucet/src/tests.rs
@@ -17,7 +17,7 @@
 //! Unit tests for the encointer_faucet module.
 
 use super::*;
-use crate::mock::{Balances, EncointerFaucet, EncointerReputationCommitments, System, Treasury};
+use crate::mock::{Balances, EncointerFaucet, EncointerReputationCommitments, System};
 use encointer_primitives::{
 	ceremonies::Reputation,
 	faucet::FromStr,
@@ -45,7 +45,7 @@ fn new_faucet(
 	if let mock::RuntimeEvent::EncointerFaucet(Event::FaucetCreated(faucet_account, _)) =
 		last_event::<TestRuntime>().unwrap()
 	{
-		return faucet_account;
+		return faucet_account
 	} else {
 		panic!("Faucet not found");
 	}
@@ -621,7 +621,7 @@ fn close_faucet_works() {
 			assert_eq!(Balances::free_balance(&faucet_account), 0);
 			assert_eq!(Balances::free_balance(&alice), 12);
 			assert_eq!(Balances::free_balance(&bob), 965);
-			assert_eq!(Balances::free_balance(&Treasury::account_id()), 23);
+			assert_eq!(Balances::free_balance(&EncointerFaucet::catch_basin_account_id()), 23);
 			assert_eq!(Balances::reserved_balance(&bob), 0);
 
 			assert_eq!(


### PR DESCRIPTION
remove faucet dependency as the Treasury pallet will be removed from our runtime
This replaces the treasury with a hard-coded account based on PalletId which currently has no spending functionality.

Can later be used to allow council to create a faucet with the collected funds from faucet creators who closed their faucet (i.e. because a community disappeared)

bumping faucet crate to 6.2.0 and released to crates.io