### PR TITLE
fix: fund benchmark sender above existential deposit

### DIFF
--- a/offline-payment/src/benchmarking.rs
+++ b/offline-payment/src/benchmarking.rs
@@ -180,8 +180,8 @@ benchmarks! {
 
 		let amount: BalanceOf<T> = 10u32.into();
 
-		// Fund sender with native token
-		T::Currency::make_free_balance_be(&sender, 100u32.into());
+		// Fund sender with enough native token (must exceed existential deposit + amount)
+		T::Currency::make_free_balance_be(&sender, 1_000_000u32.into());
 
 		let bounded_vk: BoundedVec<u8, T::MaxVkSize> =
 			BoundedVec::try_from(VK_BYTES.to_vec()).expect("VK within bounds");


### PR DESCRIPTION
The `submit_native_offline_payment` benchmark funds the sender with only 100 units, which is below the node runtime's existential deposit (500). The `KeepAlive` transfer then fails with `InsufficientBalance`.

Fix: use 1,000,000 units.

🤖 Generated with [Claude Code](https://claude.com/claude-code)