### PR TITLE
Bump polkadot-sdk crate versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,12 +81,12 @@ pallet-asset-tx-payment = { version = "44.0.0", default-features = false }
 pallet-balances = { version = "45.0.0", default-features = false }
 pallet-timestamp = { version = "43.0.0", default-features = false }
 pallet-transaction-payment = { version = "44.0.0", default-features = false }
-sp-api = { version = "39.0.0", default-features = false }
-sp-application-crypto = { version = "43.0.0", default-features = false }
+sp-api = { version = "38.0.0", default-features = false }
+sp-application-crypto = { version = "42.0.0", default-features = false }
 sp-arithmetic = { version = "28.0.0", default-features = false }
 sp-core = { version = "38.0.1", default-features = false }
-sp-io = { version = "43.0.0", default-features = false }
-sp-runtime = { version = "44.0.0", default-features = false }
+sp-io = { version = "42.0.0", default-features = false }
+sp-runtime = { version = "43.0.0", default-features = false }
 sp-std = { version = "14.0.0", default-features = false }
 
 # rpc stuff [std]
@@ -96,17 +96,17 @@ jsonrpsee-types = { version = "0.24.7" }
 pallet-transaction-payment-rpc = { version = "47.0.0" }
 sc-rpc = "49.0.0"
 sc-rpc-api = "0.53.0"
-sp-blockchain = "42.0.0"
-sp-rpc = "36.0.1"
+sp-blockchain = "41.0.0"
+sp-rpc = "36.0.0"
 
 # dev deps
 approx = "0.5.1"
 itertools = "0.11.0"
 rstest = "0.12.0"
 serde_json = "1.0.114"
-sp-inherents = "39.0.0"
-sp-keyring = "44.0.0"
-sp-keystore = "0.44.1"
+sp-inherents = "38.0.0"
+sp-keyring = "43.0.0"
+sp-keystore = "0.44.0"
 
 #[patch.crates-io]
 #substrate-fixed = { path = "../substrate-fixed"}


### PR DESCRIPTION
This PR bumps all polkadot-sdk dependencies to the latest version of `unstable2507`: https://github.com/paritytech/polkadot-sdk/releases/tag/polkadot-unstable2507-revive