### PR TITLE
[treasury] Harden swap native unit tests

### DIFF
--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -58,7 +58,7 @@ pub type AccountId = <<MultiSignature as Verify>::Signer as IdentifyAccount>::Ac
 pub type Address = sp_runtime::MultiAddress<AccountId, ()>;
 
 pub type BlockNumber = u64;
-pub type Balance = u64;
+pub type Balance = u128;
 
 pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
 
@@ -91,7 +91,7 @@ macro_rules! impl_frame_system {
 			type BlockHashCount = BlockHashCount;
 			type Version = ();
 			type PalletInfo = PalletInfo;
-			type AccountData = pallet_balances::AccountData<u64>;
+			type AccountData = pallet_balances::AccountData<Balance>;
 			type OnNewAccount = ();
 			type OnKilledAccount = ();
 			type SystemWeightInfo = ();
@@ -136,8 +136,8 @@ macro_rules! impl_timestamp {
 parameter_types! {
 	pub const TransferFee: Balance = 0;
 	pub const CreationFee: Balance = 0;
-	pub const TransactionBaseFee: u64 = 0;
-	pub const TransactionByteFee: u64 = 0;
+	pub const TransactionBaseFee: Balance = 0;
+	pub const TransactionByteFee: Balance = 0;
 }
 
 #[macro_export]
@@ -147,7 +147,7 @@ macro_rules! impl_balances {
 			type Balance = Balance;
 			type RuntimeEvent = RuntimeEvent;
 			type DustRemoval = ();
-			type ExistentialDeposit = frame_support::traits::ConstU64<1>;
+			type ExistentialDeposit = frame_support::traits::ConstU128<1>;
 			type AccountStore = System;
 			type WeightInfo = ();
 			type MaxLocks = ();

--- a/treasuries/src/lib.rs
+++ b/treasuries/src/lib.rs
@@ -121,6 +121,9 @@ pub mod pallet {
 			)
 			.checked_mul(rate)
 			.ok_or(Error::<T>::SwapOverflow)?;
+
+			// Useful for debugging in tests. Enable if desired.
+			// println!("Swapping => {cc_amount:?} CC => {desired_native_amount:?}  pKSM");
 			if swap_option.do_burn {
 				<pallet_encointer_balances::Pallet<T>>::burn(cid, &sender, cc_amount)?;
 			} else {

--- a/treasuries/src/tests.rs
+++ b/treasuries/src/tests.rs
@@ -101,7 +101,8 @@ fn swap_native_partial_works(burn: bool, native_allowance: Balance, rate_float: 
 
 		let treasury = EncointerTreasuries::get_community_treasury_account_unchecked(Some(cid));
 		Balances::make_free_balance_be(&treasury, native_allowance * 2);
-		EncointerBalances::issue(cid, &beneficiary, BalanceType::from_num(community_balance)).unwrap();
+		EncointerBalances::issue(cid, &beneficiary, BalanceType::from_num(community_balance))
+			.unwrap();
 
 		assert_ok!(EncointerTreasuries::do_issue_swap_native_option(
 			cid,

--- a/treasuries/src/tests.rs
+++ b/treasuries/src/tests.rs
@@ -74,26 +74,32 @@ fn treasury_getter_works() {
 		)
 	});
 }
-#[rstest(burn, case(false), case(true))]
-fn swap_native_partial_works(burn: bool) {
+#[rstest(
+	burn,
+	native_allowance,
+	rate_float,
+	//case(false, 10_000_000_000_000, 0.1),
+	case(true, 10_000_000_000_000, 0.1),
+	case(false, 110_000_000, 0.000_000_2),
+	case(true, 110_000_000, 0.000_000_2)
+)]
+fn swap_native_partial_works(burn: bool, native_allowance: Balance, rate_float: f64) {
 	new_test_ext().execute_with(|| {
 		System::set_block_number(System::block_number() + 1); // this is needed to assert events
 		let beneficiary = AccountId::from(AccountKeyring::Alice);
-		let native_allowance: BalanceOf<TestRuntime> = 110_000_000;
-		let rate_float = 0.000_000_2;
-		let rate = BalanceType::from_num(rate_float);
+		let rate = Some(BalanceType::from_num(rate_float));
 		let cid = CommunityIdentifier::default();
 		let swap_option: SwapNativeOption<Balance, Moment> = SwapNativeOption {
 			cid,
 			native_allowance,
-			rate: Some(rate),
+			rate,
 			do_burn: burn,
 			valid_from: None,
 			valid_until: None,
 		};
 
 		let treasury = EncointerTreasuries::get_community_treasury_account_unchecked(Some(cid));
-		Balances::make_free_balance_be(&treasury, 500_000_000);
+		Balances::make_free_balance_be(&treasury, native_allowance * 2);
 		EncointerBalances::issue(cid, &beneficiary, BalanceType::from_num(100)).unwrap();
 
 		assert_ok!(EncointerTreasuries::do_issue_swap_native_option(
@@ -103,14 +109,14 @@ fn swap_native_partial_works(burn: bool) {
 		));
 		assert_eq!(EncointerTreasuries::swap_native_options(cid, &beneficiary), Some(swap_option));
 
-		let swap_native_amount = 50_000_000;
+		let swap_native_amount = native_allowance / 10;
 		assert_ok!(EncointerTreasuries::swap_native(
 			RuntimeOrigin::signed(beneficiary.clone()),
 			cid,
 			swap_native_amount
 		));
 
-		assert_eq!(Balances::free_balance(&treasury), 450_000_000);
+		assert_eq!(Balances::free_balance(&treasury), native_allowance * 2 - native_allowance / 10);
 		assert_eq!(Balances::free_balance(&beneficiary), swap_native_amount);
 		assert_abs_diff_eq!(
 			EncointerBalances::balance(cid, &beneficiary).to_num::<f64>(),
@@ -122,7 +128,7 @@ fn swap_native_partial_works(burn: bool) {
 			EncointerTreasuries::swap_native_options(cid, &beneficiary)
 				.unwrap()
 				.native_allowance,
-			60_000_000
+			native_allowance * 9 / 10
 		);
 		assert!(event_deposited::<TestRuntime>(
 			Event::<TestRuntime>::SpentNative {
@@ -137,7 +143,7 @@ fn swap_native_partial_works(burn: bool) {
 				pallet_encointer_balances::Event::<TestRuntime>::Burned(
 					cid,
 					beneficiary.clone(),
-					BalanceType::from_num(swap_native_amount) * rate
+					BalanceType::from_num(swap_native_amount) * rate.unwrap()
 				)
 				.into()
 			));
@@ -147,7 +153,7 @@ fn swap_native_partial_works(burn: bool) {
 					cid,
 					beneficiary.clone(),
 					treasury.clone(),
-					BalanceType::from_num(swap_native_amount) * rate
+					BalanceType::from_num(swap_native_amount) * rate.unwrap()
 				)
 				.into()
 			));

--- a/treasuries/src/tests.rs
+++ b/treasuries/src/tests.rs
@@ -87,13 +87,13 @@ fn swap_native_partial_works(burn: bool, native_allowance: Balance, rate_float: 
 	new_test_ext().execute_with(|| {
 		System::set_block_number(System::block_number() + 1); // this is needed to assert events
 		let beneficiary = AccountId::from(AccountKeyring::Alice);
-		let rate = Some(BalanceType::from_num(rate_float));
+		let rate = BalanceType::from_num(rate_float);
 		let cid = CommunityIdentifier::default();
 		let community_balance = 10_000.0;
 		let swap_option: SwapNativeOption<Balance, Moment> = SwapNativeOption {
 			cid,
 			native_allowance,
-			rate,
+			rate: Some(rate),
 			do_burn: burn,
 			valid_from: None,
 			valid_until: None,
@@ -146,7 +146,7 @@ fn swap_native_partial_works(burn: bool, native_allowance: Balance, rate_float: 
 				pallet_encointer_balances::Event::<TestRuntime>::Burned(
 					cid,
 					beneficiary.clone(),
-					BalanceType::from_num(swap_native_amount) * rate.unwrap()
+					BalanceType::from_num(swap_native_amount) * rate
 				)
 				.into()
 			));
@@ -156,7 +156,7 @@ fn swap_native_partial_works(burn: bool, native_allowance: Balance, rate_float: 
 					cid,
 					beneficiary.clone(),
 					treasury.clone(),
-					BalanceType::from_num(swap_native_amount) * rate.unwrap()
+					BalanceType::from_num(swap_native_amount) * rate
 				)
 				.into()
 			));


### PR DESCRIPTION
It seems that https://github.com/encointer/encointer-wallet-flutter/issues/1773#issuecomment-2765386660 is coming from the app after all, but we harden the unit tests here by:

* Aligning the test types with the actual runtime types
* Add some more test cases with rs test