### PR TITLE
[treasuries] fix xcm benchmarks with real runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5041,7 +5041,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-treasuries"
-version = "20.6.0"
+version = "20.7.0"
 dependencies = [
  "approx",
  "encointer-primitives",

--- a/treasuries/Cargo.toml
+++ b/treasuries/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-encointer-treasuries"
-version = "20.6.0"
+version = "20.7.0"
 authors = ["Encointer Association <info@encointer.org>"]
 edition = "2021"
 description = "Treasuries pallet for the Encointer blockchain runtime"

--- a/treasuries/src/benchmarking.rs
+++ b/treasuries/src/benchmarking.rs
@@ -71,6 +71,7 @@ benchmarks! {
 			swap_option
 		).unwrap();
 
+		// `ensure_successful` ignore every argument except for `asset_id` in practice.
 		T::Paymaster::ensure_successful(&alice, &alice, asset_id, asset_allowance.into());
 
 	} : _(RawOrigin::Signed(alice.clone()), cid, 50_000_000u64.saturated_into())

--- a/treasuries/src/benchmarking.rs
+++ b/treasuries/src/benchmarking.rs
@@ -53,12 +53,13 @@ benchmarks! {
 		let cid = CommunityIdentifier::default();
 		let alice: T::AccountId = account("alice", 1, 1);
 		let asset_id = T::BenchmarkHelper::create_asset_kind(1);
+		let asset_allowance = 100_000_000u32;
 
 		pallet_encointer_balances::Pallet::<T>::issue(cid, &alice, BalanceType::from_num(12i32)).unwrap();
 		let swap_option = SwapAssetOption {
 			cid,
-			asset_allowance: 100_000_000u64.saturated_into(),
-			asset_id,
+			asset_allowance: asset_allowance.into(),
+			asset_id: asset_id.clone(),
 			rate: Some(BalanceType::from_num(0.000_000_2)),
 			do_burn: false,
 			valid_from: None,
@@ -69,6 +70,9 @@ benchmarks! {
 			&alice,
 			swap_option
 		).unwrap();
+
+		T::Paymaster::ensure_successful(&alice, &alice, asset_id, asset_allowance.into());
+
 	} : _(RawOrigin::Signed(alice.clone()), cid, 50_000_000u64.saturated_into())
 	verify {
 	}

--- a/treasuries/src/transfer.rs
+++ b/treasuries/src/transfer.rs
@@ -1,3 +1,4 @@
+
 use core::fmt::Debug;
 use frame_support::traits::tokens::PaymentStatus;
 use scale_info::TypeInfo;


### PR DESCRIPTION
We got and `Unroutable` error in the actual benchmarks.

```
Starting benchmark: pallet_encointer_treasuries::swap_asset    
2025-08-22T06:37:08.534978Z ERROR encointer: Paymaster payout error: Unroutable    
2025-08-22T06:37:08.535083Z ERROR polkadot_sdk_frame::benchmark::pallet: Benchmark pallet_encointer_treasuries::swap_asset failed: PayoutError    
```

This fixes the issue correctly calling `ensure_successful` in the benchmark.