### PR TITLE
only fixed point in benche

### DIFF
--- a/balances/Cargo.toml
+++ b/balances/Cargo.toml
@@ -12,7 +12,6 @@ license = "GPL-3.0-or-later"
 workspace = true
 
 [dependencies]
-approx = { workspace = true, optional = true }
 log = { workspace = true }
 parity-scale-codec = { workspace = true }
 scale-info = { workspace = true }
@@ -51,7 +50,6 @@ std = [
     "sp-io/std",
 ]
 runtime-benchmarks = [
-    "approx",
     "frame-benchmarking",
     "frame-support/runtime-benchmarks",
     "frame-system/runtime-benchmarks",

--- a/balances/src/benchmarking.rs
+++ b/balances/src/benchmarking.rs
@@ -1,8 +1,18 @@
 use crate::*;
-use approx::assert_abs_diff_eq;
-use encointer_primitives::{balances::BalanceType, fixed::traits::LossyInto};
+use encointer_primitives::balances::BalanceType;
 use frame_benchmarking::{account, benchmarks, impl_benchmark_test_suite};
 use frame_system::RawOrigin;
+
+// Tolerance for balance comparisons under demurrage drift. 1e-4, same as the
+// previous f64 `epsilon = 0.0001`. Computed in fixed-point so no float ops.
+fn balance_tolerance() -> BalanceType {
+	BalanceType::from_num(1u32) / 10_000
+}
+
+fn assert_balance_close(actual: BalanceType, expected: BalanceType) {
+	let diff = if actual > expected { actual - expected } else { expected - actual };
+	assert!(diff < balance_tolerance(), "balance {actual:?} not within tolerance of {expected:?}");
+}
 
 benchmarks! {
 	transfer {
@@ -13,10 +23,8 @@ benchmarks! {
 		Pallet::<T>::issue(cid, &alice, BalanceType::from_num(12i32)).ok();
 	}: _(RawOrigin::Signed(alice.clone()), bob.clone(), cid, BalanceType::from_num(10i32))
 	verify{
-		let balance_alice: f64 = Pallet::<T>::balance(cid, &alice).lossy_into();
-		assert_abs_diff_eq!(balance_alice, 2f64, epsilon= 0.0001);
-		let balance_bob: f64 = Pallet::<T>::balance(cid, &bob).lossy_into();
-		assert_abs_diff_eq!(balance_bob, 10f64, epsilon= 0.0001);
+		assert_balance_close(Pallet::<T>::balance(cid, &alice), BalanceType::from_num(2u32));
+		assert_balance_close(Pallet::<T>::balance(cid, &bob), BalanceType::from_num(10u32));
 	}
 
 	transfer_all {
@@ -28,8 +36,7 @@ benchmarks! {
 	}: _(RawOrigin::Signed(alice.clone()), bob.clone(), cid)
 	verify{
 		assert!(!Balance::<T>::contains_key(cid, alice));
-		let balance_bob: f64 = Pallet::<T>::balance(cid, &bob).lossy_into();
-		assert_abs_diff_eq!(balance_bob, 12f64, epsilon= 0.0001);
+		assert_balance_close(Pallet::<T>::balance(cid, &bob), BalanceType::from_num(12u32));
 	}
 
 	set_fee_conversion_factor {

--- a/communities/src/benchmarking.rs
+++ b/communities/src/benchmarking.rs
@@ -19,20 +19,23 @@ fn get_location(i: u32) -> Location {
 	// this is close to the worstcase scenario for the location validation algorithm
 	assert!(i < NUM_LOCATIONS);
 
-	// top left corner coordinates of the bucket u0qjb
-	let lon_base = 47.460932;
-	let lat_base = 8.437509;
+	// top left corner coordinates of the bucket u0qjb, in micro-degrees (1e-6°)
+	const LON_BASE_MICRO: i64 = 47_460_932; // 47.460932°
+	const LAT_BASE_MICRO: i64 = 8_437_509; //  8.437509°
+	const STEP_MICRO: i64 = 1_000; //         0.001°
+	const ONE_DEGREE_MICRO: i64 = 1_000_000;
 
-	let lon_step = 0.001;
-	let lat_step = 0.001;
+	let row = (i / NUM_LOCATIONS_SQRT) as i64;
+	let col = (i % NUM_LOCATIONS_SQRT) as i64;
 
-	let grid_size = NUM_LOCATIONS_SQRT;
+	let lat = Degree::from_num(LAT_BASE_MICRO + row * STEP_MICRO)
+		.checked_div(Degree::from_num(ONE_DEGREE_MICRO))
+		.expect("ONE_DEGREE_MICRO != 0; qed");
+	let lon = Degree::from_num(LON_BASE_MICRO + col * STEP_MICRO)
+		.checked_div(Degree::from_num(ONE_DEGREE_MICRO))
+		.expect("ONE_DEGREE_MICRO != 0; qed");
 
-	let lat = lat_base + (i / grid_size) as f64 * lat_step;
-
-	let lon = lon_base + (i % grid_size) as f64 * lon_step;
-
-	Location { lat: Degree::from_num(lat), lon: Degree::from_num(lon) }
+	Location { lat, lon }
 }
 
 fn setup_test_community<T: Config>() -> (
@@ -72,6 +75,9 @@ fn setup_test_community<T: Config>() -> (
 parameter_types! {
 	pub const DefaultDemurrage: Demurrage = Demurrage::from_bits(0x0000000000000000000001E3F0A8A973_i128);
 }
+
+// 0.5 in I64F64 = 1 << 63
+const HALF_DEMURRAGE: Demurrage = Demurrage::from_bits(1i128 << 63);
 
 benchmarks! {
 	new_community {
@@ -132,10 +138,10 @@ benchmarks! {
 	update_demurrage {
 		let (cid, bootstrappers, community_metadata, demurrage, nominal_income) = setup_test_community::<T>();
 	} : {
-		assert_ok!(Communities::<T>::update_demurrage(RawOrigin::Root.into(), cid, Demurrage::from_num(0.5)));
+		assert_ok!(Communities::<T>::update_demurrage(RawOrigin::Root.into(), cid, HALF_DEMURRAGE));
 	}
 	verify {
-		assert_eq!(pallet_encointer_balances::Pallet::<T>::demurrage_per_block(cid), 0.5);
+		assert_eq!(pallet_encointer_balances::Pallet::<T>::demurrage_per_block(cid), HALF_DEMURRAGE);
 	}
 
 	update_nominal_income {

--- a/reputation-rings/src/benchmarking.rs
+++ b/reputation-rings/src/benchmarking.rs
@@ -58,7 +58,7 @@ where
 	T::AccountId: AsRef<[u8; 32]>,
 {
 	let bootstrappers: Vec<T::AccountId> = (0..6).map(|n| account("bs", n, n)).collect();
-	let location = Location { lat: Degree::from_num(1.0), lon: Degree::from_num(1.0) };
+	let location = Location { lat: Degree::from_num(1i32), lon: Degree::from_num(1i32) };
 	let cid = CommunityIdentifier::new(location, bootstrappers).unwrap();
 
 	// Write directly to storage to avoid origin requirements that differ between mock and runtime.

--- a/treasuries/src/benchmarking.rs
+++ b/treasuries/src/benchmarking.rs
@@ -35,7 +35,7 @@ benchmarks! {
 		let swap_option: SwapNativeOption<BalanceOf<T>, T::Moment> = SwapNativeOption {
 			cid,
 			native_allowance: 100_000_000u64.saturated_into(),
-			rate: Some(BalanceType::from_num(0.000_000_2)),
+			rate: Some(BalanceType::from_num(2u32) / 10_000_000),
 			do_burn: false,
 			valid_from: None,
 			valid_until: None,
@@ -60,7 +60,7 @@ benchmarks! {
 			cid,
 			asset_allowance: asset_allowance.into(),
 			asset_id: asset_id.clone(),
-			rate: Some(BalanceType::from_num(0.000_000_2)),
+			rate: Some(BalanceType::from_num(2u32) / 10_000_000),
 			do_burn: false,
 			valid_from: None,
 			valid_until: None,


### PR DESCRIPTION
Remove floating points from benchmarks so that even benchmark runtimes are hygenic.