### PR TITLE
Fix no-std build on stable-202506

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,7 +214,7 @@ dependencies = [
  "ark-std 0.5.0",
  "educe",
  "fnv",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.4",
  "itertools 0.13.0",
  "num-bigint",
  "num-integer",
@@ -345,7 +345,7 @@ dependencies = [
  "ark-std 0.5.0",
  "educe",
  "fnv",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.4",
 ]
 
 [[package]]
@@ -663,12 +663,6 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
@@ -752,7 +746,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94cb07b0da6a73955f8fb85d24c466778e70cda767a568229b104f0264089330"
 dependencies = [
  "byte-tools",
- "crypto-mac 0.7.0",
+ "crypto-mac",
  "digest 0.8.1",
  "opaque-debug 0.2.3",
 ]
@@ -962,6 +956,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link",
 ]
@@ -981,15 +976,14 @@ dependencies = [
 
 [[package]]
 name = "cid"
-version = "0.10.1"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd94671561e36e4e7de75f753f577edafb0e7c05d6e4547229fdf7938fbcd2c3"
+checksum = "3147d8272e8fa0ccd29ce51194dd98f79ddfb8191ba9e3409884e751798acf3a"
 dependencies = [
  "core2",
  "multibase",
- "multihash 0.18.1",
- "serde",
- "unsigned-varint 0.7.2",
+ "multihash 0.19.3",
+ "unsigned-varint 0.8.0",
 ]
 
 [[package]]
@@ -1268,6 +1262,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1332,16 +1341,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-mac"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
-dependencies = [
- "generic-array 0.14.7",
- "subtle 2.6.1",
-]
-
-[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1373,6 +1372,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
  "quote",
  "syn 2.0.101",
 ]
@@ -1594,27 +1628,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6add3b8cff394282be81f3fc1a0605db594ed69890078ca6e2cab1c408bcf04"
 
 [[package]]
-name = "dyn-clonable"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a36efbb9bfd58e1723780aa04b61aba95ace6a05d9ffabfdb0b43672552f0805"
-dependencies = [
- "dyn-clonable-impl",
- "dyn-clone",
-]
-
-[[package]]
-name = "dyn-clonable-impl"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8671d54058979a37a26f3511fbf8d198ba1aa35ffb202c42587d918d77213a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
 name = "dyn-clone"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1721,7 +1734,7 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encointer-balances-tx-payment"
-version = "16.1.0"
+version = "19.1.0"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -1741,7 +1754,7 @@ dependencies = [
 
 [[package]]
 name = "encointer-balances-tx-payment-rpc"
-version = "16.1.0"
+version = "19.1.0"
 dependencies = [
  "encointer-balances-tx-payment-rpc-runtime-api",
  "encointer-primitives",
@@ -1764,7 +1777,7 @@ dependencies = [
 
 [[package]]
 name = "encointer-balances-tx-payment-rpc-runtime-api"
-version = "16.1.0"
+version = "19.1.0"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -1776,7 +1789,7 @@ dependencies = [
 
 [[package]]
 name = "encointer-ceremonies-assignment"
-version = "16.1.0"
+version = "19.1.0"
 dependencies = [
  "encointer-primitives",
  "sp-core",
@@ -1786,7 +1799,7 @@ dependencies = [
 
 [[package]]
 name = "encointer-meetup-validation"
-version = "16.1.0"
+version = "19.1.0"
 dependencies = [
  "encointer-primitives",
  "parity-scale-codec",
@@ -1800,7 +1813,7 @@ dependencies = [
 
 [[package]]
 name = "encointer-primitives"
-version = "16.4.0"
+version = "19.4.0"
 dependencies = [
  "approx",
  "bs58",
@@ -1823,7 +1836,7 @@ dependencies = [
 
 [[package]]
 name = "encointer-rpc"
-version = "16.1.0"
+version = "19.1.0"
 dependencies = [
  "jsonrpsee",
  "jsonrpsee-core",
@@ -1884,7 +1897,7 @@ checksum = "e48c92028aaa870e83d51c64e5d4e0b6981b360c522198c23959f219a4e1b15b"
 
 [[package]]
 name = "ep-core"
-version = "16.0.0"
+version = "19.0.0"
 dependencies = [
  "array-bytes",
  "impl-serde",
@@ -2052,9 +2065,9 @@ checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
 name = "frame-benchmarking"
-version = "40.0.0"
+version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55b0892434d3cc61fab58b2e48b27b12fc162465c5af48fa283ed15bb86dbfb2"
+checksum = "c59e4e543756eeb45603553ed65aac1bddd8b28a016ddea4eed6faec8c32a3b0"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -2077,9 +2090,9 @@ dependencies = [
 
 [[package]]
 name = "frame-metadata"
-version = "20.0.0"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26de808fa6461f2485dc51811aefed108850064994fb4a62b3ac21ffa62ac8df"
+checksum = "d8c26fcb0454397c522c05fdad5380c4e622f8a875638af33bff5a320d1fc965"
 dependencies = [
  "cfg-if",
  "parity-scale-codec",
@@ -2089,9 +2102,9 @@ dependencies = [
 
 [[package]]
 name = "frame-support"
-version = "40.1.0"
+version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6c7c272704856cc88a86aef689a778050e59f89d7ec1e4ffb3a9e8e04e6b10"
+checksum = "00861648586bca196780b311ca1f345752ee5d971fa1a027f3213955bc493434"
 dependencies = [
  "aquamarine",
  "array-bytes",
@@ -2131,9 +2144,9 @@ dependencies = [
 
 [[package]]
 name = "frame-support-procedural"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73bc18090aa96a5e69cd566fb755b5be08964b926864b2101dd900f64a870437"
+checksum = "aeeec31716c2eeecf21535814faf293dfc7120351c249d1f6f4dea0e520c155b"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -2176,9 +2189,9 @@ dependencies = [
 
 [[package]]
 name = "frame-system"
-version = "40.1.0"
+version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfc20d95c35bad22eb8b8d7ef91197a439483458237b176e621d9210f2fbff15"
+checksum = "1ce7df989cefbaab681101774748a1bbbcd23d0cc66e392f8f22d3d3159914db"
 dependencies = [
  "cfg-if",
  "docify",
@@ -2296,7 +2309,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f2f12607f92c69b12ed746fabf9ca4f5c482cba46679c1a75b874ed7c26adb"
 dependencies = [
  "futures-io",
- "rustls 0.23.26",
+ "rustls",
  "rustls-pki-types",
 ]
 
@@ -2343,6 +2356,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
  "byteorder",
+]
+
+[[package]]
+name = "generator"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d18470a76cb7f8ff746cf1f7470914f900252ec36bbc40b569d74b1258446827"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows 0.61.1",
 ]
 
 [[package]]
@@ -2520,9 +2547,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -2575,12 +2602,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "212ab92002354b4819390025006c897e8140934349e8635c9b077f47b4dcbd20"
 
 [[package]]
-name = "hex-literal"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
-
-[[package]]
 name = "hickory-proto"
 version = "0.24.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2606,6 +2627,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "hickory-proto"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna",
+ "ipnet",
+ "once_cell",
+ "rand 0.9.1",
+ "ring 0.17.14",
+ "thiserror 2.0.12",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "hickory-resolver"
 version = "0.24.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2613,7 +2659,7 @@ checksum = "cbb117a1ca520e111743ab2f6688eddee69db4e0ea242545a604dce8a66fd22e"
 dependencies = [
  "cfg-if",
  "futures-util",
- "hickory-proto",
+ "hickory-proto 0.24.4",
  "ipconfig",
  "lru-cache",
  "once_cell",
@@ -2627,22 +2673,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "hickory-resolver"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-proto 0.25.2",
+ "ipconfig",
+ "moka",
+ "once_cell",
+ "parking_lot 0.12.3",
+ "rand 0.9.1",
+ "resolv-conf",
+ "smallvec",
+ "thiserror 2.0.12",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "hkdf"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac 0.12.1",
-]
-
-[[package]]
-name = "hmac"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
-dependencies = [
- "crypto-mac 0.8.0",
- "digest 0.9.0",
+ "hmac",
 ]
 
 [[package]]
@@ -2652,17 +2709,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
-]
-
-[[package]]
-name = "hmac-drbg"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
-dependencies = [
- "digest 0.9.0",
- "generic-array 0.14.7",
- "hmac 0.8.1",
 ]
 
 [[package]]
@@ -2953,6 +2999,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3003,7 +3055,7 @@ dependencies = [
  "rtnetlink",
  "system-configuration",
  "tokio",
- "windows",
+ "windows 0.53.0",
 ]
 
 [[package]]
@@ -3102,7 +3154,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.4",
 ]
 
 [[package]]
@@ -3141,6 +3193,17 @@ dependencies = [
  "hermit-abi 0.3.9",
  "libc",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "io-uring"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
+dependencies = [
+ "bitflags 2.9.0",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -3489,7 +3552,7 @@ checksum = "97f37f30d5c7275db282ecd86e54f29dd2176bd3ac656f06abf43bedb21eb8bd"
 dependencies = [
  "async-trait",
  "futures",
- "hickory-resolver",
+ "hickory-resolver 0.24.4",
  "libp2p-core",
  "libp2p-identity",
  "parking_lot 0.12.3",
@@ -3575,7 +3638,7 @@ checksum = "14b8546b6644032565eb29046b42744aee1e9f261ed99671b2c93fb140dba417"
 dependencies = [
  "data-encoding",
  "futures",
- "hickory-proto",
+ "hickory-proto 0.24.4",
  "if-watch",
  "libp2p-core",
  "libp2p-identity",
@@ -3667,7 +3730,7 @@ dependencies = [
  "quinn",
  "rand 0.8.5",
  "ring 0.17.14",
- "rustls 0.23.26",
+ "rustls",
  "socket2",
  "thiserror 1.0.69",
  "tokio",
@@ -3757,9 +3820,9 @@ dependencies = [
  "futures-rustls",
  "libp2p-core",
  "libp2p-identity",
- "rcgen 0.11.3",
+ "rcgen",
  "ring 0.17.14",
- "rustls 0.23.26",
+ "rustls",
  "rustls-webpki 0.101.7",
  "thiserror 1.0.69",
  "x509-parser 0.16.0",
@@ -3815,7 +3878,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tracing",
  "yamux 0.12.1",
- "yamux 0.13.4",
+ "yamux 0.13.6",
 ]
 
 [[package]]
@@ -3837,14 +3900,12 @@ dependencies = [
  "arrayref",
  "base64 0.22.1",
  "digest 0.9.0",
- "hmac-drbg",
  "libsecp256k1-core",
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
  "rand 0.8.5",
  "serde",
  "sha2 0.9.9",
- "typenum",
 ]
 
 [[package]]
@@ -3938,19 +3999,18 @@ checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "litep2p"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa3aa5628ae2b2283aa01dfa58947f1926aedba0160dd25041e2cd4bc71534c9"
+checksum = "14fb10e63363204b89d91e1292df83322fd9de5d7fa76c3d5c78ddc2f8f3efa9"
 dependencies = [
  "async-trait",
  "bs58",
  "bytes",
- "cid 0.10.1",
+ "cid 0.11.1",
  "ed25519-dalek",
  "futures",
  "futures-timer",
- "hex-literal",
- "hickory-resolver",
+ "hickory-resolver 0.25.2",
  "indexmap 2.9.0",
  "libc",
  "mockall",
@@ -3959,12 +4019,9 @@ dependencies = [
  "network-interface",
  "parking_lot 0.12.3",
  "pin-project",
- "prost 0.12.6",
+ "prost 0.13.5",
  "prost-build",
  "rand 0.8.5",
- "rcgen 0.10.0",
- "ring 0.16.20",
- "rustls 0.20.9",
  "serde",
  "sha2 0.10.8",
  "simple-dns",
@@ -3982,7 +4039,7 @@ dependencies = [
  "url",
  "x25519-dalek",
  "x509-parser 0.17.0",
- "yamux 0.13.4",
+ "yamux 0.13.6",
  "yasna",
  "zeroize",
 ]
@@ -4004,12 +4061,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "lru"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown 0.15.2",
+ "hashbrown 0.15.4",
 ]
 
 [[package]]
@@ -4132,11 +4202,13 @@ dependencies = [
 
 [[package]]
 name = "memory-db"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808b50db46293432a45e63bc15ea51e0ab4c0a1647b8eb114e31a3e698dd6fbe"
+checksum = "7e300c54e3239a86f9c61cc63ab0f03862eb40b1c6e065dc6fd6ceaeff6da93d"
 dependencies = [
+ "foldhash",
  "hash-db",
+ "hashbrown 0.15.4",
 ]
 
 [[package]]
@@ -4229,6 +4301,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "moka"
+version = "0.12.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9321642ca94a4282428e6ea4af8cc2ca4eac48ac7a6a4ea8f33f76d0ce70926"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "loom",
+ "parking_lot 0.12.3",
+ "portable-atomic",
+ "rustc_version",
+ "smallvec",
+ "tagptr",
+ "thiserror 1.0.69",
+ "uuid",
+]
+
+[[package]]
 name = "multiaddr"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4282,23 +4373,6 @@ name = "multihash"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835d6ff01d610179fbce3de1694d007e500bf33a7f29689838941d6bf783ae40"
-dependencies = [
- "blake2b_simd",
- "blake2s_simd",
- "blake3",
- "core2",
- "digest 0.10.7",
- "multihash-derive",
- "sha2 0.10.8",
- "sha3",
- "unsigned-varint 0.7.2",
-]
-
-[[package]]
-name = "multihash"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd8a792c1694c6da4f68db0a9d707c72bd260994da179e6030a5dcee00bb815"
 dependencies = [
  "blake2b_simd",
  "blake2s_simd",
@@ -4436,13 +4510,13 @@ dependencies = [
 
 [[package]]
 name = "network-interface"
-version = "1.1.4"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a43439bf756eed340bdf8feba761e2d50c7d47175d87545cd5cbe4a137c4d1"
+checksum = "862f41f1276e7148fb597fc55ed8666423bebe045199a1298c3515a73ec5cdd9"
 dependencies = [
  "cc",
  "libc",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "winapi",
 ]
 
@@ -4602,6 +4676,10 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "opaque-debug"
@@ -4629,9 +4707,9 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "pallet-asset-tx-payment"
-version = "40.0.0"
+version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "080d8f7ea66322bdb98ce467c47354e44d7f8f847fdeae921083ad792199b449"
+checksum = "59c7579c21a54fd584f3fc2bc374efc1ecf2a6dba2ed6313698f58add9ed66c6"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4640,16 +4718,15 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core",
  "sp-io",
  "sp-runtime",
 ]
 
 [[package]]
 name = "pallet-balances"
-version = "41.1.0"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dcd7bf033312c976e0c044a80b4cd8b88471d7371baae6fea67b3f42eba288b"
+checksum = "8a4d7dbabb4976ebd37e386ed3abba847f4599a026602439f289a8a93b8c9bd5"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -4664,7 +4741,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-balances"
-version = "16.2.0"
+version = "19.2.0"
 dependencies = [
  "approx",
  "encointer-primitives",
@@ -4684,7 +4761,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-bazaar"
-version = "16.1.0"
+version = "19.1.0"
 dependencies = [
  "encointer-primitives",
  "frame-benchmarking",
@@ -4702,7 +4779,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-bazaar-rpc"
-version = "16.1.0"
+version = "19.1.0"
 dependencies = [
  "encointer-primitives",
  "encointer-rpc",
@@ -4721,7 +4798,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-bazaar-rpc-runtime-api"
-version = "16.1.0"
+version = "19.1.0"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -4732,7 +4809,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-ceremonies"
-version = "16.1.0"
+version = "19.1.0"
 dependencies = [
  "approx",
  "encointer-ceremonies-assignment",
@@ -4761,7 +4838,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-ceremonies-rpc"
-version = "16.1.0"
+version = "19.1.0"
 dependencies = [
  "encointer-primitives",
  "encointer-rpc",
@@ -4780,7 +4857,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-ceremonies-rpc-runtime-api"
-version = "16.1.0"
+version = "19.1.0"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -4791,7 +4868,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-communities"
-version = "16.1.0"
+version = "19.1.0"
 dependencies = [
  "approx",
  "encointer-primitives",
@@ -4812,7 +4889,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-communities-rpc"
-version = "16.1.0"
+version = "19.1.0"
 dependencies = [
  "encointer-primitives",
  "encointer-rpc",
@@ -4832,7 +4909,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-communities-rpc-runtime-api"
-version = "16.1.0"
+version = "19.1.0"
 dependencies = [
  "encointer-primitives",
  "parity-scale-codec",
@@ -4842,7 +4919,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-democracy"
-version = "16.4.0"
+version = "19.4.0"
 dependencies = [
  "approx",
  "encointer-primitives",
@@ -4872,7 +4949,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-faucet"
-version = "16.2.0"
+version = "19.2.0"
 dependencies = [
  "approx",
  "encointer-primitives",
@@ -4893,7 +4970,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-reputation-commitments"
-version = "16.1.0"
+version = "19.1.0"
 dependencies = [
  "approx",
  "encointer-primitives",
@@ -4916,7 +4993,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-scheduler"
-version = "16.1.0"
+version = "19.1.0"
 dependencies = [
  "encointer-primitives",
  "frame-benchmarking",
@@ -4935,7 +5012,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-treasuries"
-version = "16.4.1"
+version = "19.4.1"
 dependencies = [
  "approx",
  "encointer-primitives",
@@ -4959,7 +5036,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-treasuries-rpc"
-version = "16.3.0"
+version = "19.3.0"
 dependencies = [
  "encointer-primitives",
  "encointer-rpc",
@@ -4980,7 +5057,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-treasuries-rpc-runtime-api"
-version = "16.3.0"
+version = "19.3.0"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -4992,7 +5069,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-vouches"
-version = "16.1.0"
+version = "19.1.0"
 dependencies = [
  "approx",
  "encointer-primitives",
@@ -5012,9 +5089,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-timestamp"
-version = "39.0.0"
+version = "40.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf2c41020fe6b676345a2f4e224faf128ba26dfc5d4da7938d1a91049dc3203"
+checksum = "64e7580e70c6fdce0694ba5b6ead47e1492fb8326a3629cf1f86ce0f5da7b1f0"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -5024,7 +5101,6 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-inherents",
- "sp-io",
  "sp-runtime",
  "sp-storage",
  "sp-timestamp",
@@ -5032,9 +5108,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-payment"
-version = "40.0.0"
+version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8ebd61b64848e39e5615832c964dc10b63bcebff26a9ec1cb867b4087240a03"
+checksum = "8dfe13f856b4d0386d4a65d1bd18bc359a53e12c6e72c788c190076c9755141f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5042,16 +5118,15 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core",
  "sp-io",
  "sp-runtime",
 ]
 
 [[package]]
 name = "pallet-transaction-payment-rpc"
-version = "43.0.0"
+version = "44.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2d27cee9496b7e9d6ad6ae4ff6daa71d47f98fd2593fd16e79537f5993c1447"
+checksum = "adbefdc8f3f106e2de175ea7ca022452fced8637d9f3553409dba58d4589b94f"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -5066,9 +5141,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
-version = "40.0.0"
+version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bd3329d44b44623b7615cc069b292f2a1fe5c0f4a6625c36cc906f2a43fcc1"
+checksum = "31f2b97df5019ef9d0a1ce46086a12add321231fc871f2d011c8f9255313048a"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -5092,9 +5167,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.7.4"
+version = "3.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9fde3d0718baf5bc92f577d652001da0f8d54cd03a7974e118d04fc888dc23d"
+checksum = "799781ae679d79a948e13d4824a40970bfa500058d245760dd857301059810fa"
 dependencies = [
  "arrayvec",
  "bitvec",
@@ -5109,9 +5184,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.7.4"
+version = "3.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581c837bb6b9541ce7faa9377c20616e4fb7650f6b0f68bc93c827ee504fb7b3"
+checksum = "34b4653168b563151153c9e4c08ebed57fb8262bebfa79711552fa983c623e7a"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
@@ -5214,15 +5289,6 @@ dependencies = [
 
 [[package]]
 name = "pem"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
-dependencies = [
- "base64 0.13.1",
-]
-
-[[package]]
-name = "pem"
 version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38af38e8470ac9dee3ce1bae1af9c1671fffc44ddfd8bd1d0a3445bf349a8ef3"
@@ -5297,9 +5363,9 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "polkavm"
-version = "0.18.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd044ab1d3b11567ab6b98ca71259a992b4034220d5972988a0e96518e5d343d"
+checksum = "f2a01db119bb3a86572c0641ba6e7c9786fbd2ac89c25b43b688c4e353787526"
 dependencies = [
  "libc",
  "log",
@@ -5310,18 +5376,18 @@ dependencies = [
 
 [[package]]
 name = "polkavm-assembler"
-version = "0.18.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaad38dc420bfed79e6f731471c973ce5ff5e47ab403e63cf40358fef8a6368f"
+checksum = "eea6105f3f344abe0bf0151d67b3de6f5d24353f2393355ecf3f5f6e06d7fd0b"
 dependencies = [
  "log",
 ]
 
 [[package]]
 name = "polkavm-common"
-version = "0.18.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31ff33982a807d8567645d4784b9b5d7ab87bcb494f534a57cadd9012688e102"
+checksum = "d91ed9e5af472f729fcf3b3c1cf17508ddbb3505259dd6e2ee0fb5a29e105d22"
 dependencies = [
  "log",
  "polkavm-assembler",
@@ -5329,18 +5395,18 @@ dependencies = [
 
 [[package]]
 name = "polkavm-derive"
-version = "0.18.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2eb703f3b6404c13228402e98a5eae063fd16b8f58afe334073ec105ee4117e"
+checksum = "176144f8661117ea95fa7cf868c9a62d6b143e8a2ebcb7582464c3faade8669a"
 dependencies = [
  "polkavm-derive-impl-macro",
 ]
 
 [[package]]
 name = "polkavm-derive-impl"
-version = "0.18.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f2116a92e6e96220a398930f4c8a6cda1264206f3e2034fc9982bfd93f261f7"
+checksum = "c5a21844afdfcc10c92b9ef288ccb926211af27478d1730fcd55e4aec710179d"
 dependencies = [
  "polkavm-common",
  "proc-macro2",
@@ -5350,9 +5416,9 @@ dependencies = [
 
 [[package]]
 name = "polkavm-derive-impl-macro"
-version = "0.18.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c16669ddc7433e34c1007d31080b80901e3e8e523cb9d4b441c3910cf9294b"
+checksum = "ba0ef0f17ad81413ea1ca5b1b67553aedf5650c88269b673d3ba015c83bc2651"
 dependencies = [
  "polkavm-derive-impl",
  "syn 2.0.101",
@@ -5360,9 +5426,9 @@ dependencies = [
 
 [[package]]
 name = "polkavm-linux-raw"
-version = "0.18.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23eff02c070c70f31878a3d915e88a914ecf3e153741e2fb572dde28cce20fde"
+checksum = "4ec0b13e26ec7234dba213ca17118c70c562809bdce0eefe84f92613d5c8da26"
 
 [[package]]
 name = "polling"
@@ -5401,6 +5467,12 @@ dependencies = [
  "opaque-debug 0.3.1",
  "universal-hash",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "powerfmt"
@@ -5686,7 +5758,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.1",
- "rustls 0.23.26",
+ "rustls",
  "socket2",
  "thiserror 2.0.12",
  "tokio",
@@ -5705,7 +5777,7 @@ dependencies = [
  "rand 0.9.1",
  "ring 0.17.14",
  "rustc-hash 2.1.1",
- "rustls 0.23.26",
+ "rustls",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.12",
@@ -5846,23 +5918,11 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffbe84efe2f38dea12e9bfc1f65377fdf03e53a18cb3b995faedf7934c7e785b"
-dependencies = [
- "pem 1.1.1",
- "ring 0.16.20",
- "time",
- "yasna",
-]
-
-[[package]]
-name = "rcgen"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52c4f3084aa3bc7dfbba4eff4fab2a54db4324965d8872ab933565e6fbd83bc6"
 dependencies = [
- "pem 3.0.5",
+ "pem",
  "ring 0.16.20",
  "time",
  "yasna",
@@ -5988,7 +6048,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac 0.12.1",
+ "hmac",
  "subtle 2.6.1",
 ]
 
@@ -6142,17 +6202,6 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b80e3dec595989ea8510028f30c408a4630db12c9cbb8de34203b89d6577e99"
-dependencies = [
- "ring 0.16.20",
- "sct",
- "webpki",
-]
-
-[[package]]
-name = "rustls"
 version = "0.23.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df51b5869f3a441595eac5e8ff14d486ff285f7b8c0df8770e49c3b56351f0f0"
@@ -6250,9 +6299,9 @@ dependencies = [
 
 [[package]]
 name = "sc-allocator"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c10a9966875fcbde028c73697c6d5faad5f5d24e94b3c949fb1d063c727381d"
+checksum = "60c540da7cc7f00e85905921952da7bf25b9f824a586be2543f7db7bf7f7d4b2"
 dependencies = [
  "log",
  "sp-core",
@@ -6262,9 +6311,9 @@ dependencies = [
 
 [[package]]
 name = "sc-block-builder"
-version = "0.44.0"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6622da4fe938fed2f4e0f127c92cee835dedc325fb4c2358c03912232beee24"
+checksum = "d3f7a3c6e169920a2ae584e05aa2e25dd3e93ca85abcef3d2b7246d92629246b"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6278,9 +6327,9 @@ dependencies = [
 
 [[package]]
 name = "sc-chain-spec"
-version = "42.0.0"
+version = "44.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1ca4ca82a725cc03078839d823ed0f999507ffd0b9a3b24a5f21cf10f24e2e0"
+checksum = "c25df970b58c05e8381a1ead6f5708e3539aefa9212d311866fed64f141214e7"
 dependencies = [
  "array-bytes",
  "docify",
@@ -6317,9 +6366,9 @@ dependencies = [
 
 [[package]]
 name = "sc-client-api"
-version = "39.0.0"
+version = "40.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace1a9f5b53e738a353079a5e5a41e55fa62887cc1d7491b97feca6847b4f88d"
+checksum = "4d27c7d6abc9ef52394ae273b8a4890d6c0e34f3c1c71d30463e91d7764edc64"
 dependencies = [
  "fnv",
  "futures",
@@ -6344,9 +6393,9 @@ dependencies = [
 
 [[package]]
 name = "sc-executor"
-version = "0.42.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b55c745bf88acb34bd606346c7de6cc06f334f627c1ff40380252a6e52ad9354"
+checksum = "dfd7a23eebd1fea90534994440f0ef516cbd8c0ef749e272c6c77fd729bbca71"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -6368,9 +6417,9 @@ dependencies = [
 
 [[package]]
 name = "sc-executor-common"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2f84b9aa7664a9b401afbf423bcd3c1845f5adedf4f6030586808238a222df"
+checksum = "54c15851cbce9a72d7191fdb9a6e8f5919e17aeaf363df9b52653e92ead4fa1e"
 dependencies = [
  "polkavm",
  "sc-allocator",
@@ -6382,9 +6431,9 @@ dependencies = [
 
 [[package]]
 name = "sc-executor-polkavm"
-version = "0.35.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb4929b3457077f9b30ad397a724116f43f252a889ec334ec369f6cdad8f76c"
+checksum = "eefb587eb7d0cbb4a2d763fa799eb7fb60a5d2fd42e625accf455c1e9e49a9d4"
 dependencies = [
  "log",
  "polkavm",
@@ -6394,9 +6443,9 @@ dependencies = [
 
 [[package]]
 name = "sc-executor-wasmtime"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b5ad79b030a1f91ef0f667e58ac35e1c9fa33a6b8a0ec1ae7fe4890322535ac"
+checksum = "a5980897e2915ef027560886a2bb52f49a2cea4a9b9f5c75fead841201d03705"
 dependencies = [
  "anyhow",
  "log",
@@ -6411,9 +6460,9 @@ dependencies = [
 
 [[package]]
 name = "sc-mixnet"
-version = "0.19.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a4fd83a76b5a6a715a2567b762637cbc26c2f1199c8698e0603242069a6ef60"
+checksum = "49cf0f69fe91307e892204e76f692042b96706996e850c2d8f3691ce9948e568"
 dependencies = [
  "array-bytes",
  "arrayvec",
@@ -6440,9 +6489,9 @@ dependencies = [
 
 [[package]]
 name = "sc-network"
-version = "0.49.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4601296dddbaee7cb7eaf5709bbd24a56bba470d8b8cbadaad77496fe70a7706"
+checksum = "484f845242fde087532ca9d163a404fa7b7a1cfd2a1e663004290aa5d293314d"
 dependencies = [
  "array-bytes",
  "async-channel",
@@ -6491,9 +6540,9 @@ dependencies = [
 
 [[package]]
 name = "sc-network-common"
-version = "0.48.0"
+version = "0.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a5fc004d848bf6c1dc3cc433a0d5166dc7735ec7eb17023eff046c948c174d"
+checksum = "97294d7dfb8e176383dc75c3ca791321cc6b64d33dc0034ececaf74908ea658d"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -6502,9 +6551,9 @@ dependencies = [
 
 [[package]]
 name = "sc-network-types"
-version = "0.15.3"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff910b7a20f14b1a77b2616de21d509cf51ce1a006e30b2d1f293a8fae72555"
+checksum = "441af5d0adf306ff745ccf23c7426ec2edf24f6fee678fb63994e1f8d2fcc890"
 dependencies = [
  "bs58",
  "bytes",
@@ -6516,15 +6565,17 @@ dependencies = [
  "multiaddr 0.18.2",
  "multihash 0.19.3",
  "rand 0.8.5",
+ "serde",
+ "serde_with",
  "thiserror 1.0.69",
  "zeroize",
 ]
 
 [[package]]
 name = "sc-rpc"
-version = "44.0.0"
+version = "46.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf313ac99a06ececd9576909c5fc688a6e22c60997fa1b8a58035f4ff1e861bf"
+checksum = "258624592c44a14129815f4d4d7207a2f917b0217558a333ebb124a6de497999"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -6555,9 +6606,9 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc-api"
-version = "0.48.0"
+version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed810a156f70cf5f7ab8fb5d9cf818999a72821c570aba4f4699aa4eea59e01"
+checksum = "ebfebc8edeb4b0b10e9548843b31fd5774911ef9c51216ac8aca01bfe1f3000a"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -6576,9 +6627,9 @@ dependencies = [
 
 [[package]]
 name = "sc-telemetry"
-version = "28.1.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d751fd77c6a8d1a5bca8cb5df9d9c57f77b4b15e84eab07925b0f76ddee3e74"
+checksum = "8f51a1b05cdb6dd8c524678a7b98f9fa149f5f6f2c3951a0519a2fb68cd99e7e"
 dependencies = [
  "chrono",
  "futures",
@@ -6596,9 +6647,9 @@ dependencies = [
 
 [[package]]
 name = "sc-tracing"
-version = "39.0.0"
+version = "40.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97765091d1e29f00bc0ab13149b1922c89dd60b66069e1016a9eb4b289171e3"
+checksum = "d80e2558a0100794d5b4f4d75cb45cae65c061aaf386fd807d7a7e2c272251d2"
 dependencies = [
  "chrono",
  "console",
@@ -6625,9 +6676,9 @@ dependencies = [
 
 [[package]]
 name = "sc-tracing-proc-macro"
-version = "11.0.0"
+version = "11.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "151cdf86d79abf22cf2a240a7ca95041c908dbd96c2ae9a818073042aa210964"
+checksum = "fb090b3a15c077b029619476b682ba8a31f391ee3f0b2c5f3f24366f53f6c538"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
@@ -6637,9 +6688,9 @@ dependencies = [
 
 [[package]]
 name = "sc-transaction-pool-api"
-version = "39.0.0"
+version = "40.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55feca303d4ba839f02261c9a73d40f6b0ac7523882b4008472922b934678729"
+checksum = "c27a9cb54784cf7a1a607d4314f1a4437279ce6d4070eb810f3e4fbfff9b1ba7"
 dependencies = [
  "async-trait",
  "futures",
@@ -6655,9 +6706,9 @@ dependencies = [
 
 [[package]]
 name = "sc-utils"
-version = "18.0.1"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d8879d46892f1378ff633692740d0a5cb13777ee6dafe84d7e9b954b1e6753"
+checksum = "0af88bc006284cb53594f3fd353789d4e7f69bb59db50e8e5bf5ea10847520ba"
 dependencies = [
  "async-channel",
  "futures",
@@ -6734,20 +6785,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring 0.17.14",
- "untrusted 0.9.0",
-]
 
 [[package]]
 name = "sec1"
@@ -6868,6 +6915,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2c45cd61fefa9db6f254525d46e392b852e0e61d9a1fd36e5bd183450a556d5"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de90945e6565ce0d9a25098082ed4ee4002e047cb59892c318d66821e14bb30f"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -7044,9 +7119,9 @@ dependencies = [
 
 [[package]]
 name = "sp-api"
-version = "36.0.1"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "541da427f47dfb97f3dd0556fa3272bdc5dfa0d4c1ad53a22670a9bae4db63d7"
+checksum = "1ee297c1304c6b069784dda4147ef5f478f7aef75b94e0838a38c29de792f1df"
 dependencies = [
  "docify",
  "hash-db",
@@ -7067,9 +7142,9 @@ dependencies = [
 
 [[package]]
 name = "sp-api-proc-macro"
-version = "22.0.0"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36334085c348bb507debd40e604f71194b1fc669eb6fec81aebef08eb3466f6c"
+checksum = "74a14a276fde5d6e5a0668494e3dd42739b346a7ac7b6348c74f9c9142f4474a"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -7082,9 +7157,9 @@ dependencies = [
 
 [[package]]
 name = "sp-application-crypto"
-version = "40.1.0"
+version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba375ab65a76f7413d1bfe48122fd347ce7bd2047e36ecbbd78f12f5adaed121"
+checksum = "28c668f1ce424bc131f40ade33fa4c0bd4dcd2428479e1e291aad66d4b00c74f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -7095,9 +7170,9 @@ dependencies = [
 
 [[package]]
 name = "sp-arithmetic"
-version = "26.1.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9971b30935cea3858664965039dabd80f67aca74cc6cc6dd42ff1ab14547bc53"
+checksum = "2929fd12ac6ca3cfac7f62885866810ba4e9464814dbaa87592b5b5681b29aee"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -7110,9 +7185,9 @@ dependencies = [
 
 [[package]]
 name = "sp-block-builder"
-version = "36.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a165b95a2f03d9c09c3e51ac3f23d27b091543a41cd3b3df1348aa5917d01eca"
+checksum = "893f331ba57c31de7885e5b316e54748489ca9cd70fe45d39bba9134d2a34b80"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -7121,9 +7196,9 @@ dependencies = [
 
 [[package]]
 name = "sp-blockchain"
-version = "39.0.0"
+version = "40.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0afbe184cfe66895497cdfac1ab2927d85294b9c3bcc2c734798994d08b95db6"
+checksum = "849f1cfcf170048d59c8d3d1175feea2a5cd41fe39742660b9ed542f0d1be7b0"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -7141,9 +7216,9 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus"
-version = "0.42.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f5fed2e52d0cbf8ddc39a5bb7211f19a26f15f70a6c8d964ee05fc73b64e6c3"
+checksum = "c165457b72e1a1550eafc98934e25aebafd754e36792c029c79cfa94675cbcd9"
 dependencies = [
  "async-trait",
  "futures",
@@ -7156,9 +7231,9 @@ dependencies = [
 
 [[package]]
 name = "sp-core"
-version = "36.1.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cdbb58c21e6b27f2aadf3ff0c8b20a8ead13b9dfe63f46717fd59334517f3b4"
+checksum = "4e1a46a6b2323401e4489184846a7fb7d89091b42602a2391cd3ef652ede2850"
 dependencies = [
  "ark-vrf",
  "array-bytes",
@@ -7166,7 +7241,7 @@ dependencies = [
  "blake2 0.10.6",
  "bounded-collections",
  "bs58",
- "dyn-clonable",
+ "dyn-clone",
  "ed25519-zebra",
  "futures",
  "hash-db",
@@ -7188,6 +7263,7 @@ dependencies = [
  "secp256k1",
  "secrecy",
  "serde",
+ "sha2 0.10.8",
  "sp-crypto-hashing",
  "sp-debug-derive",
  "sp-externalities",
@@ -7261,9 +7337,9 @@ dependencies = [
 
 [[package]]
 name = "sp-genesis-builder"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efb0d996dfce9afb8879bdfbba9cb9a7d06f29fda38168b91e90419b3b92c42e"
+checksum = "d731c7b601124756432cd9f5b5da55f6bc55b52c7a334b6df340b769d7103383"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -7274,9 +7350,9 @@ dependencies = [
 
 [[package]]
 name = "sp-inherents"
-version = "36.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb09ff07946f3e1ecdd4bfb40b2cceba60188215ceb941b5b07230294d7aee1"
+checksum = "f1371275d805f905c407a9eef8447bc0a3d383dbd9277adba2a6264c6fe7daac"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -7288,9 +7364,9 @@ dependencies = [
 
 [[package]]
 name = "sp-io"
-version = "40.0.0"
+version = "41.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5d93ea3512cf361577719bab161e46eb04d3abd8563e32bdf5df4a42aea0ba"
+checksum = "f3f244e9a2818d21220ceb0915ac73a462814a92d0c354a124a818abdb7f4f66"
 dependencies = [
  "bytes",
  "docify",
@@ -7315,9 +7391,9 @@ dependencies = [
 
 [[package]]
 name = "sp-keyring"
-version = "41.0.0"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c601d506585c0bcee79dbde401251b127af5f04c7373fc3cf7d6a6b7f6b970a3"
+checksum = "629819dfe8d3bfa28f9492bc091c0c7a1500dd84db82495692dac645578ad9b0"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -7326,9 +7402,9 @@ dependencies = [
 
 [[package]]
 name = "sp-keystore"
-version = "0.42.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45f893398a5330e28f219662c7a0afa174fb068d8f82d2a9990016c4b0bc4369"
+checksum = "269d0ee360f6d072f9203485afea35583ac151521a525cc48b2a107fc576c2d9"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -7348,9 +7424,9 @@ dependencies = [
 
 [[package]]
 name = "sp-metadata-ir"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82d1db25e362edbf5531b427d4bdfc2562bec6a031c3eb2a9145c0a0a01a572d"
+checksum = "2319040b39b9614c35c7faaf548172f4d9a3b44b6992bbae534b096d5cdb4f79"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",
@@ -7359,9 +7435,9 @@ dependencies = [
 
 [[package]]
 name = "sp-mixnet"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e65fb51d9ff444789b3c7771a148d7b685ec3c02498792fd0ecae0f1e00218f"
+checksum = "940c798bf2e049985c9191664be88e9115b874d722b5da9b5340170e246830b4"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -7371,9 +7447,9 @@ dependencies = [
 
 [[package]]
 name = "sp-offchain"
-version = "36.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe5ac60e48200d7b7f61681320deaf06bdced47cfd5f1cb4589b533b58fa4da4"
+checksum = "f4b0f649717f1aa2347c42da6f87d9ed7a783392e395401bc4fbff9ced512590"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -7392,9 +7468,9 @@ dependencies = [
 
 [[package]]
 name = "sp-rpc"
-version = "34.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0acde213e9f08065dcc407a934e9ffd5388bef51347326195405efb62c7a0e4a"
+checksum = "e7192c98c5f4cd80466b7c2ea7489cbceef20e8073b09ca60829332bf269a30e"
 dependencies = [
  "rustc-hash 1.1.0",
  "serde",
@@ -7403,9 +7479,9 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime"
-version = "41.1.0"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3864101a28faba3d8eca026e3f56ea20dd1d979ce1bcc20152e86c9d82be52bf"
+checksum = "b25d4d3811410317175ff121b3ff8c8b723504dadf37cd418b5192a5098d11bf"
 dependencies = [
  "binary-merkle-tree",
  "docify",
@@ -7433,9 +7509,9 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime-interface"
-version = "29.0.1"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e99db36a7aff44c335f5d5b36c182a3e0cac61de2fefbe2eeac6af5fb13f63bf"
+checksum = "9fcd9c219da8c85d45d5ae1ce80e73863a872ac27424880322903c6ac893c06e"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -7453,9 +7529,9 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime-interface-proc-macro"
-version = "18.0.0"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0195f32c628fee3ce1dfbbf2e7e52a30ea85f3589da9fe62a8b816d70fc06294"
+checksum = "ca35431af10a450787ebfdcb6d7a91c23fa91eafe73a3f9d37db05c9ab36154b"
 dependencies = [
  "Inflector",
  "expander",
@@ -7467,9 +7543,9 @@ dependencies = [
 
 [[package]]
 name = "sp-session"
-version = "38.1.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4158c5558192b56cf5ba2ea028cbdbf0fc7c65258e5aa7653bdfad6e68ed21"
+checksum = "19e8de27c1f54192a9e9d1d4d2909d9d6ec49129d3a46667a9c7bdc8efdfdcd6"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -7482,9 +7558,9 @@ dependencies = [
 
 [[package]]
 name = "sp-staking"
-version = "38.0.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8f9c0a32836e3c8842b0aec0813077654885d45d83b618210fbb730ea63545"
+checksum = "bca7ccd7d7e478e9f8e933850f025a1c7f409a2b70157d30e5f51675427af022"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -7496,9 +7572,9 @@ dependencies = [
 
 [[package]]
 name = "sp-state-machine"
-version = "0.45.0"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206508475c01ae2e14f171d35d7fc3eaa7278140d7940416591d49a784792ed6"
+checksum = "483422b016ee9ddba949db6d3092961ed58526520f0586df74dc07defd922a58"
 dependencies = [
  "hash-db",
  "log",
@@ -7517,9 +7593,9 @@ dependencies = [
 
 [[package]]
 name = "sp-statement-store"
-version = "20.1.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6633564ef0b4179c3109855b8480673dea40bd0c11a46e89fa7b7fc526e65de"
+checksum = "76d11b0753df3d68f5bb0f4d0d3975788c3a4dd2d0e479e28b7af17b52f15160"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek",
@@ -7561,9 +7637,9 @@ dependencies = [
 
 [[package]]
 name = "sp-timestamp"
-version = "36.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176c77326c15425a15e085261161a9435f9a3c0d4bf61dae6dccf05b957a51c6"
+checksum = "c429c3e009980568b8065dfc1ce0504ca918cfafe2d8763af0d6e0cd438513b7"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -7586,12 +7662,14 @@ dependencies = [
 
 [[package]]
 name = "sp-trie"
-version = "39.1.0"
+version = "40.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a555bf4c42ca89e2e7bf2f11308806dad13cdbd7f8fd60cf2649f12b6ee809bf"
+checksum = "6b2e157c9cf44a1a9d20f3c69322e302db70399bf3f218211387fe009dd4041c"
 dependencies = [
  "ahash",
+ "foldhash",
  "hash-db",
+ "hashbrown 0.15.4",
  "memory-db",
  "nohash-hasher",
  "parity-scale-codec",
@@ -7601,6 +7679,7 @@ dependencies = [
  "schnellru",
  "sp-core",
  "sp-externalities",
+ "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
  "tracing",
  "trie-db",
@@ -7609,9 +7688,9 @@ dependencies = [
 
 [[package]]
 name = "sp-version"
-version = "39.0.0"
+version = "40.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd736a15ff2ea0a67c5a3bbdfd842d88f11f0774d7701a8d8a316f8deba276c5"
+checksum = "98fd599db91c11c32e4df4c85b22b6396f28284889a583db9151ff59599dd1cb"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -7640,9 +7719,9 @@ dependencies = [
 
 [[package]]
 name = "sp-wasm-interface"
-version = "21.0.1"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b066baa6d57951600b14ffe1243f54c47f9c23dd89c262e17ca00ae8dca58be9"
+checksum = "ffdbc579c72fc03263894a0077383f543a093020d75741092511bb05a440ada6"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -7653,9 +7732,9 @@ dependencies = [
 
 [[package]]
 name = "sp-weights"
-version = "31.1.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "515aa194eabac059041df2dbee75b059b99981213ec680e9de85b45b6988346a"
+checksum = "c8a1d448faceb064bb114df31fc45ff86ea2ee8fd17810c4357a578d081f7732"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -7710,6 +7789,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "strum"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7737,7 +7822,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca58ffd742f693dc13d69bdbb2e642ae239e0053f6aab3b104252892f856700a"
 dependencies = [
- "hmac 0.12.1",
+ "hmac",
  "pbkdf2",
  "schnorrkel",
  "sha2 0.10.8",
@@ -7871,6 +7956,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7912,7 +8003,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-utils"
-version = "16.3.0"
+version = "19.3.0"
 dependencies = [
  "encointer-primitives",
  "frame-benchmarking",
@@ -8051,16 +8142,18 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.44.2"
+version = "1.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
+checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio",
  "parking_lot 0.12.3",
  "pin-project-lite",
+ "slab",
  "socket2",
  "tokio-macros",
  "windows-sys 0.52.0",
@@ -8083,7 +8176,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls 0.23.26",
+ "rustls",
  "tokio",
 ]
 
@@ -8107,7 +8200,7 @@ checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.23.26",
+ "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
@@ -8315,7 +8408,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.1",
- "rustls 0.23.26",
+ "rustls",
  "rustls-pki-types",
  "sha1",
  "thiserror 2.0.12",
@@ -8470,6 +8563,17 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "uuid"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
+dependencies = [
+ "getrandom 0.3.2",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "valuable"
@@ -8912,16 +9016,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
-dependencies = [
- "ring 0.17.14",
- "untrusted 0.9.0",
-]
-
-[[package]]
 name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8985,6 +9079,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.61.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5ee8f3d025738cb02bad7868bbb5f8a6327501e870bf51f1b455b0a2454a419"
+dependencies = [
+ "windows-collections",
+ "windows-core 0.61.0",
+ "windows-future",
+ "windows-link",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.0",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9005,6 +9121,16 @@ dependencies = [
  "windows-link",
  "windows-result 0.3.2",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a1d6bbefcb7b60acd19828e1bc965da6fcf18a7e39490c5f8be71e54a19ba32"
+dependencies = [
+ "windows-core 0.61.0",
+ "windows-link",
 ]
 
 [[package]]
@@ -9034,6 +9160,16 @@ name = "windows-link"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.0",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-result"
@@ -9403,16 +9539,16 @@ dependencies = [
 
 [[package]]
 name = "yamux"
-version = "0.13.4"
+version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17610762a1207ee816c6fadc29220904753648aba0a9ed61c7b8336e80a559c4"
+checksum = "2b2dd50a6d6115feb3e5d7d0efd45e8ca364b6c83722c1e9c602f5764e0e9597"
 dependencies = [
  "futures",
  "log",
  "nohash-hasher",
  "parking_lot 0.12.3",
  "pin-project",
- "rand 0.8.5",
+ "rand 0.9.1",
  "static_assertions",
  "web-time",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ members = [
 manual_inspect = { level = "allow", priority = 2 }           # Needs substrate fix in `#[pallet]`
 multiple_bound_locations = { level = "allow", priority = 2 } # Needs substrate fix in `#[benchmark]`
 zero_prefixed_literal = { level = "allow" }                  # Better recognition of fixed-point types
+useless_conversion = { level = "allow", priority = 2 }       # Types may change
 
 [workspace.dependencies]
 # local pin

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,24 +36,24 @@ zero_prefixed_literal = { level = "allow" }                  # Better recognitio
 
 [workspace.dependencies]
 # local pin
-encointer-ceremonies-assignment = { path = "ceremonies/assignment", default-features = false, version = "16.1.0" }
-encointer-meetup-validation = { path = "ceremonies/meetup-validation", default-features = false, version = "16.1.0" }
-encointer-primitives = { path = "primitives", default-features = false, features = ["serde_derive"], version = "16.4.0" }
-encointer-rpc = { path = "rpc", version = "16.1.0" }
-ep-core = { path = "primitives/core", default-features = false, version = "16.0.0" }
-pallet-encointer-balances = { path = "balances", default-features = false, version = "16.2.0" }
-pallet-encointer-ceremonies = { path = "ceremonies", default-features = false, version = "16.1.0" }
-pallet-encointer-communities = { path = "communities", default-features = false, version = "16.1.0" }
-pallet-encointer-reputation-commitments = { path = "reputation-commitments", default-features = false, version = "16.1.0" }
-pallet-encointer-scheduler = { path = "scheduler", default-features = false, version = "16.1.0" }
-pallet-encointer-treasuries = { path = "treasuries", default-features = false, version = "16.4.0" }
+encointer-ceremonies-assignment = { path = "ceremonies/assignment", default-features = false, version = "19.1.0" }
+encointer-meetup-validation = { path = "ceremonies/meetup-validation", default-features = false, version = "19.1.0" }
+encointer-primitives = { path = "primitives", default-features = false, features = ["serde_derive"], version = "19.4.0" }
+encointer-rpc = { path = "rpc", version = "19.1.0" }
+ep-core = { path = "primitives/core", default-features = false, version = "19.0.0" }
+pallet-encointer-balances = { path = "balances", default-features = false, version = "19.2.0" }
+pallet-encointer-ceremonies = { path = "ceremonies", default-features = false, version = "19.1.0" }
+pallet-encointer-communities = { path = "communities", default-features = false, version = "19.1.0" }
+pallet-encointer-reputation-commitments = { path = "reputation-commitments", default-features = false, version = "19.1.0" }
+pallet-encointer-scheduler = { path = "scheduler", default-features = false, version = "19.1.0" }
+pallet-encointer-treasuries = { path = "treasuries", default-features = false, version = "19.4.0" }
 test-utils = { path = "test-utils" }
 # rpc apis
-encointer-balances-tx-payment-rpc-runtime-api = { path = "balances-tx-payment/rpc/runtime-api", version = "16.1.0" }
-pallet-encointer-bazaar-rpc-runtime-api = { path = "bazaar/rpc/runtime-api", version = "16.1.0" }
-pallet-encointer-ceremonies-rpc-runtime-api = { path = "ceremonies/rpc/runtime-api", version = "16.1.0" }
-pallet-encointer-communities-rpc-runtime-api = { path = "communities/rpc/runtime-api", version = "16.1.0" }
-pallet-encointer-treasuries-rpc-runtime-api = { path = "treasuries/rpc/runtime-api", version = "16.3.0" }
+encointer-balances-tx-payment-rpc-runtime-api = { path = "balances-tx-payment/rpc/runtime-api", version = "19.1.0" }
+pallet-encointer-bazaar-rpc-runtime-api = { path = "bazaar/rpc/runtime-api", version = "19.1.0" }
+pallet-encointer-ceremonies-rpc-runtime-api = { path = "ceremonies/rpc/runtime-api", version = "19.1.0" }
+pallet-encointer-communities-rpc-runtime-api = { path = "communities/rpc/runtime-api", version = "19.1.0" }
+pallet-encointer-treasuries-rpc-runtime-api = { path = "treasuries/rpc/runtime-api", version = "19.3.0" }
 
 # various
 array-bytes = "6.1.0"
@@ -71,39 +71,39 @@ serde = { version = "1.0.197", default-features = false, features = ["derive", "
 thiserror = "2.0.11"
 
 # polkadot-sdk [no_std]
-frame-benchmarking = { version = "40.0.0", default-features = false }
-frame-support = { version = "40.1.0", default-features = false }
-frame-system = { version = "40.1.0", default-features = false }
-pallet-asset-tx-payment = { version = "40.0.0", default-features = false }
-pallet-balances = { version = "41.1.0", default-features = false }
-pallet-timestamp = { version = "39.0.0", default-features = false }
-pallet-transaction-payment = { version = "40.0.0", default-features = false }
-sp-api = { version = "36.0.1", default-features = false }
-sp-application-crypto = { version = "40.1.0", default-features = false }
-sp-arithmetic = { version = "26.1.0", default-features = false }
-sp-core = { version = "36.1.0", default-features = false }
-sp-io = { version = "40.0.0", default-features = false }
-sp-runtime = { version = "41.1.0", default-features = false }
+frame-benchmarking = { version = "41.0.0", default-features = false }
+frame-support = { version = "41.0.0", default-features = false }
+frame-system = { version = "41.0.0", default-features = false }
+pallet-asset-tx-payment = { version = "41.0.0", default-features = false }
+pallet-balances = { version = "42.0.0", default-features = false }
+pallet-timestamp = { version = "40.0.0", default-features = false }
+pallet-transaction-payment = { version = "41.0.0", default-features = false }
+sp-api = { version = "37.0.0", default-features = false }
+sp-application-crypto = { version = "41.0.0", default-features = false }
+sp-arithmetic = { version = "27.0.0", default-features = false }
+sp-core = { version = "37.0.0", default-features = false }
+sp-io = { version = "41.0.1", default-features = false }
+sp-runtime = { version = "42.0.0", default-features = false }
 sp-std = { version = "14.0.0", default-features = false }
 
 # rpc stuff [std]
 jsonrpsee = { version = "0.24.7", features = ["client-core", "server", "macros"] }
 jsonrpsee-core = { version = "0.24.7" }
 jsonrpsee-types = { version = "0.24.7" }
-pallet-transaction-payment-rpc = { version = "43.0.0" }
-sc-rpc = "44.0.0"
-sc-rpc-api = "0.48.0"
-sp-blockchain = "39.0.0"
-sp-rpc = "34.0.0"
+pallet-transaction-payment-rpc = { version = "44.0.0" }
+sc-rpc = "46.0.0"
+sc-rpc-api = "0.50.0"
+sp-blockchain = "40.0.0"
+sp-rpc = "35.0.0"
 
 # dev deps
 approx = "0.5.1"
 itertools = "0.11.0"
 rstest = "0.12.0"
 serde_json = "1.0.114"
-sp-inherents = "36.0.0"
-sp-keyring = "41.0.0"
-sp-keystore = "0.42.0"
+sp-inherents = "37.0.0"
+sp-keyring = "42.0.0"
+sp-keystore = "0.43.0"
 
 #[patch.crates-io]
 #substrate-fixed = { path = "../substrate-fixed"}

--- a/README.md
+++ b/README.md
@@ -5,44 +5,54 @@
 All application-specific pallets for [encointer](https://encointer.org)
 
 ## pallet-encointer-ceremonies
+
 a substrate pallet to perform encointer ceremonies
 
 ## pallet-encointer-communities
+
 A substrate pallet for encointer communities and managing their meetup locations
 
 ## pallet-encointer-ceremonies
+
 a substrate pallet to perform encointer ceremonies
 
 ## pallet-encointer-balances
+
 a balances module that supports multiple communities and demurrage
 
 ## pallet-encointer-bazaar
+
 a registry for classifieds from community members, linking to IPFS
 
 ## ~~personhood-oracle & sybil-gate template~~ [Deprecated]
+
 A digital personhood verification oracle with XCM support. See the README.md on the stale demo branch for more info:
 https://github.com/encointer/pallets/tree/demo/xcm-personhood-oracle-and-sybil-gate-template#encointer-pallets
+
 ## Dev Hints
 
 ### Benchmarking
+
 You can automatically update the `WeightInfo` definitions by running the benchmarks in an encointer-node with the
-script in the node's repository: `./scripts/benchmark_runtime.sh` and uncommenting the line with 
+script in the node's repository: `./scripts/benchmark_runtime.sh` and uncommenting the line with
 `frame-weight-template-full-info.hbs` (see the script's documentation).
 
 ### Serializing
-* There is a know issue with serializing u-/i128 in the json-rpc crate, see (https://github.com/paritytech/substrate/issues/4641). 
-This affects us predominantly when serializing fixed point numbers in the custom RPCs. There is a custom serialization
-shim as a workaround for that issue in [ep-core](./primitives/core), which can be used as custom serde attribute like:
+
+* There is a know issue with serializing u-/i128 in the json-rpc crate,
+  see (https://github.com/paritytech/substrate/issues/4641).
+  This affects us predominantly when serializing fixed point numbers in the custom RPCs. There is a custom serialization
+  shim as a workaround for that issue in [ep-core](./primitives/core), which can be used as custom serde attribute like:
 
 ```rust
 #[cfg_attr(feature = "serde_derive", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde_derive", serde(rename_all = "camelCase"))]
 pub struct BalanceEntry<BlockNumber> {
-	/// The balance of the account after last manual adjustment
-	#[cfg_attr(feature = "serde_derive", serde(with = "serialize_fixed"))]
-	pub principal: BalanceType,
-	/// The time (block height) at which the balance was last adjusted
-	pub last_update: BlockNumber,
+    /// The balance of the account after last manual adjustment
+    #[cfg_attr(feature = "serde_derive", serde(with = "serialize_fixed"))]
+    pub principal: BalanceType,
+    /// The time (block height) at which the balance was last adjusted
+    pub last_update: BlockNumber,
 }
 ```
 
@@ -50,13 +60,18 @@ We also apply substrate's standard of serializing with `camelCase`.
 
 ### Versioning
 
-Major version must increase for polkadot-sdk release upgrades as these are always breaking changes. For convenience, all crates in this repos shall have the same major version.
+Major version must increase for polkadot-sdk release upgrades as these are always breaking changes. For convenience, all
+crates in this repos shall have the same major version. Unless there's a reason not to, use PSDK minor version as the
+major version for all crates in this repository.
 
 We bump minor crate versions separately and tag the repository with the highest crate version
 
-motivation: git blame should show on crate directory level if there was a change. This way, browsing the repo on github really shows when a certain pallet or crate has been touched. Even if it's only adjustments for upstream upgrades, just bump crate versions to the newest, which will be tagged globally
+motivation: git blame should show on crate directory level if there was a change. This way, browsing the repo on github
+really shows when a certain pallet or crate has been touched. Even if it's only adjustments for upstream upgrades, just
+bump crate versions to the newest, which will be tagged globally
 
-Pallet repo version does not need to be aligned with neither node or parachain (or runtime) crate versions - although this has been the case in the past.
+Pallet repo version does not need to be aligned with neither node or parachain (or runtime) crate versions - although
+this has been the case in the past.
 
 #### crates.io
 

--- a/balances-tx-payment/Cargo.toml
+++ b/balances-tx-payment/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "encointer-balances-tx-payment"
-version = "16.1.0"
+version = "19.1.0"
 authors = ["Encointer Association <info@encointer.org>"]
 edition = "2021"
 description = "Balances tx payment for the Encointer blockchain runtime"

--- a/balances-tx-payment/rpc/Cargo.toml
+++ b/balances-tx-payment/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "encointer-balances-tx-payment-rpc"
-version = "16.1.0"
+version = "19.1.0"
 authors = ["Encointer Association <info@encointer.org>"]
 edition = "2021"
 description = "Balances tx payment rpc for the Encointer blockchain runtime"

--- a/balances-tx-payment/rpc/runtime-api/Cargo.toml
+++ b/balances-tx-payment/rpc/runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "encointer-balances-tx-payment-rpc-runtime-api"
-version = "16.1.0"
+version = "19.1.0"
 authors = ["Encointer Association <info@encointer.org>"]
 edition = "2021"
 description = "Balances tx payment rpc runtime api for the Encointer blockchain runtime"

--- a/balances/Cargo.toml
+++ b/balances/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-encointer-balances"
-version = "16.2.0"
+version = "19.2.0"
 authors = ["Encointer Association <info@encointer.org>"]
 edition = "2021"
 description = "Balances pallet for the Encointer blockchain runtime"

--- a/balances/src/lib.rs
+++ b/balances/src/lib.rs
@@ -67,6 +67,7 @@ pub mod pallet {
 
 	#[pallet::config]
 	pub trait Config: frame_system::Config {
+        #[allow(deprecated)]
 		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 		/// the default demurrage rate applied to community balances
 		#[pallet::constant]

--- a/balances/src/lib.rs
+++ b/balances/src/lib.rs
@@ -67,7 +67,7 @@ pub mod pallet {
 
 	#[pallet::config]
 	pub trait Config: frame_system::Config {
-        #[allow(deprecated)]
+		#[allow(deprecated)]
 		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 		/// the default demurrage rate applied to community balances
 		#[pallet::constant]

--- a/balances/src/lib.rs
+++ b/balances/src/lib.rs
@@ -109,7 +109,7 @@ pub mod pallet {
 		) -> DispatchResultWithPostInfo {
 			T::CeremonyMaster::ensure_origin(origin)?;
 			<FeeConversionFactor<T>>::put(fee_conversion_factor);
-			info!(target: LOG, "set fee conversion factor to {}", fee_conversion_factor);
+			info!(target: LOG, "set fee conversion factor to {fee_conversion_factor}");
 			Self::deposit_event(Event::FeeConversionFactorUpdated(fee_conversion_factor));
 			Ok(().into())
 		}
@@ -341,7 +341,7 @@ impl<T: Config> Pallet<T> {
 		<Balance<T>>::insert(community_id, who, entry_who);
 
 		Self::deposit_event(Event::Issued(community_id, who.clone(), amount));
-		debug!(target: LOG, "issue {:?} for {:?}", amount, who);
+		debug!(target: LOG, "issue {amount:?} for {who:?}");
 		Ok(())
 	}
 

--- a/bazaar/Cargo.toml
+++ b/bazaar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-encointer-bazaar"
-version = "16.1.0"
+version = "19.1.0"
 authors = ["Encointer Association <info@encointer.org>"]
 edition = "2021"
 description = "Bazaar pallet for the Encointer blockchain runtime"

--- a/bazaar/rpc/Cargo.toml
+++ b/bazaar/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-encointer-bazaar-rpc"
-version = "16.1.0"
+version = "19.1.0"
 authors = ["Encointer Association <info@encointer.org>"]
 edition = "2021"
 description = "Bazaar rpc for the Encointer blockchain runtime"

--- a/bazaar/rpc/runtime-api/Cargo.toml
+++ b/bazaar/rpc/runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-encointer-bazaar-rpc-runtime-api"
-version = "16.1.0"
+version = "19.1.0"
 authors = ["Encointer Association <info@encointer.org>"]
 edition = "2021"
 description = "Bazaar rpc runtime API for the Encointer blockchain runtime"

--- a/bazaar/src/lib.rs
+++ b/bazaar/src/lib.rs
@@ -43,8 +43,8 @@ pub mod pallet {
 
 	#[pallet::config]
 	pub trait Config: frame_system::Config + pallet_encointer_communities::Config {
-        #[allow(deprecated)]
-        type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+		#[allow(deprecated)]
+		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 		type WeightInfo: WeightInfo;
 	}
 

--- a/bazaar/src/lib.rs
+++ b/bazaar/src/lib.rs
@@ -43,7 +43,8 @@ pub mod pallet {
 
 	#[pallet::config]
 	pub trait Config: frame_system::Config + pallet_encointer_communities::Config {
-		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+        #[allow(deprecated)]
+        type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 		type WeightInfo: WeightInfo;
 	}
 

--- a/ceremonies/Cargo.toml
+++ b/ceremonies/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-encointer-ceremonies"
-version = "16.1.0"
+version = "19.1.0"
 authors = ["Encointer Association <info@encointer.org>"]
 edition = "2021"
 description = "Ceremonies pallet for the Encointer blockchain runtime"

--- a/ceremonies/assignment/Cargo.toml
+++ b/ceremonies/assignment/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "encointer-ceremonies-assignment"
-version = "16.1.0"
+version = "19.1.0"
 authors = ["Encointer Association <info@encointer.org>"]
 edition = "2021"
 description = "Ceremonies assignments for the Encointer blockchain runtime"

--- a/ceremonies/meetup-validation/Cargo.toml
+++ b/ceremonies/meetup-validation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "encointer-meetup-validation"
-version = "16.1.0"
+version = "19.1.0"
 authors = ["Encointer Association <info@encointer.org>"]
 edition = "2021"
 description = "Meetup validation for the Encointer blockchain runtime"

--- a/ceremonies/rpc/Cargo.toml
+++ b/ceremonies/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-encointer-ceremonies-rpc"
-version = "16.1.0"
+version = "19.1.0"
 authors = ["Encointer Association <info@encointer.org>"]
 edition = "2021"
 description = "Ceremonies rpc for the Encointer blockchain runtime"

--- a/ceremonies/rpc/runtime-api/Cargo.toml
+++ b/ceremonies/rpc/runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-encointer-ceremonies-rpc-runtime-api"
-version = "16.1.0"
+version = "19.1.0"
 authors = ["Encointer Association <info@encointer.org>"]
 edition = "2021"
 description = "Ceremonies rpc runtime API for the Encointer blockchain runtime"

--- a/ceremonies/rpc/src/lib.rs
+++ b/ceremonies/rpc/src/lib.rs
@@ -91,12 +91,12 @@ where
 	pub fn cache_dirty(&self, key: &[u8]) -> bool {
 		match self.storage.read().get(STORAGE_PREFIX, key) {
 			Some(d) => Decode::decode(&mut d.as_slice()).unwrap_or_else(|e| {
-				log::error!("Cache dirty bit: {:?}", e);
-				log::info!("{:?}: Defaulting to dirty == true", key);
+				log::error!("Cache dirty bit: {e:?}");
+				log::info!("{key:?}: Defaulting to dirty == true");
 				true
 			}),
 			None => {
-				log::warn!("{:?}: Cache dirty bit is none.", key);
+				log::warn!("{key:?}: Cache dirty bit is none.");
 				true
 			},
 		}

--- a/ceremonies/src/lib.rs
+++ b/ceremonies/src/lib.rs
@@ -83,7 +83,8 @@ pub mod pallet {
 		+ pallet_encointer_balances::Config
 		+ pallet_encointer_scheduler::Config
 	{
-		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+        #[allow(deprecated)]
+        type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 
 		type CeremonyMaster: EnsureOrigin<Self::RuntimeOrigin>;
 

--- a/ceremonies/src/lib.rs
+++ b/ceremonies/src/lib.rs
@@ -183,7 +183,7 @@ pub mod pallet {
 			// invalidate reputation cache
 			sp_io::offchain_index::set(&reputation_cache_dirty_key(&sender), &true.encode());
 
-			debug!(target: LOG, "registered participant: {:?} as {:?}", sender, participant_type);
+			debug!(target: LOG, "registered participant: {sender:?} as {participant_type:?}");
 			Self::deposit_event(Event::ParticipantRegistered(cid, participant_type, sender));
 
 			Ok(().into())
@@ -397,7 +397,7 @@ pub mod pallet {
 				Self::register(cid, cindex, &newbie, false)?;
 			}
 
-			debug!(target: LOG, "bootstrapper {:?} endorsed newbie: {:?}", sender, newbie);
+			debug!(target: LOG, "bootstrapper {sender:?} endorsed newbie: {newbie:?}");
 			Self::deposit_event(Event::EndorsedParticipant(cid, sender, newbie));
 
 			Ok(().into())
@@ -463,7 +463,7 @@ pub mod pallet {
 						MeetupValidationError::BallotEmpty => {
 							debug!(
 								target: LOG,
-								"ballot empty for meetup {:?}, cid: {:?}", meetup_index, cid
+								"ballot empty for meetup {meetup_index:?}, cid: {cid:?}"
 							);
 							(
 								Err(<Error<T>>::VotesNotDependable.into()),
@@ -473,9 +473,7 @@ pub mod pallet {
 						MeetupValidationError::NoDependableVote => {
 							debug!(
 								target: LOG,
-								"ballot doesn't reach dependable majority for meetup {:?}, cid: {:?}",
-								meetup_index,
-								cid
+								"ballot doesn't reach dependable majority for meetup {meetup_index:?}, cid: {cid:?}",
 							);
 							(
 								Err(<Error<T>>::VotesNotDependable.into()),
@@ -485,7 +483,7 @@ pub mod pallet {
 						MeetupValidationError::IndexOutOfBounds => {
 							debug!(
 								target: LOG,
-								"index out of bounds for meetup {:?}, cid: {:?}", meetup_index, cid
+								"index out of bounds for meetup {meetup_index:?}, cid: {cid:?}"
 							);
 							(
 								Err(<Error<T>>::MeetupValidationIndexOutOfBounds.into()),
@@ -515,7 +513,7 @@ pub mod pallet {
 			{
 				debug!(
 					target: LOG,
-					"early rewards not possible for meetup {:?}, cid: {:?}", meetup_index, cid
+					"early rewards not possible for meetup {meetup_index:?}, cid: {cid:?}"
 				);
 				return Err(<Error<T>>::EarlyRewardsNotPossible.into());
 			}
@@ -565,8 +563,7 @@ pub mod pallet {
 			<EndorsementTicketsPerBootstrapper<T>>::put(endorsement_tickets_per_bootstrapper);
 			info!(
 				target: LOG,
-				"set endorsement tickets per bootstrapper to {}",
-				endorsement_tickets_per_bootstrapper
+				"set endorsement tickets per bootstrapper to {endorsement_tickets_per_bootstrapper}"
 			);
 			Self::deposit_event(Event::EndorsementTicketsPerBootstrapperUpdated(
 				endorsement_tickets_per_bootstrapper,
@@ -584,7 +581,7 @@ pub mod pallet {
 			<EndorsementTicketsPerReputable<T>>::put(endorsement_tickets_per_reputable);
 			info!(
 				target: LOG,
-				"set endorsement tickets per reputable to {}", endorsement_tickets_per_reputable
+				"set endorsement tickets per reputable to {endorsement_tickets_per_reputable}"
 			);
 			Self::deposit_event(Event::EndorsementTicketsPerReputableUpdated(
 				endorsement_tickets_per_reputable,
@@ -600,7 +597,7 @@ pub mod pallet {
 		) -> DispatchResultWithPostInfo {
 			<T as pallet::Config>::CeremonyMaster::ensure_origin(origin)?;
 			<ReputationLifetime<T>>::put(reputation_lifetime);
-			info!(target: LOG, "set reputation lifetime to {}", reputation_lifetime);
+			info!(target: LOG, "set reputation lifetime to {reputation_lifetime}");
 			Self::deposit_event(Event::ReputationLifetimeUpdated(reputation_lifetime));
 			Ok(().into())
 		}
@@ -624,7 +621,7 @@ pub mod pallet {
 			}
 
 			<MeetupTimeOffset<T>>::put(meetup_time_offset);
-			info!(target: LOG, "set meetup time offset to {} ms", meetup_time_offset);
+			info!(target: LOG, "set meetup time offset to {meetup_time_offset} ms");
 			Self::deposit_event(Event::MeetupTimeOffsetUpdated(meetup_time_offset));
 			Ok(().into())
 		}
@@ -637,7 +634,7 @@ pub mod pallet {
 		) -> DispatchResultWithPostInfo {
 			<T as pallet::Config>::CeremonyMaster::ensure_origin(origin)?;
 			<TimeTolerance<T>>::put(time_tolerance);
-			info!(target: LOG, "set meetup time tolerance to {:?}", time_tolerance);
+			info!(target: LOG, "set meetup time tolerance to {time_tolerance:?}");
 			Self::deposit_event(Event::TimeToleranceUpdated(time_tolerance));
 			Ok(().into())
 		}
@@ -650,7 +647,7 @@ pub mod pallet {
 		) -> DispatchResultWithPostInfo {
 			<T as pallet::Config>::CeremonyMaster::ensure_origin(origin)?;
 			<LocationTolerance<T>>::put(location_tolerance);
-			info!(target: LOG, "set meetup location tolerance to {}", location_tolerance);
+			info!(target: LOG, "set meetup location tolerance to {location_tolerance}");
 			Self::deposit_event(Event::LocationToleranceUpdated(location_tolerance));
 			Ok(().into())
 		}
@@ -1134,7 +1131,7 @@ impl<T: Config> Pallet<T> {
 		inactivity_timeout: InactivityTimeoutType,
 	) -> DispatchResultWithPostInfo {
 		<InactivityTimeout<T>>::put(inactivity_timeout);
-		info!(target: LOG, "set inactivity timeout to {}", inactivity_timeout);
+		info!(target: LOG, "set inactivity timeout to {inactivity_timeout}");
 		Self::deposit_event(Event::InactivityTimeoutUpdated(inactivity_timeout));
 		Ok(().into())
 	}
@@ -1358,7 +1355,7 @@ impl<T: Config> Pallet<T> {
 		let cid = cc.1;
 		let cindex = cc.0;
 
-		info!(target: LOG, "purging ceremony index {} history for {:?}", cindex, cid);
+		info!(target: LOG, "purging ceremony index {cindex} history for {cid:?}");
 
 		<BootstrapperRegistry<T>>::remove_prefix(cc, None);
 		<BootstrapperIndex<T>>::remove_prefix(cc, None);
@@ -1404,7 +1401,7 @@ impl<T: Config> Pallet<T> {
 		for cid in cids.into_iter() {
 			Self::purge_community_ceremony_internal((cid, cindex));
 		}
-		debug!(target: LOG, "purged registry for ceremony {}", cindex);
+		debug!(target: LOG, "purged registry for ceremony {cindex}", );
 	}
 
 	fn generate_meetup_assignment_params(
@@ -1499,9 +1496,7 @@ impl<T: Config> Pallet<T> {
 		let num_registered_newbies = Self::newbie_count(community_ceremony);
 		debug!(
 			target: LOG,
-			"Number of registered bootstrappers {:?}, endorsees {:?}, reputables {:?}, newbies {:?}",
-			num_registered_bootstrappers, num_registered_endorsees, num_registered_reputables,
-			num_registered_newbies
+			"Number of registered bootstrappers {num_registered_bootstrappers:?}, endorsees {num_registered_endorsees:?}, reputables {num_registered_reputables:?}, newbies {num_registered_newbies:?}",
 		);
 
 		let max_num_meetups = min(
@@ -1528,11 +1523,7 @@ impl<T: Config> Pallet<T> {
 		);
 		info!(
 			target: LOG,
-			"Number of assigned bootstrappers {:?}, endorsees {:?}, reputables {:?}, newbies {:?}",
-			num_registered_bootstrappers,
-			num_assigned_endorsees,
-			num_assigned_reputables,
-			num_assigned_newbies
+			"Number of assigned bootstrappers {num_registered_bootstrappers:?}, endorsees {num_assigned_endorsees:?}, reputables {num_assigned_reputables:?}, newbies {num_assigned_newbies:?}",
 		);
 		Ok(AssignmentCount {
 			bootstrappers: num_registered_bootstrappers,
@@ -1596,7 +1587,7 @@ impl<T: Config> Pallet<T> {
 			{
 				error!(
 					target: LOG,
-					"Could not generate meetup assignment params for cid: {:?}. {:?}", cid, e
+					"Could not generate meetup assignment params for cid: {cid:?}. {e:?}"
 				);
 			}
 		}
@@ -1686,7 +1677,7 @@ impl<T: Config> Pallet<T> {
 		if meetup_index > meetup_count || meetup_index < 1 {
 			error!(
 				target: LOG,
-				"Invalid meetup index {}, meetup_count is {}", meetup_index, meetup_count
+				"Invalid meetup index {meetup_index}, meetup_count is {meetup_count}"
 			);
 			return Err(<Error<T>>::InvalidMeetupIndex);
 		}
@@ -1813,7 +1804,7 @@ impl<T: Config> Pallet<T> {
 			let participant = &meetup_participants
 				.get(*i)
 				.ok_or(Error::<T>::MeetupValidationIndexOutOfBounds)?;
-			trace!(target: LOG, "participant merits reward: {:?}", participant);
+			trace!(target: LOG, "participant merits reward: {participant:?}");
 
 			if <pallet_encointer_balances::Pallet<T>>::issue(cid, participant, reward).is_ok() {
 				<ParticipantReputation<T>>::insert(
@@ -1896,13 +1887,13 @@ impl<T: Config> Pallet<T> {
 		let mut verified_attestees = vec![];
 		for attestee in attestations.iter() {
 			if attestee == &participant {
-				warn!(target: LOG, "ignoring attestation for self: {:?}", attestee);
+				warn!(target: LOG, "ignoring attestation for self: {attestee:?}");
 				continue;
 			};
 			if !meetup_participants.contains(attestee) {
 				warn!(
 					target: LOG,
-					"ignoring attestation that isn't a meetup participant: {:?}", attestee
+					"ignoring attestation that isn't a meetup participant: {attestee:?}"
 				);
 				continue;
 			};
@@ -1931,7 +1922,7 @@ impl<T: Config> Pallet<T> {
 		);
 		<AttestationIndex<T>>::insert((cid, cindex), &participant, idx);
 		let verified_count = verified_attestees.len() as u32;
-		debug!(target: LOG, "successfully registered {} attestations", verified_count);
+		debug!(target: LOG, "successfully registered {verified_count} attestations");
 		Self::deposit_event(Event::AttestationsRegistered(
 			*cid,
 			meetup_index,

--- a/ceremonies/src/lib.rs
+++ b/ceremonies/src/lib.rs
@@ -83,8 +83,8 @@ pub mod pallet {
 		+ pallet_encointer_balances::Config
 		+ pallet_encointer_scheduler::Config
 	{
-        #[allow(deprecated)]
-        type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+		#[allow(deprecated)]
+		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 
 		type CeremonyMaster: EnsureOrigin<Self::RuntimeOrigin>;
 

--- a/ceremonies/src/migrations.rs
+++ b/ceremonies/src/migrations.rs
@@ -89,7 +89,7 @@ pub mod v1 {
 				ensure!(count <= T::MaxAttestations::get(), "too many attestations");
 				attestation_count += count;
 			}
-			log::info!(target: TARGET, "{} attestations will be migrated.", attestation_count,);
+			log::info!(target: TARGET, "{attestation_count} attestations will be migrated.");
 
 			Ok((attestation_count).encode())
 		}
@@ -128,7 +128,7 @@ pub mod v1 {
 				"must migrate all attestations"
 			);
 
-			log::info!(target: TARGET, "{} attestations migrated", new_attestation_count);
+			log::info!(target: TARGET, "{new_attestation_count} attestations migrated");
 			Ok(())
 		}
 	}
@@ -146,7 +146,7 @@ pub mod v2 {
 			assert_eq!(StorageVersion::get::<Pallet<T>>(), 1, "can only upgrade from version 1");
 
 			let reputation_count = v1::ParticipantReputation::<T>::iter().count() as u32;
-			log::info!(target: TARGET, "{} reputation entries will be migrated.", reputation_count);
+			log::info!(target: TARGET, "{reputation_count} reputation entries will be migrated.");
 
 			Ok((reputation_count).encode())
 		}
@@ -190,7 +190,7 @@ pub mod v2 {
 
 			assert_eq!(old_reputation_count, new_reputation_count, "must migrate all reputations");
 
-			log::info!(target: TARGET, "{} reputation entries migrated", new_reputation_count);
+			log::info!(target: TARGET, "{new_reputation_count} reputation entries migrated");
 			Ok(())
 		}
 	}

--- a/communities/Cargo.toml
+++ b/communities/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-encointer-communities"
-version = "16.1.0"
+version = "19.1.0"
 authors = ["Encointer Association <info@encointer.org>"]
 edition = "2021"
 description = "Communities pallet for the Encointer blockchain runtime"

--- a/communities/rpc/Cargo.toml
+++ b/communities/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-encointer-communities-rpc"
-version = "16.1.0"
+version = "19.1.0"
 authors = ["Encointer Association <info@encointer.org>"]
 edition = "2021"
 description = "Communities rpc for the Encointer blockchain runtime"

--- a/communities/rpc/runtime-api/Cargo.toml
+++ b/communities/rpc/runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-encointer-communities-rpc-runtime-api"
-version = "16.1.0"
+version = "19.1.0"
 authors = ["Encointer Association <info@encointer.org>"]
 edition = "2021"
 description = "Communities rpc runtime api for the Encointer blockchain runtime"

--- a/communities/rpc/src/lib.rs
+++ b/communities/rpc/src/lib.rs
@@ -83,7 +83,7 @@ where
 	pub fn cache_dirty(&self) -> bool {
 		match self.storage.read().get(STORAGE_PREFIX, CACHE_DIRTY_KEY) {
 			Some(d) => Decode::decode(&mut d.as_slice()).unwrap_or_else(|e| {
-				log::error!("Cache dirty bit: {:?}", e);
+				log::error!("Cache dirty bit: {e:?}");
 				log::info!("Defaulting to dirty == true");
 				true
 			}),
@@ -158,7 +158,7 @@ where
 
 		match self.get_storage(CIDS_KEY)? {
 			Some(cids) => {
-				log::info!("Using cached community list: {:?}", cids);
+				log::info!("Using cached community list: {cids:?}");
 				Ok(cids)
 			},
 			None => Err(Error::OffchainStorageNotFound(format!("{CIDS_KEY:?}")).into()),
@@ -201,5 +201,5 @@ where
 
 /// This should never happen!
 fn warn_storage_inconsistency(cid: &CommunityIdentifier) {
-	log::warn!("Storage inconsistency. Could not find cid: {:?} in offchain storage. This is a fatal bug in the pallet", cid)
+	log::warn!("Storage inconsistency. Could not find cid: {cid:?} in offchain storage. This is a fatal bug in the pallet")
 }

--- a/communities/src/lib.rs
+++ b/communities/src/lib.rs
@@ -64,7 +64,8 @@ pub mod pallet {
 		+ pallet_encointer_scheduler::Config
 		+ pallet_encointer_balances::Config
 	{
-		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+        #[allow(deprecated)]
+        type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 
 		/// Required origin for updating a community (though can always be Root).
 		type CommunityMaster: EnsureOrigin<Self::RuntimeOrigin>;

--- a/communities/src/lib.rs
+++ b/communities/src/lib.rs
@@ -159,7 +159,7 @@ pub mod pallet {
 			sp_io::offchain_index::set(CACHE_DIRTY_KEY, &true.encode());
 
 			Self::deposit_event(Event::CommunityRegistered(cid));
-			info!(target: LOG, "registered community with cid: {:?}", cid);
+			info!(target: LOG, "registered community with cid: {cid:?}");
 			Ok(().into())
 		}
 
@@ -255,7 +255,7 @@ pub mod pallet {
 		) -> DispatchResultWithPostInfo {
 			T::CommunityMaster::ensure_origin(origin)?;
 			<MinSolarTripTimeS<T>>::put(min_solar_trip_time_s);
-			info!(target: LOG, "set min solar trip time to {} s", min_solar_trip_time_s);
+			info!(target: LOG, "set min solar trip time to {min_solar_trip_time_s} s");
 			Self::deposit_event(Event::MinSolarTripTimeSUpdated(min_solar_trip_time_s));
 			Ok(().into())
 		}
@@ -269,7 +269,7 @@ pub mod pallet {
 		) -> DispatchResultWithPostInfo {
 			T::CommunityMaster::ensure_origin(origin)?;
 			<MaxSpeedMps<T>>::put(max_speed_mps);
-			info!(target: LOG, "set max speed mps to {}", max_speed_mps);
+			info!(target: LOG, "set max speed mps to {max_speed_mps}");
 			Self::deposit_event(Event::MaxSpeedMpsUpdated(max_speed_mps));
 			Ok(().into())
 		}
@@ -455,7 +455,7 @@ impl<T: Config> Pallet<T> {
 		}
 		sp_io::offchain_index::set(CACHE_DIRTY_KEY, &true.encode());
 
-		info!(target: LOG, "added location {:?} to community with cid: {:?}", location, cid);
+		info!(target: LOG, "added location {location:?} to community with cid: {cid:?}");
 		Self::deposit_event(Event::LocationAdded(cid, location));
 		Ok(().into())
 	}
@@ -469,7 +469,7 @@ impl<T: Config> Pallet<T> {
 		let geo_hash = GeoHash::try_from_params(location.lat, location.lon)
 			.map_err(|_| <Error<T>>::InvalidLocationForGeohash)?;
 		Self::remove_location_intern(cid, location, geo_hash);
-		info!(target: LOG, "removed location {:?} to community with cid: {:?}", location, cid);
+		info!(target: LOG, "removed location {location:?} to community with cid: {cid:?}");
 		Self::deposit_event(Event::LocationRemoved(cid, location));
 		Ok(().into())
 	}
@@ -487,7 +487,7 @@ impl<T: Config> Pallet<T> {
 		sp_io::offchain_index::set(&cid.encode(), &community_metadata.name.encode());
 		sp_io::offchain_index::set(CACHE_DIRTY_KEY, &true.encode());
 
-		info!(target: LOG, "updated community metadata for cid: {:?}", cid);
+		info!(target: LOG, "updated community metadata for cid: {cid:?}");
 		Self::deposit_event(Event::MetadataUpdated(cid));
 
 		Ok(().into())
@@ -501,7 +501,7 @@ impl<T: Config> Pallet<T> {
 		<pallet_encointer_balances::Pallet<T>>::set_demurrage(&cid, demurrage)
 			.map_err(|_| <Error<T>>::InvalidDemurrage)?;
 
-		info!(target: LOG, " updated demurrage for cid: {:?}", cid);
+		info!(target: LOG, " updated demurrage for cid: {cid:?}");
 		Self::deposit_event(Event::DemurrageUpdated(cid, demurrage));
 
 		Ok(().into())
@@ -515,7 +515,7 @@ impl<T: Config> Pallet<T> {
 
 		<NominalIncome<T>>::insert(cid, nominal_income);
 
-		info!(target: LOG, " updated nominal income for cid: {:?}", cid);
+		info!(target: LOG, " updated nominal income for cid: {cid:?}");
 		Self::deposit_event(Event::NominalIncomeUpdated(cid, nominal_income));
 
 		Ok(().into())
@@ -542,7 +542,7 @@ impl<T: Config> Pallet<T> {
 	}
 
 	pub fn remove_community(cid: CommunityIdentifier) {
-		info!(target: LOG, "removing community {:?}", cid);
+		info!(target: LOG, "removing community {cid:?}");
 		for (geo_hash, locations) in <Locations<T>>::iter_prefix(cid) {
 			for location in locations {
 				Self::remove_location_intern(cid, location, geo_hash.clone());
@@ -734,7 +734,7 @@ impl<T: Config> Pallet<T> {
 		// prohibit proximity to dateline
 		let dateline_proxy = Location { lat: location.lat, lon: DATELINE_LON };
 		if Self::haversine_distance(location, &dateline_proxy) < DATELINE_DISTANCE_M {
-			warn!(target: LOG, "location too close to dateline: {:?}", location);
+			warn!(target: LOG, "location too close to dateline: {location:?}");
 			return Err(<Error<T>>::MinimumDistanceViolationToDateLine)?;
 		}
 

--- a/communities/src/lib.rs
+++ b/communities/src/lib.rs
@@ -64,8 +64,8 @@ pub mod pallet {
 		+ pallet_encointer_scheduler::Config
 		+ pallet_encointer_balances::Config
 	{
-        #[allow(deprecated)]
-        type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+		#[allow(deprecated)]
+		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 
 		/// Required origin for updating a community (though can always be Root).
 		type CommunityMaster: EnsureOrigin<Self::RuntimeOrigin>;

--- a/communities/src/migrations.rs
+++ b/communities/src/migrations.rs
@@ -169,14 +169,13 @@ pub mod v2 {
 			);
 
 			let cid_count = v0::CommunityIdentifiers::<T>::get().len() as u32;
-			log::info!(target: TARGET, "{} cids will be migrated.", cid_count,);
+			log::info!(target: TARGET, "{cid_count} cids will be migrated.");
 			ensure!(cid_count <= T::MaxCommunityIdentifiers::get(), "too many cids");
 
 			let cmeta_count = v0::CommunityMetadata::<T>::iter().count() as u32;
 			log::info!(
 				target: TARGET,
-				"{} community metadata entried will be migrated.",
-				cmeta_count,
+				"{cmeta_count} community metadata entried will be migrated.",
 			);
 
 			let cids_by_geohash = v0::CommunityIdentifiersByGeohash::<T>::iter();
@@ -191,8 +190,7 @@ pub mod v2 {
 			}
 			log::info!(
 				target: TARGET,
-				"{} cids by geohash will be migrated.",
-				cids_by_geohash_count,
+				"{cids_by_geohash_count} cids by geohash will be migrated."
 			);
 
 			let locations_by_geohash = v0::Locations::<T>::iter();
@@ -207,8 +205,7 @@ pub mod v2 {
 			}
 			log::info!(
 				target: TARGET,
-				"{} locations by geohash will be migrated.",
-				locations_by_geohash_count,
+				"{locations_by_geohash_count} locations by geohash will be migrated.",
 			);
 
 			let bootstrappers = v0::Bootstrappers::<T>::iter();
@@ -218,7 +215,7 @@ pub mod v2 {
 				ensure!(count <= T::MaxBootstrappers::get(), "too many bootstrappers");
 				bootstrappers_count += count
 			}
-			log::info!(target: TARGET, "{} bootstrappers will be migrated.", bootstrappers_count,);
+			log::info!(target: TARGET, "{bootstrappers_count} bootstrappers will be migrated.");
 
 			// For community metadata, we do not need any checks, because the data is bounded
 			// already due to the CommmunityMetadata validate() function.
@@ -324,14 +321,13 @@ pub mod v2 {
 				"must migrate all bootstrappers"
 			);
 
-			log::info!(target: TARGET, "{} community identifiers migrated", new_cids_count);
+			log::info!(target: TARGET, "{new_cids_count} community identifiers migrated");
 			log::info!(
 				target: TARGET,
-				"{} community identifiers by geohash migrated",
-				new_cids_by_geohash_count
+				"{new_cids_by_geohash_count} community identifiers by geohash migrated"
 			);
-			log::info!(target: TARGET, "{} locations migrated", new_locations_by_geohash_count);
-			log::info!(target: TARGET, "{} bootstrappers migrated", new_bootstrappers_count);
+			log::info!(target: TARGET, "{new_locations_by_geohash_count} locations migrated");
+			log::info!(target: TARGET, "{new_bootstrappers_count} bootstrappers migrated");
 			Ok(())
 		}
 	}

--- a/communities/src/migrations.rs
+++ b/communities/src/migrations.rs
@@ -242,9 +242,7 @@ pub mod v2 {
 
 			log::info!(
 				target: TARGET,
-				"Running migration with current storage version {:?} / onchain {:?}",
-				current_version,
-				onchain_version
+				"Running migration with current storage version {current_version:?} / onchain {onchain_version:?}"
 			);
 
 			let mut translated = 0u64;
@@ -260,7 +258,7 @@ pub mod v2 {
 					|k: CommunityIdentifier, meta: UnboundedCommunityMetadata| {
 						info!(
 							target: TARGET,
-							"     Migrating community metadata from v0 to v2 for {:?}...", k
+							"     Migrating community metadata from v0 to v2 for {k:?}..."
 						);
 						translated.saturating_inc();
 						Some(meta.migrate_to_v2())
@@ -271,7 +269,7 @@ pub mod v2 {
 					|k: CommunityIdentifier, meta: CommunityMetadataV1| {
 						info!(
 							target: TARGET,
-							"     Migrating community metadata from v1 to v2 for {:?}...", k
+							"     Migrating community metadata from v1 to v2 for {k:?}..."
 						);
 						translated.saturating_inc();
 						Some(meta.migrate_to_v2())

--- a/democracy/Cargo.toml
+++ b/democracy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-encointer-democracy"
-version = "16.4.0"
+version = "19.4.0"
 authors = ["Encointer Association <info@encointer.org>"]
 edition = "2021"
 description = "Democracy pallet for the Encointer blockchain runtime"

--- a/democracy/src/lib.rs
+++ b/democracy/src/lib.rs
@@ -92,7 +92,8 @@ pub mod pallet {
 		+ pallet_encointer_reputation_commitments::Config
 		+ pallet_encointer_treasuries::Config
 	{
-		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+        #[allow(deprecated)]
+        type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 
 		type WeightInfo: WeightInfo;
 

--- a/democracy/src/lib.rs
+++ b/democracy/src/lib.rs
@@ -92,8 +92,8 @@ pub mod pallet {
 		+ pallet_encointer_reputation_commitments::Config
 		+ pallet_encointer_treasuries::Config
 	{
-        #[allow(deprecated)]
-        type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+		#[allow(deprecated)]
+		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 
 		type WeightInfo: WeightInfo;
 

--- a/democracy/src/migrations.rs
+++ b/democracy/src/migrations.rs
@@ -32,9 +32,7 @@ pub mod v1 {
 
 			log::info!(
 				target: TARGET,
-				"Running migration with current storage version {:?} / onchain {:?}",
-				current_version,
-				onchain_version
+				"Running migration with current storage version {current_version:?} / onchain {onchain_version:?}",
 			);
 
 			if onchain_version >= 1 {

--- a/faucet/Cargo.toml
+++ b/faucet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-encointer-faucet"
-version = "16.2.0"
+version = "19.2.0"
 authors = ["Encointer Association <info@encointer.org>"]
 edition = "2021"
 description = "Faucet pallet for the Encointer blockchain runtime"

--- a/faucet/src/lib.rs
+++ b/faucet/src/lib.rs
@@ -76,8 +76,8 @@ pub mod pallet {
 		+ pallet_encointer_reputation_commitments::Config
 		+ pallet_encointer_communities::Config
 	{
-        #[allow(deprecated)]
-        type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+		#[allow(deprecated)]
+		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 		type Currency: Currency<Self::AccountId> + NamedReservableCurrency<Self::AccountId>;
 		type ControllerOrigin: EnsureOrigin<Self::RuntimeOrigin>;
 		type WeightInfo: WeightInfo;

--- a/faucet/src/lib.rs
+++ b/faucet/src/lib.rs
@@ -76,7 +76,8 @@ pub mod pallet {
 		+ pallet_encointer_reputation_commitments::Config
 		+ pallet_encointer_communities::Config
 	{
-		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+        #[allow(deprecated)]
+        type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 		type Currency: Currency<Self::AccountId> + NamedReservableCurrency<Self::AccountId>;
 		type ControllerOrigin: EnsureOrigin<Self::RuntimeOrigin>;
 		type WeightInfo: WeightInfo;

--- a/faucet/src/lib.rs
+++ b/faucet/src/lib.rs
@@ -152,7 +152,7 @@ pub mod pallet {
 				Faucet { name: name.clone(), purpose_id, whitelist, drip_amount, creator: from },
 			);
 
-			info!(target: LOG, "faucet created: {:?}, {:?}", name, faucet_account);
+			info!(target: LOG, "faucet created: {name:?}, {faucet_account:?}");
 			Self::deposit_event(Event::FaucetCreated(faucet_account, name));
 
 			Ok(().into())
@@ -224,7 +224,7 @@ pub mod pallet {
 				AllowDeath,
 			)?;
 
-			info!(target: LOG, "faucet dissolved {:?}", faucet_account);
+			info!(target: LOG, "faucet dissolved {faucet_account:?}");
 			Self::deposit_event(Event::FaucetDissolved(faucet_account));
 			Ok(().into())
 		}
@@ -258,7 +258,7 @@ pub mod pallet {
 				AllowDeath,
 			)?;
 
-			info!(target: LOG, "faucet closed {:?}", faucet_account);
+			info!(target: LOG, "faucet closed {faucet_account:?}");
 			Self::deposit_event(Event::FaucetClosed(faucet_account));
 
 			Ok(().into())
@@ -272,7 +272,7 @@ pub mod pallet {
 		) -> DispatchResultWithPostInfo {
 			T::ControllerOrigin::ensure_origin(origin)?;
 			<ReserveAmount<T>>::put(reserve_amount);
-			info!(target: LOG, "reserve amount set to {:?} s", reserve_amount);
+			info!(target: LOG, "reserve amount set to {reserve_amount:?} s");
 			Self::deposit_event(Event::ReserveAmountUpdated(reserve_amount));
 			Ok(().into())
 		}

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "encointer-primitives"
-version = "16.4.0"
+version = "19.4.0"
 authors = ["Encointer Association <info@encointer.org>"]
 edition = "2021"
 description = "Primitives for the Encointer blockchain runtime"

--- a/primitives/core/Cargo.toml
+++ b/primitives/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ep-core"
-version = "16.0.0"
+version = "19.0.0"
 authors = ["Encointer Association <info@encointer.org>"]
 edition = "2021"
 description = "Core primitives for the Encointer blockchain runtime"

--- a/primitives/src/communities.rs
+++ b/primitives/src/communities.rs
@@ -118,7 +118,7 @@ fn fmt(cid: &CommunityIdentifier, f: &mut Formatter<'_>) -> fmt::Result {
 	match sp_std::str::from_utf8(&cid.geohash) {
 		Ok(geohash_str) => write!(f, "{}{}", geohash_str, bs58::encode(cid.digest).into_string()),
 		Err(e) => {
-			log::error!("[Cid.fmt] {:?}", e);
+			log::error!("[Cid.fmt] {e:?}");
 			Err(fmt::Error)
 		},
 	}
@@ -181,7 +181,7 @@ impl FromStr for CommunityIdentifier {
 		let mut geohash: [u8; 5] = [0u8; 5];
 		let mut digest: [u8; 4] = [0u8; 4];
 
-		geohash.clone_from_slice(cid[..5].as_bytes());
+		geohash.clone_from_slice(&cid.as_bytes()[..5]);
 		digest.clone_from_slice(&bs58::decode(&cid[5..]).into_vec().map_err(decorate_bs58_err)?);
 
 		Ok(Self { geohash, digest })

--- a/reputation-commitments/Cargo.toml
+++ b/reputation-commitments/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-encointer-reputation-commitments"
-version = "16.1.0"
+version = "19.1.0"
 authors = ["Encointer Association <info@encointer.org>"]
 edition = "2021"
 description = "Reputation commitments pallet for the Encointer blockchain runtime"

--- a/reputation-commitments/src/lib.rs
+++ b/reputation-commitments/src/lib.rs
@@ -55,7 +55,8 @@ pub mod pallet {
 		+ pallet_encointer_ceremonies::Config
 		+ pallet_encointer_communities::Config
 	{
-		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+        #[allow(deprecated)]
+        type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 		type WeightInfo: WeightInfo;
 	}
 

--- a/reputation-commitments/src/lib.rs
+++ b/reputation-commitments/src/lib.rs
@@ -95,7 +95,7 @@ pub mod pallet {
 
 			<CurrentPurposeId<T>>::put(next_id);
 			<Purposes<T>>::insert(current_id, descriptor.clone());
-			info!(target: LOG, "commitment purpose registered: {:?}, {:?}", current_id, descriptor);
+			info!(target: LOG, "commitment purpose registered: {current_id:?}, {descriptor:?}");
 			Self::deposit_event(Event::RegisteredCommitmentPurpose(current_id, descriptor));
 			Ok(current_id)
 		}
@@ -149,7 +149,7 @@ pub mod pallet {
 			for cid in cids.into_iter() {
 				<Commitments<T>>::remove_prefix((cid, cindex), None);
 			}
-			info!(target: LOG, "commitment registry purged at cindex {:?}", cindex);
+			info!(target: LOG, "commitment registry purged at cindex {cindex:?}");
 			Self::deposit_event(Event::CommitmentRegistryPurged(cindex));
 		}
 	}

--- a/reputation-commitments/src/lib.rs
+++ b/reputation-commitments/src/lib.rs
@@ -55,8 +55,8 @@ pub mod pallet {
 		+ pallet_encointer_ceremonies::Config
 		+ pallet_encointer_communities::Config
 	{
-        #[allow(deprecated)]
-        type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+		#[allow(deprecated)]
+		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 		type WeightInfo: WeightInfo;
 	}
 

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "encointer-rpc"
-version = "16.1.0"
+version = "19.1.0"
 authors = ["Encointer Association <info@encointer.org>"]
 edition = "2021"
 description = "RPC for the Encointer blockchain runtime"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.84.1"                   # align with https://github.com/polkadot-fellows/runtimes/blob/main/.github/env#L1
+channel = "1.88.0"                   # align with https://github.com/polkadot-fellows/runtimes/blob/main/.github/env#L1
 profile = "default"                  # include rustfmt, clippy
 targets = ["wasm32-unknown-unknown"]

--- a/scheduler/Cargo.toml
+++ b/scheduler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-encointer-scheduler"
-version = "16.1.0"
+version = "19.1.0"
 authors = ["Encointer Association <info@encointer.org>"]
 edition = "2021"
 description = "Scheduler pallet for the Encointer blockchain runtime"

--- a/scheduler/src/lib.rs
+++ b/scheduler/src/lib.rs
@@ -48,7 +48,8 @@ pub mod pallet {
 
 	#[pallet::config]
 	pub trait Config: frame_system::Config + pallet_timestamp::Config {
-		type RuntimeEvent: From<Event> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+        #[allow(deprecated)]
+        type RuntimeEvent: From<Event> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 
 		/// Required origin to interfere with the scheduling (though can always be Root)
 		type CeremonyMaster: EnsureOrigin<Self::RuntimeOrigin>;

--- a/scheduler/src/lib.rs
+++ b/scheduler/src/lib.rs
@@ -208,7 +208,7 @@ impl<T: Config> Pallet<T> {
 			CeremonyPhaseType::Attesting => {
 				let next_ceremony_index = current_ceremony_index.saturating_add(1);
 				<CurrentCeremonyIndex<T>>::put(next_ceremony_index);
-				info!(target: LOG, "new ceremony phase with index {}", next_ceremony_index);
+				info!(target: LOG, "new ceremony phase with index {next_ceremony_index}");
 				CeremonyPhaseType::Registering
 			},
 		};
@@ -219,7 +219,7 @@ impl<T: Config> Pallet<T> {
 		<CurrentPhase<T>>::put(next_phase);
 		T::OnCeremonyPhaseChange::on_ceremony_phase_change(next_phase);
 		Self::deposit_event(Event::PhaseChangedTo(next_phase));
-		info!(target: LOG, "phase changed to: {:?}", next_phase);
+		info!(target: LOG, "phase changed to: {next_phase:?}");
 		Ok(())
 	}
 
@@ -254,7 +254,7 @@ impl<T: Config> Pallet<T> {
 			}
 		};
 		<NextPhaseTimestamp<T>>::put(tnext);
-		info!(target: LOG, "next phase change at: {:?}", tnext);
+		info!(target: LOG, "next phase change at: {tnext:?}");
 		Ok(())
 	}
 

--- a/scheduler/src/lib.rs
+++ b/scheduler/src/lib.rs
@@ -48,8 +48,8 @@ pub mod pallet {
 
 	#[pallet::config]
 	pub trait Config: frame_system::Config + pallet_timestamp::Config {
-        #[allow(deprecated)]
-        type RuntimeEvent: From<Event> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+		#[allow(deprecated)]
+		type RuntimeEvent: From<Event> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 
 		/// Required origin to interfere with the scheduling (though can always be Root)
 		type CeremonyMaster: EnsureOrigin<Self::RuntimeOrigin>;

--- a/scripts/run_for_all_no_std_crates.sh
+++ b/scripts/run_for_all_no_std_crates.sh
@@ -1,3 +1,5 @@
+export RUSTFLAGS="$RUSTFLAGS --cfg substrate_runtime"
+
 find . -name "Cargo.toml" | while read -r CARGO_TOML; do
   DIR=$(dirname "$CARGO_TOML")
   echo "Checking in directory: $DIR"

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test-utils"
-version = "16.3.0"
+version = "19.3.0"
 authors = ["Encointer Association <info@encointer.org>"]
 edition = "2021"
 description = "Test utils for the Encointer blockchain runtime"

--- a/test-utils/src/helpers.rs
+++ b/test-utils/src/helpers.rs
@@ -109,7 +109,7 @@ pub fn assert_dispatch_err(actual: DispatchResultWithPostInfo, expected: Dispatc
 }
 
 pub fn almost_eq(a: u128, b: u128, delta: u128) -> bool {
-	let diff = if a > b { a - b } else { b - a };
+	let diff = a.abs_diff(b);
 	diff < delta
 }
 

--- a/treasuries/Cargo.toml
+++ b/treasuries/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-encointer-treasuries"
-version = "16.4.1"
+version = "19.4.1"
 authors = ["Encointer Association <info@encointer.org>"]
 edition = "2021"
 description = "Treasuries pallet for the Encointer blockchain runtime"

--- a/treasuries/rpc/Cargo.toml
+++ b/treasuries/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-encointer-treasuries-rpc"
-version = "16.3.0"
+version = "19.3.0"
 authors = ["Encointer Association <info@encointer.org>"]
 edition = "2021"
 description = "Treasuries pallet rpc for the Encointer blockchain runtime"

--- a/treasuries/rpc/runtime-api/Cargo.toml
+++ b/treasuries/rpc/runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-encointer-treasuries-rpc-runtime-api"
-version = "16.3.0"
+version = "19.3.0"
 authors = ["Encointer Association <info@encointer.org>"]
 edition = "2021"
 description = "Treasuries pallet rpc runtime api for the Encointer blockchain runtime"

--- a/treasuries/src/lib.rs
+++ b/treasuries/src/lib.rs
@@ -58,8 +58,8 @@ pub mod pallet {
 	pub trait Config:
 		frame_system::Config + pallet_encointer_balances::Config + pallet_timestamp::Config
 	{
-        #[allow(deprecated)]
-        type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+		#[allow(deprecated)]
+		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 		type Currency: Currency<Self::AccountId>;
 
 		/// The treasuries' pallet id, used for deriving sovereign account IDs per community.

--- a/treasuries/src/lib.rs
+++ b/treasuries/src/lib.rs
@@ -58,7 +58,8 @@ pub mod pallet {
 	pub trait Config:
 		frame_system::Config + pallet_encointer_balances::Config + pallet_timestamp::Config
 	{
-		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+        #[allow(deprecated)]
+        type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 		type Currency: Currency<Self::AccountId>;
 
 		/// The treasuries' pallet id, used for deriving sovereign account IDs per community.

--- a/treasuries/src/lib.rs
+++ b/treasuries/src/lib.rs
@@ -166,7 +166,7 @@ pub mod pallet {
 		) -> DispatchResultWithPostInfo {
 			let treasury = Self::get_community_treasury_account_unchecked(maybecid);
 			T::Currency::transfer(&treasury, beneficiary, amount, KeepAlive)?;
-			info!(target: LOG, "treasury spent native: {:?}, {:?} to {:?}", maybecid, amount, beneficiary);
+			info!(target: LOG, "treasury spent native: {maybecid:?}, {amount:?} to {beneficiary:?}");
 			Self::deposit_event(Event::SpentNative {
 				treasury,
 				beneficiary: beneficiary.clone(),

--- a/vouches/Cargo.toml
+++ b/vouches/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-encointer-vouches"
-version = "16.1.0"
+version = "19.1.0"
 authors = ["Encointer Association <info@encointer.org>"]
 edition = "2021"
 description = "Vouches pallet for the Encointer blockchain runtime"

--- a/vouches/src/lib.rs
+++ b/vouches/src/lib.rs
@@ -44,7 +44,8 @@ pub mod pallet {
 
 	#[pallet::config]
 	pub trait Config: frame_system::Config + pallet_timestamp::Config {
-		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+        #[allow(deprecated)]
+        type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 		type WeightInfo: WeightInfo;
 		#[pallet::constant]
 		type MaxVouchesPerAttester: Get<u32>;

--- a/vouches/src/lib.rs
+++ b/vouches/src/lib.rs
@@ -44,8 +44,8 @@ pub mod pallet {
 
 	#[pallet::config]
 	pub trait Config: frame_system::Config + pallet_timestamp::Config {
-        #[allow(deprecated)]
-        type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+		#[allow(deprecated)]
+		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 		type WeightInfo: WeightInfo;
 		#[pallet::constant]
 		type MaxVouchesPerAttester: Get<u32>;

--- a/vouches/src/lib.rs
+++ b/vouches/src/lib.rs
@@ -73,7 +73,7 @@ pub mod pallet {
 					Ok(().into())
 				},
 			)?;
-			info!(target: LOG, "vouching: {:?} for {:?}, vouch type: {:?}, quality: {:?}", attester, attestee, vouch_kind, quality);
+			info!(target: LOG, "vouching: {attester:?} for {attestee:?}, vouch type: {vouch_kind:?}, quality: {quality:?}");
 			Self::deposit_event(Event::VouchedFor { attestee, attester, vouch_kind });
 			Ok(().into())
 		}


### PR DESCRIPTION
Polkadot has introduced a new rust build flag for their no-std build of sp-io. Unfortunately, this is not well documented, and I could only find the error through source code crawling.

If the `substrate_runtime` rust flag is missing, it breaks the no-std build for sp-io: https://github.com/paritytech/polkadot-sdk/blob/73b44193c8e66acd699f04265027289d030f6c66/substrate/primitives/io/Cargo.toml#L35