### PR TITLE
feat(reputation-rings): automatic ring computation via on_idle

### DIFF
--- a/reputation-rings/src/mock.rs
+++ b/reputation-rings/src/mock.rs
@@ -32,7 +32,7 @@ impl_timestamp!(TestRuntime, EncointerScheduler);
 impl_balances!(TestRuntime, System);
 impl_encointer_balances!(TestRuntime);
 impl_encointer_communities!(TestRuntime);
-impl_encointer_scheduler!(TestRuntime);
+impl_encointer_scheduler!(TestRuntime, EncointerReputationRings);
 impl_encointer_ceremonies!(TestRuntime);
 
 pub fn new_test_ext() -> sp_io::TestExternalities {


### PR DESCRIPTION
## Summary

- Auto-initiate ring computation on ceremony completion (Registering→Assigning phase transition) via `OnCeremonyPhaseChange` hook
- Process computation steps in `on_idle` using leftover block weight — zero impact on normal transactions
- Queue all communities on phase change, process them sequentially with one `PendingRingComputation` at a time
- Manual `initiate_rings` + `continue_ring_computation` extrinsics remain for fallback/OCW use

Closes #457

## Details

**New storage items:** `PendingCommunities` (bounded vec queue), `PendingCeremonyIndex` (shared ceremony index for batch). Both `ValueQuery` with empty/zero defaults — no migration needed, storage version bumped 1→2.

**Weight accounting:** `on_idle` uses `single_step_weight()` (max of existing benchmarked `continue_ring_computation_collect` and `_build`) plus `DbWeight` overhead per iteration. No new benchmarks required.

**Safety:** On step error, aborts current community computation and moves to next. Skips queue population if previous batch still pending (logs warning). No panics.

## Test plan

- [x] `on_ceremony_phase_change_assigning_populates_queue` — verifies queue + ceremony index
- [x] `on_ceremony_phase_change_ignores_non_assigning` — Registering/Attesting don't trigger
- [x] `on_ceremony_phase_change_skips_if_queue_nonempty` — no overwrite of pending batch
- [x] `on_idle_processes_single_community` — end-to-end: phase change → on_idle → rings published
- [x] `on_idle_processes_multiple_communities` — sequential processing of 2 communities
- [x] `on_idle_respects_weight_limit` — zero weight = no progress
- [x] `on_idle_handles_step_error_gracefully` — error recovery, next community still processed
- [x] `manual_extrinsics_still_work` — coexistence with automatic processing
- [x] All 24 existing tests still pass (32 total)
- [x] `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)